### PR TITLE
Introduce BlobSchedule (EIP-7840)

### DIFF
--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(evmone-state PRIVATE ${evmone_private_include_dir})
 target_sources(
     evmone-state PRIVATE
     account.hpp
+    blob_schedule.hpp
     block.hpp
     block.cpp
     bloom_filter.hpp

--- a/test/state/blob_schedule.hpp
+++ b/test/state/blob_schedule.hpp
@@ -1,0 +1,32 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2025 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <evmc/evmc.hpp>
+
+namespace evmone::state
+{
+/// The cost of a single blob in gas units (EIP-4844).
+constexpr auto GAS_PER_BLOB = 0x20000;  // 2**17
+
+/// The maximum number of blobs that can be included in a transaction (EIP-7594).
+constexpr auto MAX_TX_BLOB_COUNT = 6;
+
+/// The blob schedule for an EVM revision (EIP-7840).
+struct BlobSchedule
+{
+    uint16_t target = 0;
+    uint16_t max = 0;
+    uint32_t base_fee_update_fraction = 0;
+};
+
+/// Returns the blob schedule for the given EVM revision.
+constexpr BlobSchedule get_blob_schedule(evmc_revision rev) noexcept
+{
+    if (rev >= EVMC_PRAGUE)
+        return {6, 9, 5007716};
+    return {3, 6, 3338477};
+}
+}  // namespace evmone::state

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "blob_schedule.hpp"
 #include "bloom_filter.hpp"
 #include "state_diff.hpp"
 #include <intx/intx.hpp>
@@ -12,12 +13,6 @@
 
 namespace evmone::state
 {
-/// The cost of a single blob in gas units (EIP-4844).
-constexpr auto GAS_PER_BLOB = 0x20000;  // 2**17
-
-/// The maximum number of blobs that can be included in a transaction (EIP-7594).
-constexpr auto MAX_TX_BLOB_COUNT = 6;
-
 using AccessList = std::vector<std::pair<address, std::vector<bytes32>>>;
 
 struct Authorization


### PR DESCRIPTION
Refactor constants related to the blob schedule by introducing `struct BlobSchedule` based on EIP-7840.
https://eips.ethereum.org/EIPS/eip-7840

Closes https://github.com/ipsilon/evmone/issues/1283.