### PR TITLE
test: Handle full state tests in `evmone-bench`

### DIFF
--- a/test/statetest/CMakeLists.txt
+++ b/test/statetest/CMakeLists.txt
@@ -5,7 +5,7 @@
 add_library(evmone-statetestutils STATIC)
 add_library(evmone::statetestutils ALIAS evmone-statetestutils)
 target_compile_features(evmone-statetestutils PUBLIC cxx_std_20)
-target_link_libraries(evmone-statetestutils PRIVATE evmone::state evmone::testutils nlohmann_json::nlohmann_json)
+target_link_libraries(evmone-statetestutils PRIVATE evmone::state evmone::testutils nlohmann_json::nlohmann_json GTest::gtest)
 target_include_directories(evmone-statetestutils PRIVATE ${evmone_private_include_dir})
 target_sources(
     evmone-statetestutils PRIVATE
@@ -14,6 +14,7 @@ target_sources(
     statetest_export.cpp
     statetest_loader.cpp
     statetest_logs_hash.cpp
+    statetest_runner.cpp
 )
 
 add_executable(evmone-statetest)
@@ -22,5 +23,4 @@ target_include_directories(evmone-statetest PRIVATE ${evmone_private_include_dir
 target_sources(
     evmone-statetest PRIVATE
     statetest.cpp
-    statetest_runner.cpp
 )


### PR DESCRIPTION
This PR implements proper support for evm benchmarking in a form of state test file.
- Remove old style benchmarking support using raw bytecode in file
- Load state test `json` file and run benchmarks on tests defined in file.
- Run state tests before benchmarking to make sure that it passes.