### PR TITLE
Implement Fast CIOS for Montgomery modular multiplication

### DIFF
--- a/include/evmmax/evmmax.hpp
+++ b/include/evmmax/evmmax.hpp
@@ -83,26 +83,48 @@ public:
         // Based on 2.3.2 from
         // High-Speed Algorithms & Architectures For Number-Theoretic Cryptosystems
         // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
+        // and on 2.2 from
+        // EdMSM: Multi-Scalar-Multiplication for SNARKs and Faster Montgomery multiplication
+        // https://eprint.iacr.org/2022/1400.pdf
 
+        constexpr uint64_t most_significant_mod_word_limit {std::numeric_limits<uint64_t>::max() >> 1};
         constexpr auto S = UintT::num_words;  // TODO(C++23): Make it static
 
         intx::uint<UintT::num_bits + 64> t;
-        for (size_t i = 0; i != S; ++i)
+        if (mod[S - 1] < most_significant_mod_word_limit)
         {
-            uint64_t c = 0;
-            for (size_t j = 0; j != S; ++j)
-                std::tie(c, t[j]) = addmul(t[j], x[j], y[i], c);
-            auto tmp = intx::addc(t[S], c);
-            t[S] = tmp.value;
-            const auto d = tmp.carry;  // TODO: Carry is 0 for sparse modulus.
+            for (size_t i = 0; i != S; ++i)
+            {
+                uint64_t c = 0;
+                for (size_t j = 0; j != S; ++j)
+                    std::tie(c, t[j]) = addmul(t[j], x[j], y[i], c);
+                auto const c_2 = c;
+                const auto m = t[0] * m_mod_inv;
+                std::tie(c, std::ignore) = addmul(t[0], m, mod[0], 0);
+                for (size_t j = 1; j != S; ++j)
+                    std::tie(c, t[j - 1]) = addmul(t[j], m, mod[j], c);
+                t[S - 1] = c_2 + c;
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i != S; ++i)
+            {
+                uint64_t c = 0;
+                for (size_t j = 0; j != S; ++j)
+                    std::tie(c, t[j]) = addmul(t[j], x[j], y[i], c);
+                auto tmp = intx::addc(t[S], c);
+                t[S] = tmp.value;
+                const auto d = tmp.carry;  // TODO: Carry is 0 for sparse modulus.
 
-            const auto m = t[0] * m_mod_inv;
-            std::tie(c, std::ignore) = addmul(t[0], m, mod[0], 0);
-            for (size_t j = 1; j != S; ++j)
-                std::tie(c, t[j - 1]) = addmul(t[j], m, mod[j], c);
-            tmp = intx::addc(t[S], c);
-            t[S - 1] = tmp.value;
-            t[S] = d + tmp.carry;  // TODO: Carry is 0 for sparse modulus.
+                const auto m = t[0] * m_mod_inv;
+                std::tie(c, std::ignore) = addmul(t[0], m, mod[0], 0);
+                for (size_t j = 1; j != S; ++j)
+                    std::tie(c, t[j - 1]) = addmul(t[j], m, mod[j], c);
+                tmp = intx::addc(t[S], c);
+                t[S - 1] = tmp.value;
+                t[S] = d + tmp.carry;  // TODO: Carry is 0 for sparse modulus.
+            }
         }
 
         if (t >= mod)


### PR DESCRIPTION
This PR implements the improvement of the CIOS variant of the Montgomery algorithm showcased in the following document: [EdMSM: Multi-Scalar-Multiplication for SNARKs and Faster Montgomery multiplication](https://eprint.iacr.org/2022/1400.pdf) and proposed in https://github.com/ethereum/evmone/issues/869.
The optimization occurs when `most_significant_p_word < (word_size / 2)`, `p` is represented by the variable `mod` in the current implementation.

Here are the benchmarks performed after applying these changes starting from commit 01eca779c58c19c8659fd5a6bf0cad85613c629b.

Build: `cmake --build build --parallel`

Benchmarks: `taskset -c 0 ./build/bin/evmone-bench-internal --benchmark_filter=evmmax* --benchmark_repetitions=10 --benchmark_format=json --benchmark_out=cios_classic.json`

Comparison:
```
user@user:~/sandbox/evmone$ python3 ../benchmark/tools/compare.py benchmarks cios_classic.json cios_improved.json 
Comparing cios_classic.json to cios_improved.json
Benchmark                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------
evmmax_mul<uint256, bn254>_pvalue                     0.0002          0.0002      U Test, Repetitions: 10 vs 10
evmmax_mul<uint256, bn254>_mean                      +7.8884         +7.8873            27           238            27           238
evmmax_mul<uint256, bn254>_median                    +7.8595         +7.8584            27           237            27           237
evmmax_mul<uint256, bn254>_stddev                   +17.5405        +17.5057             0             3             0             3
evmmax_mul<uint256, bn254>_cv                        +1.0859         +1.0823             0             0             0             0
evmmax_mul<uint256, secp256k1>_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
evmmax_mul<uint256, secp256k1>_mean                  +7.6644         +7.6636            29           249            29           249
evmmax_mul<uint256, secp256k1>_median                +7.7730         +7.7721            28           249            28           249
evmmax_mul<uint256, secp256k1>_stddev               +10.6559        +10.6522             1             7             1             7
evmmax_mul<uint256, secp256k1>_cv                    +0.3453         +0.3450             0             0             0             0
OVERALL_GEOMEAN                                      +1.0661         +1.0658             0             0             0             0
```

As you can see, the results do not indicate a performance improvement.

