### PR TITLE
Optimize `ecmul` and `ecrecovery` implementation with field endomorphism

### DIFF
--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -11,6 +11,28 @@ namespace
 constexpr ModArith Fp{FieldPrime};
 constexpr auto B = Fp.to_mont(3);
 constexpr auto B3 = Fp.to_mont(3 * 3);
+
+struct Config
+{
+    // Linearly independent short vectors (𝑣₁=(𝑥₁, 𝑦₁), 𝑣₂=(x₂, 𝑦₂)) such that f(𝑣₁) = f(𝑣₂) = 0,
+    // where f : ℤ×ℤ → ℤₙ is defined as (𝑖,𝑗) → (𝑖+𝑗λ), where λ² + λ ≡ -1 mod n. n is bn245 curve
+    // order. Here λ = 0xb3c4d79d41a917585bfc41088d8daaa78b17ea66b99c90dd. DET is (𝑣₁, 𝑣₂) matrix
+    // determinant. For more details see https://www.iacr.org/archive/crypto2001/21390189.pdf
+    static constexpr auto X1 = 147946756881789319020627676272574806254_u512;
+    // Y1 should be negative, hence we calculate the determinant below adding operands instead of
+    // subtracting.
+    static constexpr auto Y1 = 147946756881789318990833708069417712965_u512;
+    static constexpr auto X2 = 147946756881789319000765030803803410728_u512;
+    static constexpr auto Y2 = 147946756881789319010696353538189108491_u512;
+    static constexpr auto DET =
+        43776485743678550444492811490514550177096728800832068687396408373151616991234_u256;
+};
+
+// For bn254 curve and β ∈ 𝔽ₚ endomorphism ϕ : E₂ → E₂ defined as (𝑥,𝑦) → (β𝑥,𝑦) calculates [λ](𝑥,𝑦)
+// with only one multiplication in 𝔽ₚ. BETA value in Montgomery form;
+inline constexpr auto BETA =
+    20006444479023397533370224967097343182639219473961804911780625968796493078869_u256;
+
 }  // namespace
 
 bool validate(const Point& pt) noexcept
@@ -40,8 +62,15 @@ Point mul(const Point& pt, const uint256& c) noexcept
     if (c == 0)
         return {};
 
-    const Point p_mont{Fp.to_mont(pt.x), Fp.to_mont(pt.y)};
-    const auto pr = ecc::mul(Fp, p_mont, c, B3);
+    const auto [k1, k2] = ecc::decompose<Config>(c % Order);
+
+    const ecc::Point<uint256> q = {Fp.mul(BETA, Fp.to_mont(pt.x)),
+        !k2.first ? Fp.to_mont(pt.y) : Fp.to_mont(FieldPrime - pt.y)};
+
+    const ecc::Point<uint256> p =
+        !k1.first ? ecc::to_mont(Fp, pt) : ecc::to_mont(Fp, Point{pt.x, FieldPrime - pt.y});
+
+    const auto pr = shamir_multiply(Fp, k1.second, p, k2.second, q, B3);
 
     return ecc::to_affine(Fp, pr);
 }

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -16,6 +16,10 @@ using namespace intx;
 inline constexpr auto FieldPrime =
     0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_u256;
 
+/// The bn254 curve order (N)
+inline constexpr auto Order =
+    0x30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000001_u256;
+
 using Point = ecc::Point<uint256>;
 /// Note that real part of G2 value goes first and imaginary part is the second. i.e (a + b*i)
 /// The pairing check precompile EVM ABI presumes that imaginary part goes first.


### PR DESCRIPTION
- `ecmul` in `ecc` lib for bn254 is optimized using curve endomorphism and "Shamir's trick" multiplication.
- https://www.iacr.org/archive/crypto2001/21390189.pdf
- `v1` and `v2` vectors taken from [cloudflare implementation](https://github.com/flashbots/builder/blob/main/crypto/bn256/cloudflare/lattice.go/)

Prev version bench:

```
--------------------------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------
identity<evmone::state::identity_execute>                 56.9 ns         56.9 ns     11887577 gas_rate=7.01801G/s gas_used=399
ecrecover<evmone::state::ecrecover_execute>             315018 ns       314858 ns         2246 gas_rate=9.52812M/s gas_used=3k
ecrecover<evmone::state::silkpre_ecrecover_execute>      37609 ns        37590 ns        18163 gas_rate=79.8074M/s gas_used=3k
ecadd<evmone::state::ecadd_execute>                       7643 ns         7628 ns        94194 gas_rate=19.665M/s gas_used=150
ecadd<evmone::state::silkpre_ecadd_execute>               2842 ns         2841 ns       243360 gas_rate=52.8011M/s gas_used=150
ecmul<evmone::state::ecmul_execute>                     146770 ns       146614 ns         4772 gas_rate=40.9238M/s gas_used=6k
ecmul<evmone::state::silkpre_ecmul_execute>             197282 ns       197215 ns         3608 gas_rate=30.4236M/s gas_used=6k
```

vs. new version:

```
--------------------------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------
identity<evmone::state::identity_execute>                 56.1 ns         56.1 ns     12784221 gas_rate=7.11174G/s gas_used=399
ecrecover<evmone::state::ecrecover_execute>             131971 ns       131685 ns         5299 gas_rate=22.7816M/s gas_used=3k
ecrecover<evmone::state::silkpre_ecrecover_execute>      37476 ns        37447 ns        18732 gas_rate=80.1135M/s gas_used=3k
ecadd<evmone::state::ecadd_execute>                       7480 ns         7476 ns        93637 gas_rate=20.0635M/s gas_used=150
ecadd<evmone::state::silkpre_ecadd_execute>               2822 ns         2818 ns       248081 gas_rate=53.2334M/s gas_used=150
ecmul<evmone::state::ecmul_execute>                      62607 ns        62566 ns        11059 gas_rate=95.8992M/s gas_used=6k
ecmul<evmone::state::silkpre_ecmul_execute>             199830 ns       199335 ns         3680 gas_rate=30.1001M/s gas_used=6k
(vvenv) rodia@MacBook-Air-3 evmone % cmake --build build                 
```
