### PR TITLE
cmake: Disable Control-Flow check instrumentation

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -49,6 +49,7 @@ if(CABLE_COMPILER_GNULIKE)
         evmone PRIVATE
         -fno-exceptions
         $<$<CXX_COMPILER_ID:GNU>:-Wstack-usage=2600>
+        -fcf-protection=none
     )
     if(NOT SANITIZE MATCHES undefined)
         # RTTI can be disabled except for UBSan which checks vptr integrity.


### PR DESCRIPTION
Disable Control-Flow protection (CET) for the Baseline interpreter. This is controlled by -fcf-protection GCC/Clang compiler flag and may be enabled by default depending on the OS configuration.

This is disabled because it slightly affects performance and code size. If the CF protection is desired it should be enabled uniformly in all compilers which support it.

Somehow, applying [[nocf_check]] attribute has no desired effect.

See GCC documentation:
https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fcf-protection