### PR TITLE
cable: external git info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Documentation of all notable changes to the **evmone** project.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [0.14.0] — 2024-XX-XX
+
+### Added
+
+- cable: external git info
+  [#1067](https://github.com/ethereum/evmone/pull/1067)
+
 ## [0.13.0] — 2024-09-23
 
 This release adds BLS precompiles and a system contract for [Prague]

--- a/cmake/cable/CableBuildInfo.cmake
+++ b/cmake/cable/CableBuildInfo.cmake
@@ -22,8 +22,15 @@ include(GNUInstallDirs)
 set(cable_buildinfo_template_dir ${CMAKE_CURRENT_LIST_DIR}/buildinfo)
 
 function(cable_add_buildinfo_library)
-
-    cmake_parse_arguments("" "" PROJECT_NAME;EXPORT "" ${ARGN})
+    set(
+        ARG_NAMES
+        PROJECT_NAME
+        EXPORT
+        GIT_DESCRIBE
+        GIT_BRANCH
+        GIT_ORIGIN_URL
+    )
+    cmake_parse_arguments(PARSE_ARGV 0 "" "" "${ARG_NAMES}" "")
 
     if(NOT _PROJECT_NAME)
         message(FATAL_ERROR "The PROJECT_NAME argument missing")
@@ -55,10 +62,14 @@ function(cable_add_buildinfo_library)
         ${name}-git
         COMMAND ${CMAKE_COMMAND}
         -DGIT=${GIT_EXECUTABLE}
+        -DGIT_DESCRIBE=${_GIT_DESCRIBE}
+        -DGIT_BRANCH=${_GIT_BRANCH}
+        -DGIT_ORIGIN_URL=${_GIT_ORIGIN_URL}
         -DSOURCE_DIR=${PROJECT_SOURCE_DIR}
         -DOUTPUT_DIR=${output_dir}
         -P ${cable_buildinfo_template_dir}/gitinfo.cmake
         BYPRODUCTS ${output_dir}/gitinfo.txt
+        COMMENT "CableBuildInfo: updating gitinfo.txt"
     )
 
     add_custom_command(

--- a/cmake/cable/buildinfo/gitinfo.cmake
+++ b/cmake/cable/buildinfo/gitinfo.cmake
@@ -4,45 +4,55 @@
 
 # Execute git only if the tool is available.
 if(GIT)
-    execute_process(
-        COMMAND ${GIT} describe --always --long --tags --first-parent --match=v* --abbrev=40 --dirty
-        WORKING_DIRECTORY ${SOURCE_DIR}
-        OUTPUT_VARIABLE gitinfo
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_VARIABLE error
-        ERROR_STRIP_TRAILING_WHITESPACE
-    )
-    if(error)
-        message(WARNING "Git ${error}")
+    if (GIT_DESCRIBE)
+        set(gitdescribe "${GIT_DESCRIBE}")
+    else()
+        execute_process(
+            COMMAND ${GIT} describe --always --long --tags --first-parent --match=v* --abbrev=40 --dirty
+            WORKING_DIRECTORY ${SOURCE_DIR}
+            OUTPUT_VARIABLE gitdescribe
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE error
+            ERROR_STRIP_TRAILING_WHITESPACE
+        )
+        if(error)
+            message(WARNING "Git ${error}")
+        endif()
     endif()
 
-    execute_process(
-        COMMAND ${GIT} rev-parse --abbrev-ref HEAD
-        WORKING_DIRECTORY ${SOURCE_DIR}
-        OUTPUT_VARIABLE gitbranch
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_VARIABLE error
-        ERROR_STRIP_TRAILING_WHITESPACE
-    )
-    if(error)
-        message(WARNING "Git ${error}")
+    if (GIT_BRANCH)
+        set(gitbranch "${GIT_BRANCH}")
     else()
-        set(gitinfo "${gitinfo}\n${gitbranch}")
+        execute_process(
+            COMMAND ${GIT} rev-parse --abbrev-ref HEAD
+            WORKING_DIRECTORY ${SOURCE_DIR}
+            OUTPUT_VARIABLE gitbranch
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE error
+            ERROR_STRIP_TRAILING_WHITESPACE
+        )
+        if(error)
+            message(WARNING "Git ${error}")
+        endif()
     endif()
 
-    execute_process(
-        COMMAND ${GIT} config --get remote.origin.url
-        WORKING_DIRECTORY ${SOURCE_DIR}
-        OUTPUT_VARIABLE gitorigin
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_VARIABLE error
-        ERROR_STRIP_TRAILING_WHITESPACE
-    )
-    if(error)
-        message(WARNING "Git ${error}")
+    if (GIT_ORIGIN_URL)
+        set(gitorigin "${GIT_ORIGIN_URL}")
     else()
-        set(gitinfo "${gitinfo}\n${gitorigin}\n")
+        execute_process(
+            COMMAND ${GIT} config --get remote.origin.url
+            WORKING_DIRECTORY ${SOURCE_DIR}
+            OUTPUT_VARIABLE gitorigin
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE error
+            ERROR_STRIP_TRAILING_WHITESPACE
+        )
+        if(error)
+            message(WARNING "Git ${error}")
+        endif()
     endif()
+
+    set(gitinfo "${gitdescribe}\n${gitbranch}\n${gitorigin}\n")
 endif()
 
 set(gitinfo_file ${OUTPUT_DIR}/gitinfo.txt)


### PR DESCRIPTION
#### Problem:

A git commit sha or a branch name change causes relinking of executable targets with silkworm-buildinfo library even if nothing else has changed.

During development (e.g. local Debug builds) it is more important to have fast incremental builds than having the correct git commit sha and a branch name baked into the binary.

#### Solution:

Add arguments to cable_add_buildinfo_library:
* GIT_DESCRIBE
* GIT_BRANCH
* GIT_ORIGIN_URL

If passed they override corresponding git commands.

In Silkworm we can hardcode them in Debug builds to avoid relinking and save time when doing small changes and git rebase/squash/reword operations.

See related Silkworm PR: 
https://github.com/erigontech/silkworm/pull/2473

#### Test

Silkworm `git commit --amend --date=now && time make` output before the change:

```
...
[11/70] Updating silkworm-buildinfo:
       Project Version:  0.1.0-dev+commit.11e1cbbc.dirty (prerelease)
       System Name:      darwin
       System Processor: arm64
       Compiler ID:      appleclang
       Compiler Version: 15.0.0.15000309
       Build Type:       debug
       Git Info:         //11e1cbbc69056575cae00370af1883e5f6504944 (dirty)
       Git Branch:       pr/test
       Git Origin URL:   git@github.com:erigontech/silkworm.git
       Timestamp:        2024-11-04T10:57:47
[68/69] Linking CXX executable cmd/dev/snapshots
make  104.37s user 9.23s system 509% cpu 22.279 total
```

Silkworm `git commit --amend --date=now && time make` output after the change:

```
...
[1/47] CableBuildInfo: updating gitinfo.txt
make  0.08s user 0.07s system 84% cpu 0.176 total
```

#### Note

I've also tried passing GIT_COMMIT_HASH directly to buildinfo.cmake instead of via gitinfo.cmake, but it didn't help, because gitinfo.cmake is regenerating gitinfo.txt, and gitinfo.txt is set as a dependency to buildinfo.c, so even though buildinfo.c contents was not changed, it was "touched" and silkworm-buildinfo library got rebuilt.
