### PR TITLE
Add --time flag, print time spent applying block

### DIFF
--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -73,6 +73,6 @@ struct BlockchainTest
 
 std::vector<BlockchainTest> load_blockchain_tests(std::istream& input);
 
-void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm);
+void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm, bool time);
 
 }  // namespace evmone::test


### PR DESCRIPTION
zkevm tests output example:

```
$ ./build/bin/evmone-blockchaintest --time ../fixtures/blockchain_tests/zkevm/
[==========] Running 3 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from worst_bytecode
[ RUN      ] worst_bytecode.worst_bytecode_single_opcode
                tests/zkevm/test_worst_bytecode.py::test_worst_bytecode_single_opcode[fork_Cancun-blockchain_test-opcode_EXTCODESIZE] last block time: 1336578 ns
[       OK ] worst_bytecode.worst_bytecode_single_opcode (36 ms)
[----------] 1 test from worst_bytecode (36 ms total)

[----------] 2 tests from worst_compute
[ RUN      ] worst_compute.worst_keccak
                tests/zkevm/test_worst_compute.py::test_worst_keccak[fork_Cancun-blockchain_test-gas_limit_36000000] last block time: 286945744 ns
[       OK ] worst_compute.worst_keccak (287 ms)
[ RUN      ] worst_compute.worst_modexp
                tests/zkevm/test_worst_compute.py::test_worst_modexp[fork_Cancun-blockchain_test-gas_limit_0x044aa200] last block time: 383692010 ns
[       OK ] worst_compute.worst_modexp (384 ms)
[----------] 2 tests from worst_compute (672 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 2 test suites ran. (708 ms total)
[  PASSED  ] 3 tests.
```

Fixes #1236