### PR TITLE
baseline: Optimize code analysis allocation

### DIFF
--- a/lib/evmone/baseline_analysis.cpp
+++ b/lib/evmone/baseline_analysis.cpp
@@ -16,44 +16,48 @@ static_assert(!std::is_copy_assignable_v<CodeAnalysis>);
 
 namespace
 {
-CodeAnalysis::JumpdestMap analyze_jumpdests(bytes_view code)
+void analyze_jumpdests(BitsetSpan map, bytes_view code) noexcept
 {
     // To find if op is any PUSH opcode (OP_PUSH1 <= op <= OP_PUSH32)
-    // it can be noticed that OP_PUSH32 is INT8_MAX (0x7f) therefore
+    // it can be noticed that OP_PUSH32 is INT8_MAX (0x7f) therefore,
     // static_cast<int8_t>(op) <= OP_PUSH32 is always true and can be skipped.
     static_assert(OP_PUSH32 == std::numeric_limits<int8_t>::max());
 
-    CodeAnalysis::JumpdestMap map(code.size());  // Allocate and init bitmap with zeros.
     for (size_t i = 0; i < code.size(); ++i)
     {
         const auto op = code[i];
         if (static_cast<int8_t>(op) >= OP_PUSH1)  // If any PUSH opcode (see explanation above).
             i += op - size_t{OP_PUSH1 - 1};       // Skip PUSH data.
         else if (INTX_UNLIKELY(op == OP_JUMPDEST))
-            map[i] = true;
+            map.set(i);
     }
-
-    return map;
 }
-
-std::unique_ptr<uint8_t[]> pad_code(bytes_view code)
-{
-    // We need at most 33 bytes of code padding: 32 for possible missing all data bytes of PUSH32
-    // at the very end of the code; and one more byte for STOP to guarantee there is a terminating
-    // instruction at the code end.
-    constexpr auto padding = 32 + 1;
-
-    auto padded_code = std::make_unique_for_overwrite<uint8_t[]>(code.size() + padding);
-    std::ranges::copy(code, padded_code.get());
-    std::fill_n(&padded_code[code.size()], padding, uint8_t{OP_STOP});
-    return padded_code;
-}
-
 
 CodeAnalysis analyze_legacy(bytes_view code)
 {
-    // TODO: The padded code buffer and jumpdest bitmap can be created with single allocation.
-    return {pad_code(code), code.size(), analyze_jumpdests(code)};
+    // We need at most 33 bytes of code padding: 32 for possible missing all data bytes of
+    // the PUSH32 at the code end; and one more byte for STOP to guarantee there is a terminating
+    // instruction at the code end.
+    static constexpr auto PADDING = 32 + 1;
+
+    static constexpr auto BITSET_ALIGNMENT = alignof(BitsetSpan::word_type);
+
+    const auto padded_code_size = code.size() + PADDING;
+    const auto aligned_code_size =
+        (padded_code_size + (BITSET_ALIGNMENT - 1)) / BITSET_ALIGNMENT * BITSET_ALIGNMENT;
+    const auto bitset_words = (code.size() + (BitsetSpan::WORD_BITS)) / BitsetSpan::WORD_BITS;
+    const auto total_size = aligned_code_size + bitset_words * sizeof(BitsetSpan::word_type);
+
+    auto storage = std::make_unique_for_overwrite<uint8_t[]>(total_size);
+    std::ranges::copy(code, storage.get());                           // Copy code.
+    std::fill_n(&storage[code.size()], total_size - code.size(), 0);  // Pad code and init bitset.
+
+    const auto bitset_storage =
+        new (&storage[aligned_code_size]) BitsetSpan::word_type[bitset_words];
+    const BitsetSpan jumpdest_bitset{bitset_storage};
+    analyze_jumpdests(jumpdest_bitset, code);
+
+    return {std::move(storage), code.size(), jumpdest_bitset};
 }
 
 CodeAnalysis analyze_eof1(bytes_view container)


### PR DESCRIPTION
Construct analyzed code with single allocation. This replaces two allocations: one for the code copy and one for the jumpdest bitset with a single one of the following layout:

- code copy
- code padding (33 bytes)
- alignment padding (0–7 bytes)
- jumpdest bitset with 8-byte words (`ceil(code.size() / 64)` bits)