### PR TITLE
crypto: Add better API for FieldElement and AffinePoint in ECC

### DIFF
--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -13,11 +13,12 @@ constexpr auto B3 = Fp.to_mont(3 * 3);
 }  // namespace
 
 
-bool validate(const bn254::AffinePoint& pt) noexcept
+bool validate(const AffinePoint& pt) noexcept
 {
     static constexpr auto _3 = AffinePoint::E{3};
 
-    if (pt.is_neutral())
+    // TODO: Reverse order check.
+    if (pt == 0)
         return true;
 
     const auto yy = pt.y * pt.y;

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -21,18 +21,18 @@ bool validate(const AffinePoint& pt) noexcept
     return yy == xxx + _3;
 }
 
-Point mul(const AffinePoint& pt, const uint256& c) noexcept
+AffinePoint mul(const AffinePoint& pt, const uint256& c) noexcept
 {
     constexpr auto& Fp = Curve::Fp;
     static constexpr auto B3 = Fp.to_mont(3 * 3);
 
     if (pt == 0)
-        return pt.to_old();
+        return pt;
 
     if (c == 0)
         return {};
 
     const auto pr = ecc::mul(Fp, pt.to_old(), c, B3);
-    return ecc::to_affine(Fp, pr);
+    return ecc::to_affine<Curve>(pr);
 }
 }  // namespace evmmax::bn254

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -8,10 +8,20 @@ namespace evmmax::bn254
 {
 namespace
 {
-constexpr ModArith Fp{FieldPrime};
 constexpr auto B = Fp.to_mont(3);
 constexpr auto B3 = Fp.to_mont(3 * 3);
 }  // namespace
+
+
+bool validate(const bn254::PT& pt) noexcept
+{
+    if (pt == PT{})
+        return true;
+
+    const auto yy = pt.y * pt.y;
+    const auto xxx = pt.x * pt.x * pt.x;
+    return yy == xxx + PT::FE{B};
+}
 
 bool validate(const Point& pt) noexcept
 {

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -39,11 +39,6 @@ bool validate(const Point& pt) noexcept
     return y2 == x3_3;
 }
 
-Point add(const Point& p, const Point& q) noexcept
-{
-    return ecc::add(Fp, p, q);
-}
-
 Point mul(const Point& pt, const uint256& c) noexcept
 {
     if (pt.is_inf())

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -8,6 +8,7 @@ namespace evmmax::bn254
 {
 namespace
 {
+constexpr auto& Fp = Curve::Fp;
 constexpr auto B = Fp.to_mont(3);
 constexpr auto B3 = Fp.to_mont(3 * 3);
 }  // namespace

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -8,13 +8,6 @@ namespace evmmax::bn254
 {
 static_assert(AffinePoint{} == 0, "default constructed is the point at infinity");
 
-namespace
-{
-constexpr auto& Fp = Curve::Fp;
-constexpr auto B3 = Fp.to_mont(3 * 3);
-}  // namespace
-
-
 bool validate(const AffinePoint& pt) noexcept
 {
     static constexpr auto _3 = AffinePoint::E{3};
@@ -30,6 +23,9 @@ bool validate(const AffinePoint& pt) noexcept
 
 Point mul(const Point& pt, const uint256& c) noexcept
 {
+    constexpr auto& Fp = Curve::Fp;
+    static constexpr auto B3 = Fp.to_mont(3 * 3);
+
     if (pt.is_inf())
         return pt;
 

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -21,18 +21,18 @@ bool validate(const AffinePoint& pt) noexcept
     return yy == xxx + _3;
 }
 
-Point mul(const Point& pt, const uint256& c) noexcept
+Point mul(const AffinePoint& pt, const uint256& c) noexcept
 {
     constexpr auto& Fp = Curve::Fp;
     static constexpr auto B3 = Fp.to_mont(3 * 3);
 
-    if (pt.is_inf())
-        return pt;
+    if (pt == 0)
+        return pt.to_old();
 
     if (c == 0)
         return {};
 
-    const auto pr = ecc::mul(Fp, pt, c, B3);
+    const auto pr = ecc::mul(Fp, pt.to_old(), c, B3);
     return ecc::to_affine(Fp, pr);
 }
 }  // namespace evmmax::bn254

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -13,14 +13,14 @@ constexpr auto B3 = Fp.to_mont(3 * 3);
 }  // namespace
 
 
-bool validate(const bn254::PT& pt) noexcept
+bool validate(const bn254::AffinePoint& pt) noexcept
 {
     if (pt.is_neutral())
         return true;
 
     const auto yy = pt.y * pt.y;
     const auto xxx = pt.x * pt.x * pt.x;
-    return yy == xxx + PT::FE{B};
+    return yy == xxx + AffinePoint::FE{B};
 }
 
 bool validate(const Point& pt) noexcept

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -10,15 +10,13 @@ static_assert(AffinePoint{} == 0, "default constructed is the point at infinity"
 
 bool validate(const AffinePoint& pt) noexcept
 {
-    static constexpr auto _3 = AffinePoint::E{3};
-
     // TODO: Reverse order check.
     if (pt == 0)
         return true;
 
     const auto yy = pt.y * pt.y;
     const auto xxx = pt.x * pt.x * pt.x;
-    return yy == xxx + _3;
+    return yy == xxx + Curve::B;
 }
 
 AffinePoint mul(const AffinePoint& pt, const uint256& c) noexcept

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -6,10 +6,11 @@
 
 namespace evmmax::bn254
 {
+static_assert(AffinePoint{} == 0, "default constructed is the point at infinity");
+
 namespace
 {
 constexpr auto& Fp = Curve::Fp;
-constexpr auto B = Fp.to_mont(3);
 constexpr auto B3 = Fp.to_mont(3 * 3);
 }  // namespace
 
@@ -27,20 +28,6 @@ bool validate(const AffinePoint& pt) noexcept
     return yy == xxx + _3;
 }
 
-bool validate(const Point& pt) noexcept
-{
-    if (pt.is_inf())
-        return true;
-
-    const auto xm = Fp.to_mont(pt.x);
-    const auto ym = Fp.to_mont(pt.y);
-    const auto y2 = Fp.mul(ym, ym);
-    const auto x2 = Fp.mul(xm, xm);
-    const auto x3 = Fp.mul(x2, xm);
-    const auto x3_3 = Fp.add(x3, B);
-    return y2 == x3_3;
-}
-
 Point mul(const Point& pt, const uint256& c) noexcept
 {
     if (pt.is_inf())
@@ -49,9 +36,7 @@ Point mul(const Point& pt, const uint256& c) noexcept
     if (c == 0)
         return {};
 
-    const Point p_mont{Fp.to_mont(pt.x), Fp.to_mont(pt.y)};
-    const auto pr = ecc::mul(Fp, p_mont, c, B3);
-
+    const auto pr = ecc::mul(Fp, pt, c, B3);
     return ecc::to_affine(Fp, pr);
 }
 }  // namespace evmmax::bn254

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -15,7 +15,7 @@ constexpr auto B3 = Fp.to_mont(3 * 3);
 
 bool validate(const bn254::PT& pt) noexcept
 {
-    if (pt == PT{})
+    if (pt.is_neutral())
         return true;
 
     const auto yy = pt.y * pt.y;

--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -15,12 +15,14 @@ constexpr auto B3 = Fp.to_mont(3 * 3);
 
 bool validate(const bn254::AffinePoint& pt) noexcept
 {
+    static constexpr auto _3 = AffinePoint::E{3};
+
     if (pt.is_neutral())
         return true;
 
     const auto yy = pt.y * pt.y;
     const auto xxx = pt.x * pt.x * pt.x;
-    return yy == xxx + AffinePoint::FE{B};
+    return yy == xxx + _3;
 }
 
 bool validate(const Point& pt) noexcept

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -36,8 +36,6 @@ using ExtPoint = ecc::Point<std::pair<uint256, uint256>>;
 /// Validates that point is from the bn254 curve group
 ///
 /// Returns true if y^2 == x^3 + 3. Input is converted to the Montgomery form.
-bool validate(const Point& pt) noexcept;
-
 bool validate(const AffinePoint& pt) noexcept;
 
 /// Scalar multiplication in bn254 curve group.

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -19,7 +19,12 @@ inline constexpr auto FieldPrime =
 constexpr ModArith Fp{FieldPrime};
 
 
-using PT = ecc::PT<uint256, Fp>;
+struct Curve {
+    using uint_type = uint256;
+    static constexpr ModArith M{FieldPrime};
+};
+
+using PT = ecc::PT<Curve>;
 
 using Point = ecc::Point<uint256>;
 /// Note that real part of G2 value goes first and imaginary part is the second. i.e (a + b*i)
@@ -37,7 +42,6 @@ bool validate(const bn254::PT& pt) noexcept;
 ///
 /// Computes P ⊕ Q for two points in affine coordinates on the bn254 curve,
 Point add(const Point& p, const Point& q) noexcept;
-PT add(const PT& p, const PT& q) noexcept;
 
 /// Scalar multiplication in bn254 curve group.
 ///

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -41,7 +41,7 @@ bool validate(const AffinePoint& pt) noexcept;
 /// Scalar multiplication in bn254 curve group.
 ///
 /// Computes [c]P for a point in affine coordinate on the bn254 curve,
-Point mul(const AffinePoint& pt, const uint256& c) noexcept;
+AffinePoint mul(const AffinePoint& pt, const uint256& c) noexcept;
 
 /// ate paring implementation for bn254 curve according to https://eips.ethereum.org/EIPS/eip-197
 ///

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -24,6 +24,8 @@ struct Curve
 
     /// The modular arithmetic for the field.
     static constexpr ModArith Fp{FIELD_PRIME};
+
+    static constexpr auto B = ecc::FieldElement<Curve>(3_u256);
 };
 
 using AffinePoint = ecc::AffinePoint<Curve>;

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -12,16 +12,18 @@ namespace evmmax::bn254
 {
 using namespace intx;
 
-/// The bn254 field prime number (P).
-inline constexpr auto FieldPrime =
-    0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_u256;
-
-constexpr ModArith Fp{FieldPrime};
-
-
-struct Curve {
+/// The BN254 curve parameters.
+struct Curve
+{
+    /// The field/scalar unsigned int type.
     using uint_type = uint256;
-    static constexpr ModArith M{FieldPrime};
+
+    /// The field prime number (P).
+    static constexpr auto FIELD_PRIME =
+        0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_u256;
+
+    /// The modular arithmetic for the field.
+    static constexpr ModArith Fp{FIELD_PRIME};
 };
 
 using AffinePoint = ecc::AffinePoint<Curve>;

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -16,6 +16,11 @@ using namespace intx;
 inline constexpr auto FieldPrime =
     0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_u256;
 
+constexpr ModArith Fp{FieldPrime};
+
+
+using PT = ecc::PT<uint256, Fp>;
+
 using Point = ecc::Point<uint256>;
 /// Note that real part of G2 value goes first and imaginary part is the second. i.e (a + b*i)
 /// The pairing check precompile EVM ABI presumes that imaginary part goes first.
@@ -26,10 +31,13 @@ using ExtPoint = ecc::Point<std::pair<uint256, uint256>>;
 /// Returns true if y^2 == x^3 + 3. Input is converted to the Montgomery form.
 bool validate(const Point& pt) noexcept;
 
+bool validate(const bn254::PT& pt) noexcept;
+
 /// Addition in bn254 curve group.
 ///
 /// Computes P ⊕ Q for two points in affine coordinates on the bn254 curve,
 Point add(const Point& p, const Point& q) noexcept;
+PT add(const PT& p, const PT& q) noexcept;
 
 /// Scalar multiplication in bn254 curve group.
 ///

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -25,7 +25,7 @@ struct Curve
     /// The modular arithmetic for the field.
     static constexpr ModArith Fp{FIELD_PRIME};
 
-    static constexpr auto B = ecc::FieldElement<Curve>(3_u256);
+    static constexpr auto B = ecc::FieldElement<Curve>(3);
 };
 
 using AffinePoint = ecc::AffinePoint<Curve>;

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -24,7 +24,7 @@ struct Curve {
     static constexpr ModArith M{FieldPrime};
 };
 
-using PT = ecc::PT<Curve>;
+using AffinePoint = ecc::AffinePoint<Curve>;
 
 using Point = ecc::Point<uint256>;
 /// Note that real part of G2 value goes first and imaginary part is the second. i.e (a + b*i)
@@ -36,7 +36,7 @@ using ExtPoint = ecc::Point<std::pair<uint256, uint256>>;
 /// Returns true if y^2 == x^3 + 3. Input is converted to the Montgomery form.
 bool validate(const Point& pt) noexcept;
 
-bool validate(const bn254::PT& pt) noexcept;
+bool validate(const AffinePoint& pt) noexcept;
 
 /// Addition in bn254 curve group.
 ///

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -38,11 +38,6 @@ bool validate(const Point& pt) noexcept;
 
 bool validate(const AffinePoint& pt) noexcept;
 
-/// Addition in bn254 curve group.
-///
-/// Computes P ⊕ Q for two points in affine coordinates on the bn254 curve,
-Point add(const Point& p, const Point& q) noexcept;
-
 /// Scalar multiplication in bn254 curve group.
 ///
 /// Computes [c]P for a point in affine coordinate on the bn254 curve,

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -41,7 +41,7 @@ bool validate(const AffinePoint& pt) noexcept;
 /// Scalar multiplication in bn254 curve group.
 ///
 /// Computes [c]P for a point in affine coordinate on the bn254 curve,
-Point mul(const Point& pt, const uint256& c) noexcept;
+Point mul(const AffinePoint& pt, const uint256& c) noexcept;
 
 /// ate paring implementation for bn254 curve according to https://eips.ethereum.org/EIPS/eip-197
 ///

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -50,22 +50,30 @@ struct FE
 
     friend constexpr auto operator*(const FE& a, const FE& b) noexcept
     {
-        return FE{M.mul(a.value_, b.value_)};
+        return wrap(M.mul(a.value_, b.value_));
     }
 
     friend constexpr auto operator+(const FE& a, const FE& b) noexcept
     {
-        return FE{M.add(a.value_, b.value_)};
+        return wrap(M.add(a.value_, b.value_));
     }
 
     friend constexpr auto operator-(const FE& a, const FE& b) noexcept
     {
-        return FE{M.sub(a.value_, b.value_)};
+        return wrap(M.sub(a.value_, b.value_));
     }
 
     friend constexpr auto operator/(const FE& a, const FE& b) noexcept
     {
-        return FE{M.mul(a.value_, M.inv(b.value_))};
+        return wrap(M.mul(a.value_, M.inv(b.value_)));
+    }
+
+private:
+    [[gnu::always_inline]] static constexpr FE wrap(const uint_type& v) noexcept
+    {
+        FE element;
+        element.value_ = v;
+        return element;
     }
 };
 

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -25,15 +25,15 @@ template <typename Curve>
 struct Element
 {
     using uint_type = typename Curve::uint_type;
-    static constexpr auto& M = Curve::M;
+    static constexpr auto& Fp = Curve::Fp;
 
     uint_type value_{};
 
     Element() = default;
 
-    constexpr explicit Element(uint_type v) : value_(Curve::M.to_mont(v)) {}
+    constexpr explicit Element(uint_type v) : value_(Fp.to_mont(v)) {}
 
-    constexpr uint_type value() const noexcept { return Curve::M.from_mont(value_); }
+    constexpr uint_type value() const noexcept { return Fp.from_mont(value_); }
 
     static constexpr Element from_bytes(std::span<const uint8_t, sizeof(uint_type)> b) noexcept
     {
@@ -56,22 +56,22 @@ struct Element
 
     friend constexpr auto operator*(const Element& a, const Element& b) noexcept
     {
-        return wrap(M.mul(a.value_, b.value_));
+        return wrap(Fp.mul(a.value_, b.value_));
     }
 
     friend constexpr auto operator+(const Element& a, const Element& b) noexcept
     {
-        return wrap(M.add(a.value_, b.value_));
+        return wrap(Fp.add(a.value_, b.value_));
     }
 
     friend constexpr auto operator-(const Element& a, const Element& b) noexcept
     {
-        return wrap(M.sub(a.value_, b.value_));
+        return wrap(Fp.sub(a.value_, b.value_));
     }
 
     friend constexpr auto operator/(const Element& a, const Element& b) noexcept
     {
-        return wrap(M.mul(a.value_, M.inv(b.value_)));
+        return wrap(Fp.mul(a.value_, Fp.inv(b.value_)));
     }
 
 private:

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -70,6 +70,8 @@ struct PT
     FE y;
 
     constexpr bool operator==(const PT&) const = default;
+
+    constexpr bool is_neutral() const noexcept { return *this == PT{}; }
 };
 
 /// The affine (two coordinates) point on an Elliptic Curve over a prime field.

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -73,19 +73,19 @@ struct FE
 template <typename Curve>
 struct AffinePoint
 {
-    using FE = FE<Curve>;
+    using E = FE<Curve>;
 
-    FE x;
-    FE y;
+    E x;
+    E y;
 
     friend constexpr bool operator==(const AffinePoint&, const AffinePoint&) = default;
 
     constexpr bool is_neutral() const noexcept { return *this == AffinePoint{}; }
 
-    static constexpr AffinePoint from_bytes(std::span<uint8_t, sizeof(FE) * 2> b)
+    static constexpr AffinePoint from_bytes(std::span<uint8_t, sizeof(E) * 2> b)
     {
-        const auto x = FE::from_bytes(b.template subspan<0, sizeof(FE)>());
-        const auto y = FE::from_bytes(b.template subspan<sizeof(FE), sizeof(FE)>());
+        const auto x = E::from_bytes(b.template subspan<0, sizeof(E)>());
+        const auto y = E::from_bytes(b.template subspan<sizeof(E), sizeof(E)>());
         return AffinePoint{x, y};
     }
 };

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -223,43 +223,6 @@ inline AffinePoint<Curve> to_affine(const ProjPoint<typename Curve::uint_type>& 
     return {FieldElement<Curve>::wrap(p.x) * z_inv, FieldElement<Curve>::wrap(p.y) * z_inv};
 }
 
-/// Adds two elliptic curve points in affine coordinates
-/// and returns the result in affine coordinates.
-template <typename IntT>
-Point<IntT> add(const ModArith<IntT>& m, const Point<IntT>& p, const Point<IntT>& q) noexcept
-{
-    if (p.is_inf())
-        return q;
-    if (q.is_inf())
-        return p;
-
-    const auto x1 = m.to_mont(p.x);
-    const auto y1 = m.to_mont(p.y);
-    const auto x2 = m.to_mont(q.x);
-    const auto y2 = m.to_mont(q.y);
-
-    // Use classic formula for point addition.
-    // https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication#Point_operations
-
-    auto dx = m.sub(x2, x1);
-    auto dy = m.sub(y2, y1);
-    if (dx == 0)
-    {
-        if (dy != 0)    // For opposite points
-            return {};  // return the point at infinity.
-
-        // For coincident points find the slope of the tangent line.
-        const auto xx = m.mul(x1, x1);
-        dy = m.add(m.add(xx, xx), xx);
-        dx = m.add(y1, y1);
-    }
-    const auto slope = m.mul(dy, m.inv(dx));
-
-    const auto xr = m.sub(m.sub(m.mul(slope, slope), x1), x2);
-    const auto yr = m.sub(m.mul(m.sub(x1, xr), slope), y1);
-    return {m.from_mont(xr), m.from_mont(yr)};
-}
-
 /// Elliptic curve point addition in affine coordinates.
 ///
 /// Computes P ⊕ Q for two points in affine coordinates on the elliptic curve.

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -83,7 +83,22 @@ private:
     }
 };
 
+/// The affine (two coordinates) point on an Elliptic Curve over a prime field.
+template <typename ValueT>
+struct Point
+{
+    ValueT x = {};
+    ValueT y = {};
 
+    friend constexpr bool operator==(const Point& a, const Point& b) noexcept = default;
+
+    friend constexpr Point operator-(const Point& p) noexcept { return {p.x, -p.y}; }
+
+    /// Checks if the point represents the special "infinity" value.
+    [[nodiscard]] constexpr bool is_inf() const noexcept { return *this == Point{}; }
+};
+
+/// The affine (two coordinates) point on an Elliptic Curve over a prime field.
 template <typename Curve>
 struct AffinePoint
 {
@@ -111,24 +126,9 @@ struct AffinePoint
         x.to_bytes(b.template subspan<0, sizeof(E)>());
         y.to_bytes(b.template subspan<sizeof(E), sizeof(E)>());
     }
+
+    Point<typename Curve::uint_type> to_old() const noexcept { return {x.value_, y.value_}; }
 };
-
-/// The affine (two coordinates) point on an Elliptic Curve over a prime field.
-template <typename ValueT>
-struct Point
-{
-    ValueT x = {};
-    ValueT y = {};
-
-    friend constexpr bool operator==(const Point& a, const Point& b) noexcept = default;
-
-    friend constexpr Point operator-(const Point& p) noexcept { return {p.x, -p.y}; }
-
-    /// Checks if the point represents the special "infinity" value.
-    [[nodiscard]] constexpr bool is_inf() const noexcept { return *this == Point{}; }
-};
-
-static_assert(Point<unsigned>{}.is_inf());
 
 template <typename IntT>
 struct ProjPoint

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -69,12 +69,16 @@ struct Element
         return wrap(Fp.sub(a.value_, b.value_));
     }
 
+    friend constexpr auto operator/(one_t, const Element& a) noexcept
+    {
+        return wrap(Fp.inv(a.value_));
+    }
+
     friend constexpr auto operator/(const Element& a, const Element& b) noexcept
     {
         return wrap(Fp.mul(a.value_, Fp.inv(b.value_)));
     }
 
-private:
     [[gnu::always_inline]] static constexpr Element wrap(const uint_type& v) noexcept
     {
         Element element;
@@ -194,6 +198,15 @@ inline Point<IntT> to_affine(const ModArith<IntT>& s, const ProjPoint<IntT>& p) 
     // FIXME: Add tests for inf.
     const auto z_inv = s.inv(p.z);
     return {s.from_mont(s.mul(p.x, z_inv)), s.from_mont(s.mul(p.y, z_inv))};
+}
+
+/// Converts a projected point to an affine point.
+template <typename Curve>
+inline AffinePoint<Curve> to_affine(const ProjPoint<typename Curve::uint_type>& p) noexcept
+{
+    // FIXME: Add tests for inf.
+    const auto z_inv = 1 / Element<Curve>::wrap(p.z);
+    return {Element<Curve>::wrap(p.x) * z_inv, Element<Curve>::wrap(p.y) * z_inv};
 }
 
 /// Adds two elliptic curve points in affine coordinates

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <evmmax/evmmax.hpp>
-
 #include <span>
 
 namespace evmmax::ecc
@@ -12,9 +11,9 @@ namespace evmmax::ecc
 template <int N>
 struct Constant : std::integral_constant<int, N>
 {
-    consteval explicit(false) Constant(int value) noexcept
+    consteval explicit(false) Constant(int v) noexcept
     {
-        if (N != value)
+        if (N != v)
             intx::unreachable();
     }
 };

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -26,7 +26,7 @@ using one_t = Constant<1>;
 template <typename Curve>
 struct FieldElement
 {
-    using uint_type = typename Curve::uint_type;
+    using uint_type = Curve::uint_type;
     static constexpr auto& Fp = Curve::Fp;
 
     // TODO: Make this private.
@@ -120,8 +120,7 @@ struct AffinePoint
     constexpr AffinePoint(const FE& x_, const FE& y_) noexcept : x{x_}, y{y_} {}
 
     /// Create the point from literal values.
-    consteval AffinePoint(
-        const typename Curve::uint_type& x_value, const typename Curve::uint_type& y_value) noexcept
+    consteval AffinePoint(const Curve::uint_type& x_value, const Curve::uint_type& y_value) noexcept
       : x{x_value}, y{y_value}
     {}
 
@@ -229,11 +228,9 @@ inline AffinePoint<Curve> to_affine(const ProjPoint<typename Curve::uint_type>& 
 template <typename Curve>
 AffinePoint<Curve> add(const AffinePoint<Curve>& p, const AffinePoint<Curve>& q) noexcept
 {
-    using PT = AffinePoint<Curve>;
-
-    if (p == PT{})
+    if (p == 0)
         return q;
-    if (q == PT{})
+    if (q == 0)
         return p;
 
     const auto& [x1, y1] = p;

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -35,7 +35,7 @@ struct FieldElement
 
     FieldElement() = default;
 
-    constexpr explicit FieldElement(uint_type v) : value_(Fp.to_mont(v)) {}
+    constexpr explicit FieldElement(uint_type v) : value_{Fp.to_mont(v)} {}
 
     constexpr uint_type value() const noexcept { return Fp.from_mont(value_); }
 
@@ -112,10 +112,19 @@ struct Point
 template <typename Curve>
 struct AffinePoint
 {
-    using E = FieldElement<Curve>;
+    using FE = FieldElement<Curve>;
 
-    E x;
-    E y;
+    FE x;
+    FE y;
+
+    AffinePoint() = default;
+    constexpr AffinePoint(const FE& x_, const FE& y_) noexcept : x{x_}, y{y_} {}
+
+    /// Create the point from literal values.
+    consteval AffinePoint(
+        const typename Curve::uint_type& x_value, const typename Curve::uint_type& y_value) noexcept
+      : x{x_value}, y{y_value}
+    {}
 
     friend constexpr bool operator==(const AffinePoint&, const AffinePoint&) = default;
 
@@ -124,17 +133,17 @@ struct AffinePoint
         return p == AffinePoint{};
     }
 
-    static constexpr AffinePoint from_bytes(std::span<const uint8_t, sizeof(E) * 2> b) noexcept
+    static constexpr AffinePoint from_bytes(std::span<const uint8_t, sizeof(FE) * 2> b) noexcept
     {
-        const auto x = E::from_bytes(b.template subspan<0, sizeof(E)>());
-        const auto y = E::from_bytes(b.template subspan<sizeof(E), sizeof(E)>());
-        return AffinePoint{x, y};
+        const auto x = FE::from_bytes(b.template subspan<0, sizeof(FE)>());
+        const auto y = FE::from_bytes(b.template subspan<sizeof(FE), sizeof(FE)>());
+        return {x, y};
     }
 
-    constexpr void to_bytes(std::span<uint8_t, sizeof(E) * 2> b) const noexcept
+    constexpr void to_bytes(std::span<uint8_t, sizeof(FE) * 2> b) const noexcept
     {
-        x.to_bytes(b.template subspan<0, sizeof(E)>());
-        y.to_bytes(b.template subspan<sizeof(E), sizeof(E)>());
+        x.to_bytes(b.template subspan<0, sizeof(FE)>());
+        y.to_bytes(b.template subspan<sizeof(FE), sizeof(FE)>());
     }
 
     Point<typename Curve::uint_type> to_old() const noexcept { return {x.value_, y.value_}; }

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -230,6 +230,9 @@ Point<IntT> add(const ModArith<IntT>& m, const Point<IntT>& p, const Point<IntT>
     return {m.from_mont(xr), m.from_mont(yr)};
 }
 
+/// Elliptic curve point addition in affine coordinates.
+///
+/// Computes P ⊕ Q for two points in affine coordinates on the elliptic curve.
 template <typename Curve>
 AffinePoint<Curve> add(const AffinePoint<Curve>& p, const AffinePoint<Curve>& q) noexcept
 {

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -35,10 +35,16 @@ struct Element
 
     constexpr uint_type value() const noexcept { return Curve::M.from_mont(value_); }
 
-    static constexpr Element from_bytes(std::span<uint8_t, sizeof(uint_type)> b) noexcept
+    static constexpr Element from_bytes(std::span<const uint8_t, sizeof(uint_type)> b) noexcept
     {
         // TODO: Add intx::load from std::span.
         return Element{intx::be::unsafe::load<uint_type>(b.data())};
+    }
+
+    constexpr void to_bytes(std::span<uint8_t, sizeof(uint_type)> b) const noexcept
+    {
+        // TODO: Add intx::store to std::span.
+        intx::be::unsafe::store(b.data(), value());
     }
 
 
@@ -90,11 +96,17 @@ struct AffinePoint
 
     constexpr bool is_neutral() const noexcept { return *this == AffinePoint{}; }
 
-    static constexpr AffinePoint from_bytes(std::span<uint8_t, sizeof(E) * 2> b)
+    static constexpr AffinePoint from_bytes(std::span<const uint8_t, sizeof(E) * 2> b) noexcept
     {
         const auto x = E::from_bytes(b.template subspan<0, sizeof(E)>());
         const auto y = E::from_bytes(b.template subspan<sizeof(E), sizeof(E)>());
         return AffinePoint{x, y};
+    }
+
+    constexpr void to_bytes(std::span<uint8_t, sizeof(E) * 2> b) const noexcept
+    {
+        x.to_bytes(b.template subspan<0, sizeof(E)>());
+        y.to_bytes(b.template subspan<sizeof(E), sizeof(E)>());
     }
 };
 

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -218,7 +218,7 @@ inline Point<IntT> to_affine(const ModArith<IntT>& s, const ProjPoint<IntT>& p) 
 template <typename Curve>
 inline AffinePoint<Curve> to_affine(const ProjPoint<typename Curve::uint_type>& p) noexcept
 {
-    // FIXME: Add tests for inf.
+    // This works correctly for the point at infinity (z == 0) because then z_inv == 0.
     const auto z_inv = 1 / FieldElement<Curve>::wrap(p.z);
     return {FieldElement<Curve>::wrap(p.x) * z_inv, FieldElement<Curve>::wrap(p.y) * z_inv};
 }

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -22,56 +22,56 @@ using zero_t = Constant<0>;
 using one_t = Constant<1>;
 
 template <typename Curve>
-struct FE
+struct Element
 {
     using uint_type = typename Curve::uint_type;
     static constexpr auto& M = Curve::M;
 
-    uint_type value_;
+    uint_type value_{};
 
-    FE() = default;
+    Element() = default;
 
-    constexpr explicit FE(uint_type v) : value_(Curve::M.to_mont(v)) {}
+    constexpr explicit Element(uint_type v) : value_(Curve::M.to_mont(v)) {}
 
     constexpr uint_type value() const noexcept { return Curve::M.from_mont(value_); }
 
-    static constexpr FE from_bytes(std::span<uint8_t, sizeof(uint_type)> b) noexcept
+    static constexpr Element from_bytes(std::span<uint8_t, sizeof(uint_type)> b) noexcept
     {
         // TODO: Add intx::load from std::span.
-        return FE{intx::be::unsafe::load<uint_type>(b.data())};
+        return Element{intx::be::unsafe::load<uint_type>(b.data())};
     }
 
 
     constexpr explicit operator bool() const noexcept { return static_cast<bool>(value_); }
 
-    friend constexpr bool operator==(const FE&, const FE&) = default;
+    friend constexpr bool operator==(const Element&, const Element&) = default;
 
-    friend constexpr bool operator==(const FE& a, zero_t) noexcept { return !a.value_; }
+    friend constexpr bool operator==(const Element& a, zero_t) noexcept { return !a.value_; }
 
-    friend constexpr auto operator*(const FE& a, const FE& b) noexcept
+    friend constexpr auto operator*(const Element& a, const Element& b) noexcept
     {
         return wrap(M.mul(a.value_, b.value_));
     }
 
-    friend constexpr auto operator+(const FE& a, const FE& b) noexcept
+    friend constexpr auto operator+(const Element& a, const Element& b) noexcept
     {
         return wrap(M.add(a.value_, b.value_));
     }
 
-    friend constexpr auto operator-(const FE& a, const FE& b) noexcept
+    friend constexpr auto operator-(const Element& a, const Element& b) noexcept
     {
         return wrap(M.sub(a.value_, b.value_));
     }
 
-    friend constexpr auto operator/(const FE& a, const FE& b) noexcept
+    friend constexpr auto operator/(const Element& a, const Element& b) noexcept
     {
         return wrap(M.mul(a.value_, M.inv(b.value_)));
     }
 
 private:
-    [[gnu::always_inline]] static constexpr FE wrap(const uint_type& v) noexcept
+    [[gnu::always_inline]] static constexpr Element wrap(const uint_type& v) noexcept
     {
-        FE element;
+        Element element;
         element.value_ = v;
         return element;
     }
@@ -81,7 +81,7 @@ private:
 template <typename Curve>
 struct AffinePoint
 {
-    using E = FE<Curve>;
+    using E = Element<Curve>;
 
     E x;
     E y;

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -62,16 +62,16 @@ struct FE
 
 
 template <typename Curve>
-struct PT
+struct AffinePoint
 {
-    using FE = evmmax::ecc::FE<Curve>;
+    using FE = FE<Curve>;
 
     FE x;
     FE y;
 
-    constexpr bool operator==(const PT&) const = default;
+    friend constexpr bool operator==(const AffinePoint&, const AffinePoint&) = default;
 
-    constexpr bool is_neutral() const noexcept { return *this == PT{}; }
+    constexpr bool is_neutral() const noexcept { return *this == AffinePoint{}; }
 };
 
 /// The affine (two coordinates) point on an Elliptic Curve over a prime field.
@@ -195,9 +195,9 @@ Point<IntT> add(const ModArith<IntT>& m, const Point<IntT>& p, const Point<IntT>
 }
 
 template <typename Curve>
-PT<Curve> add(const PT<Curve>& p, const PT<Curve>& q) noexcept
+AffinePoint<Curve> add(const AffinePoint<Curve>& p, const AffinePoint<Curve>& q) noexcept
 {
-    using PT = PT<Curve>;
+    using PT = AffinePoint<Curve>;
 
     if (p == PT{})
         return q;

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -94,7 +94,10 @@ struct AffinePoint
 
     friend constexpr bool operator==(const AffinePoint&, const AffinePoint&) = default;
 
-    constexpr bool is_neutral() const noexcept { return *this == AffinePoint{}; }
+    friend constexpr bool operator==(const AffinePoint& p, zero_t) noexcept
+    {
+        return p == AffinePoint{};
+    }
 
     static constexpr AffinePoint from_bytes(std::span<const uint8_t, sizeof(E) * 2> b) noexcept
     {

--- a/lib/evmone_precompiles/pairing/bn254/fields.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/fields.hpp
@@ -15,8 +15,8 @@ using namespace intx;
 struct BaseFieldConfig
 {
     using ValueT = uint256;
-    static constexpr auto MOD_ARITH = ModArith{FieldPrime};
-    static constexpr uint256 ONE = MOD_ARITH.to_mont(1);
+    static constexpr auto& MOD_ARITH = Curve::Fp;
+    static constexpr auto ONE = MOD_ARITH.to_mont(1);
 };
 using Fq = ecc::BaseFieldElem<BaseFieldConfig>;
 

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -70,7 +70,7 @@ static inline std::array<std::array<Fq2, 5>, 3> FROBENIUS_COEFFS = {
 /// Verifies that value is in the proper prime field.
 constexpr bool is_field_element(const uint256& v)
 {
-    return v < FieldPrime;
+    return v < Curve::FIELD_PRIME;
 }
 
 /// Verifies that affine point is on the curve (not twisted)

--- a/lib/evmone_precompiles/secp256k1.cpp
+++ b/lib/evmone_precompiles/secp256k1.cpp
@@ -11,9 +11,8 @@ namespace
 constexpr auto B = Curve::Fp.to_mont(7);
 constexpr auto B3 = Curve::Fp.to_mont(7 * 3);
 
-constexpr AffinePoint G{
-    AffinePoint::E{0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_u256},
-    AffinePoint::E{0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_u256}};
+constexpr AffinePoint G{0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_u256,
+    0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_u256};
 }  // namespace
 
 // FIXME: Change to "uncompress_point".
@@ -100,7 +99,7 @@ std::optional<AffinePoint> secp256k1_ecdsa_recover(
     const auto y = Fp.from_mont(*y_mont);
 
     // 6. Calculate public key point Q.
-    const auto R = AffinePoint{AffinePoint::E{r}, AffinePoint::E{y}};
+    const auto R = AffinePoint{AffinePoint::FE{r}, AffinePoint::FE{y}};
     const auto T1 = ecc::mul(Fp, G.to_old(), u1, B3);
     const auto T2 = ecc::mul(Fp, R.to_old(), u2, B3);
     const auto pQ = ecc::add(Fp, T1, T2, B3);

--- a/lib/evmone_precompiles/secp256k1.hpp
+++ b/lib/evmone_precompiles/secp256k1.hpp
@@ -12,15 +12,22 @@ namespace evmmax::secp256k1
 {
 using namespace intx;
 
-/// The secp256k1 field prime number (P).
-inline constexpr auto FieldPrime =
-    0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f_u256;
+struct Curve
+{
+    using uint_type = uint256;
 
-/// The secp256k1 curve group order (N).
-inline constexpr auto Order =
-    0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_u256;
+    /// The field prime number (P).
+    static constexpr auto FIELD_PRIME =
+        0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f_u256;
 
-using Point = ecc::Point<uint256>;
+    /// The secp256k1 curve group order (N).
+    static constexpr auto ORDER =
+        0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_u256;
+
+    static constexpr ModArith Fp{FIELD_PRIME};
+};
+
+using AffinePoint = ecc::AffinePoint<Curve>;
 
 /// Square root for secp256k1 prime field.
 ///
@@ -34,20 +41,15 @@ std::optional<uint256> field_sqrt(const ModArith<uint256>& m, const uint256& x) 
 std::optional<uint256> calculate_y(
     const ModArith<uint256>& m, const uint256& x, bool y_parity) noexcept;
 
-/// Addition in secp256k1.
-///
-/// Computes P ⊕ Q for two points in affine coordinates on the secp256k1 curve,
-Point add(const Point& p, const Point& q) noexcept;
-
 /// Scalar multiplication in secp256k1.
 ///
 /// Computes [c]P for a point in affine coordinate on the secp256k1 curve,
-Point mul(const Point& p, const uint256& c) noexcept;
+AffinePoint mul(const AffinePoint& p, const uint256& c) noexcept;
 
 /// Convert the secp256k1 point (uncompressed public key) to Ethereum address.
-evmc::address to_address(const Point& pt) noexcept;
+evmc::address to_address(const AffinePoint& pt) noexcept;
 
-std::optional<Point> secp256k1_ecdsa_recover(
+std::optional<AffinePoint> secp256k1_ecdsa_recover(
     const ethash::hash256& e, const uint256& r, const uint256& s, bool v) noexcept;
 
 std::optional<evmc::address> ecrecover(

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -470,9 +470,9 @@ ExecutionResult ecmul_execute(const uint8_t* input, size_t input_size, uint8_t* 
     if (validate(p))
     {
         const auto res = evmmax::bn254::mul(p, c);
-        intx::be::unsafe::store(output, res.x);
-        intx::be::unsafe::store(output + 32, res.y);
-        return {EVMC_SUCCESS, 64};
+        const std::span<uint8_t, 64> output_span{output, 64};
+        res.to_bytes(output_span);
+        return {EVMC_SUCCESS, output_span.size()};
     }
     else
         return {EVMC_PRECOMPILE_FAILURE, 0};

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -443,9 +443,9 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
     if (validate(p) && validate(q))
     {
         const auto res = evmmax::ecc::add(p, q);
-        intx::be::unsafe::store(output, res.x.value());
-        intx::be::unsafe::store(output + 32, res.y.value());
-        return {EVMC_SUCCESS, 64};
+        const std::span<uint8_t, 64> output_span{output, 64};
+        res.to_bytes(output_span);
+        return {EVMC_SUCCESS, output_span.size()};
     }
     else
         return {EVMC_PRECOMPILE_FAILURE, 0};

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -460,13 +460,16 @@ ExecutionResult ecmul_execute(const uint8_t* input, size_t input_size, uint8_t* 
     if (input_size != 0)
         std::memcpy(input_buffer, input, std::min(input_size, std::size(input_buffer)));
 
-    const evmmax::bn254::Point p = {intx::be::unsafe::load<intx::uint256>(input_buffer),
-        intx::be::unsafe::load<intx::uint256>(input_buffer + 32)};
+    const auto input_span = std::span{input_buffer};
+
+    using namespace evmmax::bn254;
+
+    const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
     const auto c = intx::be::unsafe::load<intx::uint256>(input_buffer + 64);
 
-    if (evmmax::bn254::validate(p))
+    if (validate(p))
     {
-        const auto res = evmmax::bn254::mul(p, c);
+        const auto res = evmmax::bn254::mul(p.to_old(), c);
         intx::be::unsafe::store(output, res.x);
         intx::be::unsafe::store(output + 32, res.y);
         return {EVMC_SUCCESS, 64};

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -433,14 +433,14 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
     if (input_size != 0)
         std::memcpy(input_buffer, input, std::min(input_size, std::size(input_buffer)));
 
+    const auto input_span = std::span{input_buffer};
+
     using namespace evmmax::bn254;
 
-    const AffinePoint p{AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer)},
-        AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 32)}};
-    const AffinePoint q{AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 64)},
-        AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 96)}};
+    const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
+    const auto q = AffinePoint::from_bytes(input_span.subspan<64, 64>());
 
-    if (evmmax::bn254::validate(p) && validate(q))
+    if (validate(p) && validate(q))
     {
         const auto res = evmmax::ecc::add(p, q);
         intx::be::unsafe::store(output, res.x.value());

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -469,7 +469,7 @@ ExecutionResult ecmul_execute(const uint8_t* input, size_t input_size, uint8_t* 
 
     if (validate(p))
     {
-        const auto res = evmmax::bn254::mul(p.to_old(), c);
+        const auto res = evmmax::bn254::mul(p, c);
         intx::be::unsafe::store(output, res.x);
         intx::be::unsafe::store(output + 32, res.y);
         return {EVMC_SUCCESS, 64};

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -442,7 +442,7 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
 
     if (evmmax::bn254::validate(p) && validate(q))
     {
-        const auto res = evmmax::bn254::add(p, q);
+        const auto res = evmmax::ecc::add(p, q);
         intx::be::unsafe::store(output, res.x.value());
         intx::be::unsafe::store(output + 32, res.y.value());
         return {EVMC_SUCCESS, 64};

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -435,10 +435,10 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
 
     using namespace evmmax::bn254;
 
-    const PT p{PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer)},
-        PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 32)}};
-    const PT q{PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 64)},
-        PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 96)}};
+    const AffinePoint p{AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer)},
+        AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 32)}};
+    const AffinePoint q{AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 64)},
+        AffinePoint::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 96)}};
 
     if (evmmax::bn254::validate(p) && validate(q))
     {

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -433,16 +433,18 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
     if (input_size != 0)
         std::memcpy(input_buffer, input, std::min(input_size, std::size(input_buffer)));
 
-    const evmmax::bn254::Point p = {intx::be::unsafe::load<intx::uint256>(input_buffer),
-        intx::be::unsafe::load<intx::uint256>(input_buffer + 32)};
-    const evmmax::bn254::Point q = {intx::be::unsafe::load<intx::uint256>(input_buffer + 64),
-        intx::be::unsafe::load<intx::uint256>(input_buffer + 96)};
+    using namespace evmmax::bn254;
 
-    if (evmmax::bn254::validate(p) && evmmax::bn254::validate(q))
+    const PT p{PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer)},
+        PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 32)}};
+    const PT q{PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 64)},
+        PT::FE{intx::be::unsafe::load<intx::uint256>(input_buffer + 96)}};
+
+    if (evmmax::bn254::validate(p) && validate(q))
     {
         const auto res = evmmax::bn254::add(p, q);
-        intx::be::unsafe::store(output, res.x);
-        intx::be::unsafe::store(output + 32, res.y);
+        intx::be::unsafe::store(output, res.x.value());
+        intx::be::unsafe::store(output + 32, res.y.value());
         return {EVMC_SUCCESS, 64};
     }
     else

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -19,7 +19,7 @@ namespace evmone::state
 namespace
 {
 /// Secp256k1's N/2 is the upper bound of the signature's s value.
-constexpr auto SECP256K1N_OVER_2 = evmmax::secp256k1::Order / 2;
+constexpr auto SECP256K1N_OVER_2 = evmmax::secp256k1::Curve::ORDER / 2;
 /// EIP-7702: The cost of authorization that sets delegation to an account that didn't exist before.
 constexpr auto AUTHORIZATION_EMPTY_ACCOUNT_COST = 25000;
 /// EIP-7702: The cost of authorization that sets delegation to an account that already exists.

--- a/test/unittests/evmmax_bn254_add_test.cpp
+++ b/test/unittests/evmmax_bn254_add_test.cpp
@@ -121,16 +121,14 @@ TEST(evmmax, bn254_validate_inputs)
         ASSERT_EQ(t.input.size(), 128);
         ASSERT_EQ(t.expected_output.size(), 64);
 
-        const Point a{
-            be::unsafe::load<uint256>(t.input.data()), be::unsafe::load<uint256>(&t.input[32])};
-        const Point b{
-            be::unsafe::load<uint256>(&t.input[64]), be::unsafe::load<uint256>(&t.input[96])};
-        const Point e{be::unsafe::load<uint256>(t.expected_output.data()),
-            be::unsafe::load<uint256>(&t.expected_output[32])};
+        const auto p = AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.input[0], 64});
+        const auto q = AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.input[64], 64});
+        const auto r =
+            AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.expected_output[0], 64});
 
-        EXPECT_TRUE(validate(a));
-        EXPECT_TRUE(validate(b));
-        EXPECT_TRUE(validate(e));
+        EXPECT_TRUE(validate(p));
+        EXPECT_TRUE(validate(q));
+        EXPECT_TRUE(validate(r));
     }
 }
 
@@ -138,13 +136,11 @@ TEST(evmmax, bn254_pt_add)
 {
     for (const auto& t : test_cases)
     {
-        const Point a{
-            be::unsafe::load<uint256>(t.input.data()), be::unsafe::load<uint256>(&t.input[32])};
-        const Point b{
-            be::unsafe::load<uint256>(&t.input[64]), be::unsafe::load<uint256>(&t.input[96])};
-        const Point e{be::unsafe::load<uint256>(t.expected_output.data()),
-            be::unsafe::load<uint256>(&t.expected_output[32])};
+        const auto p = AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.input[0], 64});
+        const auto q = AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.input[64], 64});
+        const auto r =
+            AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.expected_output[0], 64});
 
-        EXPECT_EQ(add(a, b), e);
+        EXPECT_EQ(add(p, q), r);
     }
 }

--- a/test/unittests/evmmax_bn254_mul_test.cpp
+++ b/test/unittests/evmmax_bn254_mul_test.cpp
@@ -217,13 +217,12 @@ TEST(evmmax, bn254_mul_validate_inputs)
         ASSERT_EQ(t.input.size(), 96);
         ASSERT_EQ(t.expected_output.size(), 64);
 
-        const Point a{
-            be::unsafe::load<uint256>(t.input.data()), be::unsafe::load<uint256>(&t.input[32])};
-        const Point e{be::unsafe::load<uint256>(t.expected_output.data()),
-            be::unsafe::load<uint256>(&t.expected_output[32])};
+        const auto p = AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.input[0], 64});
+        const auto r =
+            AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.expected_output[0], 64});
 
-        EXPECT_TRUE(validate(a));
-        EXPECT_TRUE(validate(e));
+        EXPECT_TRUE(validate(p));
+        EXPECT_TRUE(validate(r));
     }
 }
 
@@ -231,14 +230,12 @@ TEST(evmmax, bn254_pt_mul)
 {
     for (const auto& t : test_cases)
     {
-        const Point p{
-            be::unsafe::load<uint256>(t.input.data()), be::unsafe::load<uint256>(&t.input[32])};
-        const auto d{be::unsafe::load<uint256>(&t.input[64])};
+        const auto p = AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.input[0], 64});
+        const auto c = be::unsafe::load<uint256>(&t.input[64]);
         const Point e{be::unsafe::load<uint256>(t.expected_output.data()),
             be::unsafe::load<uint256>(&t.expected_output[32])};
 
-        auto r = mul(p, d);
-
+        const auto r = mul(p.to_old(), c);
         EXPECT_EQ(r, e);
     }
 }

--- a/test/unittests/evmmax_bn254_mul_test.cpp
+++ b/test/unittests/evmmax_bn254_mul_test.cpp
@@ -235,7 +235,7 @@ TEST(evmmax, bn254_pt_mul)
         const Point e{be::unsafe::load<uint256>(t.expected_output.data()),
             be::unsafe::load<uint256>(&t.expected_output[32])};
 
-        const auto r = mul(p.to_old(), c);
+        const auto r = mul(p, c);
         EXPECT_EQ(r, e);
     }
 }

--- a/test/unittests/evmmax_bn254_mul_test.cpp
+++ b/test/unittests/evmmax_bn254_mul_test.cpp
@@ -232,8 +232,8 @@ TEST(evmmax, bn254_pt_mul)
     {
         const auto p = AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.input[0], 64});
         const auto c = be::unsafe::load<uint256>(&t.input[64]);
-        const Point e{be::unsafe::load<uint256>(t.expected_output.data()),
-            be::unsafe::load<uint256>(&t.expected_output[32])};
+        const auto e =
+            AffinePoint::from_bytes(std::span<const uint8_t, 64>{&t.expected_output[0], 64});
 
         const auto r = mul(p, c);
         EXPECT_EQ(r, e);

--- a/test/unittests/evmmax_bn254_pairing_test.cpp
+++ b/test/unittests/evmmax_bn254_pairing_test.cpp
@@ -34,7 +34,8 @@ TEST(evmmax, bn254_pairing)
         },
     };
     // -Q1:
-    const auto nQ1 = ExtPoint{Q1.x, {Curve::FIELD_PRIME - Q1.y.first, Curve::FIELD_PRIME - Q1.y.second}};
+    const auto nQ1 =
+        ExtPoint{Q1.x, {Curve::FIELD_PRIME - Q1.y.first, Curve::FIELD_PRIME - Q1.y.second}};
     // -Q1 * 16:
     const auto nQ1_16 = ExtPoint{
         {

--- a/test/unittests/evmmax_bn254_pairing_test.cpp
+++ b/test/unittests/evmmax_bn254_pairing_test.cpp
@@ -16,7 +16,7 @@ TEST(evmmax, bn254_pairing)
         0x3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41_u256,
     };
     // -P1:
-    const auto nP1 = Point{P1.x, FieldPrime - P1.y};
+    const auto nP1 = Point{P1.x, Curve::FIELD_PRIME - P1.y};
     // P1 * 17:
     const auto P1_17 = Point{
         0x22980b2e458ec77e258b19ca3a7b46181f63c6536307acae03eea236f6919eeb_u256,
@@ -34,7 +34,7 @@ TEST(evmmax, bn254_pairing)
         },
     };
     // -Q1:
-    const auto nQ1 = ExtPoint{Q1.x, {FieldPrime - Q1.y.first, FieldPrime - Q1.y.second}};
+    const auto nQ1 = ExtPoint{Q1.x, {Curve::FIELD_PRIME - Q1.y.first, Curve::FIELD_PRIME - Q1.y.second}};
     // -Q1 * 16:
     const auto nQ1_16 = ExtPoint{
         {
@@ -124,14 +124,14 @@ TEST(evmmax, bn254_pairing_invalid_input)
     {
         // Coordinate not a field element
         auto input = valid_input;
-        input[0].first.x = FieldPrime;
+        input[0].first.x = Curve::FIELD_PRIME;
         EXPECT_EQ(pairing_check(input), std::nullopt);
     }
 
     {
         // Coordinate not a field element
         auto input = valid_input;
-        input[0].second.x.second = FieldPrime;
+        input[0].second.x.second = Curve::FIELD_PRIME;
         EXPECT_EQ(pairing_check(input), std::nullopt);
     }
 

--- a/test/unittests/evmmax_secp256k1_test.cpp
+++ b/test/unittests/evmmax_secp256k1_test.cpp
@@ -181,9 +181,8 @@ TEST(evmmax, secp256k1_hash_to_number)
 
 TEST(evmmax, secp256k1_pt_add_inf)
 {
-    const AffinePoint p1{
-        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
-        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
+    const AffinePoint p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
+        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
     const AffinePoint inf;
     ASSERT_TRUE(inf == 0);
 
@@ -194,53 +193,41 @@ TEST(evmmax, secp256k1_pt_add_inf)
 
 TEST(evmmax, secp256k1_pt_add)
 {
-    const AffinePoint p1{
-        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
-        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
-    const AffinePoint p2{
-        AffinePoint::E{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256},
-        AffinePoint::E{0xb6d73966107b10526e2e140c17f343ee0a373351f2b1408923151b027f55b82_u256}};
-    const AffinePoint p3{
-        AffinePoint::E{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256},
-        AffinePoint::E{0xf4928c699ef84efad91d1ebf3e80cbc11f5c8ccae0d4ebf76dceae4ed80aa0ad_u256}};
-    const AffinePoint p4{AffinePoint::E{0x1_u256},
-        AffinePoint::E{0xbde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441_u256}};
+    const AffinePoint p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
+        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
+    const AffinePoint p2{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256,
+        0xb6d73966107b10526e2e140c17f343ee0a373351f2b1408923151b027f55b82_u256};
+    const AffinePoint p3{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256,
+        0xf4928c699ef84efad91d1ebf3e80cbc11f5c8ccae0d4ebf76dceae4ed80aa0ad_u256};
+    const AffinePoint p4{
+        0x1_u256, 0xbde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441_u256};
 
     {
-        const AffinePoint e{
-            AffinePoint::E{0x40468d7704db3d11961ab9c222e35919d7e5d1baef59e0f46255d66bec3bd1d3_u256},
-            AffinePoint::E{0x6fff88d9f575236b6cc5c74e7d074832a460c2792fba888aea7b9986429dd7f7_u256},
-        };
+        const AffinePoint e{0x40468d7704db3d11961ab9c222e35919d7e5d1baef59e0f46255d66bec3bd1d3_u256,
+            0x6fff88d9f575236b6cc5c74e7d074832a460c2792fba888aea7b9986429dd7f7_u256};
         EXPECT_EQ(add(p1, p2), e);
     }
     {
-        const AffinePoint e{
-            AffinePoint::E{0xd8e7b42b8c82e185bf0669ce0754697a6eb46c156497d5d1971bd6a23f38ed9e_u256},
-            AffinePoint::E{0x628c3107fc73c92e7b8c534e239257fb2de95bd6b965dc1021f636da086a7e99_u256},
-        };
+        const AffinePoint e{0xd8e7b42b8c82e185bf0669ce0754697a6eb46c156497d5d1971bd6a23f38ed9e_u256,
+            0x628c3107fc73c92e7b8c534e239257fb2de95bd6b965dc1021f636da086a7e99_u256};
         EXPECT_EQ(add(p1, p1), e);
     }
     {
-        const AffinePoint e{
-            AffinePoint::E{0xdf592d726f42759020da10d3106db3880e514c783d6970d2a9085fb16879b37f_u256},
-            AffinePoint::E{0x10aa0ef9fe224e3797792b4b286b9f63542d4c11fe26d449a845b9db0f5993f9_u256},
-        };
+        const AffinePoint e{0xdf592d726f42759020da10d3106db3880e514c783d6970d2a9085fb16879b37f_u256,
+            0x10aa0ef9fe224e3797792b4b286b9f63542d4c11fe26d449a845b9db0f5993f9_u256};
         EXPECT_EQ(add(p1, p3), e);
     }
     {
-        const AffinePoint e{
-            AffinePoint::E{0x12a5fd099bcd30e7290e58d63f8d5008287239500e6d0108020040497c5cb9c9_u256},
-            AffinePoint::E{0x7f6bd83b5ac46e3b59e24af3bc9bfbb213ed13e21d754e4950ae635961742574_u256},
-        };
+        const AffinePoint e{0x12a5fd099bcd30e7290e58d63f8d5008287239500e6d0108020040497c5cb9c9_u256,
+            0x7f6bd83b5ac46e3b59e24af3bc9bfbb213ed13e21d754e4950ae635961742574_u256};
         EXPECT_EQ(add(p1, p4), e);
     }
 }
 
 TEST(evmmax, secp256k1_pt_mul_inf)
 {
-    const AffinePoint p1{
-        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
-        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
+    const AffinePoint p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
+        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
     const AffinePoint inf;
 
     EXPECT_EQ(mul(p1, 0), inf);
@@ -253,40 +240,31 @@ TEST(evmmax, secp256k1_pt_mul_inf)
 
 TEST(evmmax, secp256k1_pt_mul)
 {
-    const AffinePoint p1{
-        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
-        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
+    const AffinePoint p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
+        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
 
     {
         const auto d{100000000000000000000_u256};
-        const AffinePoint e{
-            AffinePoint::E{0x4c34e6dc48badd579d1ce4702fd490fb98fa0e666417bfc2d4ff8e957d99c565_u256},
-            AffinePoint::E{0xb53da5be179d80c7f07226ba79b6bce643d89496b37d6bc2d111b009e37cc28b_u256},
-        };
+        const AffinePoint e{0x4c34e6dc48badd579d1ce4702fd490fb98fa0e666417bfc2d4ff8e957d99c565_u256,
+            0xb53da5be179d80c7f07226ba79b6bce643d89496b37d6bc2d111b009e37cc28b_u256};
         auto r = mul(p1, d);
         EXPECT_EQ(r, e);
     }
 
     {
         const auto d{100000000000000000000000000000000_u256};
-        const AffinePoint e{
-            AffinePoint::E{0xf86902594c8a4e4fc5f6dfb27886784271302c6bab3dc4350a0fe7c5b056af66_u256},
-            AffinePoint::E{0xb5748aa8f9122bfdcbf5846f6f8ec76f41626642a3f2ea0f483c92bf915847ad_u256},
-        };
+        const AffinePoint e{0xf86902594c8a4e4fc5f6dfb27886784271302c6bab3dc4350a0fe7c5b056af66_u256,
+            0xb5748aa8f9122bfdcbf5846f6f8ec76f41626642a3f2ea0f483c92bf915847ad_u256};
         auto r = mul(p1, d);
         EXPECT_EQ(r, e);
     }
 
     {
         const auto u1 = 0xd17a4c1f283fa5d67656ea81367b520eaa689207e5665620d4f51c7cf85fa220_u256;
-        const AffinePoint G{
-            AffinePoint::E{0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_u256},
-            AffinePoint::E{0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_u256},
-        };
-        const AffinePoint e{
-            AffinePoint::E{0x39cb41b2567f68137aae52e99dbe91cd38d9faa3ba6be536a04355b63a7964fe_u256},
-            AffinePoint::E{0xf31e6abd08cbd8e4896c9e0304b25000edcd52a9f6d2bac7cfbdad2c835c9a35_u256},
-        };
+        const AffinePoint G{0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_u256,
+            0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_u256};
+        const AffinePoint e{0x39cb41b2567f68137aae52e99dbe91cd38d9faa3ba6be536a04355b63a7964fe_u256,
+            0xf31e6abd08cbd8e4896c9e0304b25000edcd52a9f6d2bac7cfbdad2c835c9a35_u256};
         auto r = mul(G, u1);
         EXPECT_EQ(r, e);
     }
@@ -309,8 +287,8 @@ static const TestCaseECR test_cases_ecr[] = {
         0x3134a4ba8fafe11b351a720538398a5635e235c0b3258dce19942000731079ec_u256,
         false,
         {
-            AffinePoint::E{0x43ec87f8ee6f58605d947dac51b5e4cfe26705f509e5dad058212aadda180835_u256},
-            AffinePoint::E{0x90ebad786ce091f5af1719bf30ee236a4e6ce8a7ab6c36a16c93c6177aa109df_u256},
+            0x43ec87f8ee6f58605d947dac51b5e4cfe26705f509e5dad058212aadda180835_u256,
+            0x90ebad786ce091f5af1719bf30ee236a4e6ce8a7ab6c36a16c93c6177aa109df_u256,
         },
     },
 };

--- a/test/unittests/evmmax_secp256k1_test.cpp
+++ b/test/unittests/evmmax_secp256k1_test.cpp
@@ -12,7 +12,7 @@ using namespace evmone::test;
 
 TEST(secp256k1, field_sqrt)
 {
-    const evmmax::ModArith m{FieldPrime};
+    const auto& m = Curve::Fp;
 
     for (const auto& t : std::array{
              1_u256,
@@ -27,7 +27,7 @@ TEST(secp256k1, field_sqrt)
              0x9c76942a65df7c6a4a16b7d6a5f6c3a0b0c4b5c76a4b5c78a9f6d3c4a7a5b4_u256,
              0xad65931a55cf6b594915a6c5a4f5b2a9f0b3a4b6593a4b6789e5c2b39694a3_u256,
              0xbe54820a45bf5a48381495b494e4a1f8e9a293b548394a5678d4b1a28583a2_u256,
-             FieldPrime - 1,
+             Curve::FIELD_PRIME - 1,
          })
     {
         const auto a = m.to_mont(t);
@@ -40,9 +40,9 @@ TEST(secp256k1, field_sqrt)
 
 TEST(secp256k1, field_sqrt_invalid)
 {
-    const evmmax::ModArith m{FieldPrime};
+    const auto& m = Curve::Fp;
 
-    for (const auto& t : std::array{3_u256, FieldPrime - 1})
+    for (const auto& t : std::array{3_u256, Curve::FIELD_PRIME - 1})
     {
         EXPECT_FALSE(field_sqrt(m, m.to_mont(t)).has_value());
     }
@@ -50,15 +50,15 @@ TEST(secp256k1, field_sqrt_invalid)
 
 TEST(secp256k1, scalar_inv)
 {
-    const evmmax::ModArith n{Order};
+    const evmmax::ModArith n{Curve::ORDER};
 
     for (const auto& t : std::array{
              1_u256,
              0x6e140df17432311190232a91a38daed3ee9ed7f038645dd0278da7ca6e497de_u256,
-             Order - 1,
+             Curve::ORDER - 1,
          })
     {
-        ASSERT_LT(t, Order);
+        ASSERT_LT(t, Curve::ORDER);
         const auto a = n.to_mont(t);
         const auto a_inv = n.inv(a);
         const auto p = n.mul(a, a_inv);
@@ -68,7 +68,7 @@ TEST(secp256k1, scalar_inv)
 
 TEST(secp256k1, calculate_y)
 {
-    const evmmax::ModArith m{FieldPrime};
+    const auto& m = Curve::Fp;
 
     struct TestCase
     {
@@ -111,11 +111,11 @@ TEST(secp256k1, calculate_y)
 
 TEST(secp256k1, calculate_y_invalid)
 {
-    const evmmax::ModArith m{FieldPrime};
+    const auto& m = Curve::Fp;
 
     for (const auto& t : std::array{
              0x207ea538f1835f6de40c793fc23d22b14da5a80015a0fecddf56f146b21d7949_u256,
-             FieldPrime - 1,
+             Curve::FIELD_PRIME - 1,
          })
     {
         const auto x = m.to_mont(t);
@@ -133,7 +133,7 @@ TEST(secp256k1, point_to_address)
     // Check if converting the point at infinity gives the known address.
     // https://www.google.com/search?q=0x3f17f1962B36e491b30A40b2405849e597Ba5FB5
     // https://etherscan.io/address/0x3f17f1962b36e491b30a40b2405849e597ba5fb5
-    EXPECT_EQ(to_address(Point{}), 0x3f17f1962B36e491b30A40b2405849e597Ba5FB5_address);
+    EXPECT_EQ(to_address({}), 0x3f17f1962B36e491b30A40b2405849e597Ba5FB5_address);
 }
 
 TEST(evmmax, secp256k1_calculate_u1)
@@ -143,7 +143,7 @@ TEST(evmmax, secp256k1_calculate_u1)
     const auto r = 0x71cd6bfc24665312ff489aba9279710a560eda74aca333bf298785dc3cd72f6e_u256;
     const auto expected = 0xd80ea4db5200c96e969270ab7c105e16abb9fc18a6e01cc99575dd3f5ce41eed_u256;
 
-    const evmmax::ModArith m{evmmax::secp256k1::FieldPrime};
+    const auto& m = Curve::Fp;
     const auto z_mont = m.to_mont(z);
     const auto r_mont = m.to_mont(r);
     const auto r_inv = m.inv(r_mont);
@@ -160,7 +160,7 @@ TEST(evmmax, secp256k1_calculate_u2)
     const auto s = 0x7ce91fc325f28e78a016fa674a80d85581cc278d15453ea2fede2471b1adaada_u256;
     const auto expected = 0xf888ea06899abc190fa37a165c98e6d4b00b13c50db1d1c34f38f0ab8fd9c29b_u256;
 
-    const evmmax::ModArith m{evmmax::secp256k1::FieldPrime};
+    const auto& m = Curve::Fp;
     const auto s_mont = m.to_mont(s);
     const auto r_mont = m.to_mont(r);
     const auto r_inv = m.inv(r_mont);
@@ -172,19 +172,20 @@ TEST(evmmax, secp256k1_calculate_u2)
 TEST(evmmax, secp256k1_hash_to_number)
 {
     const auto max_h = ~uint256{};
-    const auto hm = max_h % evmmax::secp256k1::FieldPrime;
+    const auto hm = max_h % Curve::FIELD_PRIME;
 
     // Optimized mod.
-    const auto hm2 = max_h - evmmax::secp256k1::FieldPrime;
+    const auto hm2 = max_h - Curve::FIELD_PRIME;
     EXPECT_EQ(hm2, hm);
 }
 
 TEST(evmmax, secp256k1_pt_add_inf)
 {
-    const Point p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
-        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
-    const Point inf;
-    ASSERT_TRUE(inf.is_inf());
+    const AffinePoint p1{
+        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
+        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
+    const AffinePoint inf;
+    ASSERT_TRUE(inf == 0);
 
     EXPECT_EQ(add(p1, inf), p1);
     EXPECT_EQ(add(inf, p1), p1);
@@ -193,79 +194,99 @@ TEST(evmmax, secp256k1_pt_add_inf)
 
 TEST(evmmax, secp256k1_pt_add)
 {
-    const Point p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
-        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
-    const Point p2{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256,
-        0xb6d73966107b10526e2e140c17f343ee0a373351f2b1408923151b027f55b82_u256};
-    const Point p3{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256,
-        0xf4928c699ef84efad91d1ebf3e80cbc11f5c8ccae0d4ebf76dceae4ed80aa0ad_u256};
-    const Point p4{
-        0x1_u256, 0xbde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441_u256};
+    const AffinePoint p1{
+        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
+        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
+    const AffinePoint p2{
+        AffinePoint::E{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256},
+        AffinePoint::E{0xb6d73966107b10526e2e140c17f343ee0a373351f2b1408923151b027f55b82_u256}};
+    const AffinePoint p3{
+        AffinePoint::E{0xf929e07c83d65da3569113ae03998d13359ba982216285a686f4d66e721a0beb_u256},
+        AffinePoint::E{0xf4928c699ef84efad91d1ebf3e80cbc11f5c8ccae0d4ebf76dceae4ed80aa0ad_u256}};
+    const AffinePoint p4{AffinePoint::E{0x1_u256},
+        AffinePoint::E{0xbde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441_u256}};
 
     {
-        const Point e = {0x40468d7704db3d11961ab9c222e35919d7e5d1baef59e0f46255d66bec3bd1d3_u256,
-            0x6fff88d9f575236b6cc5c74e7d074832a460c2792fba888aea7b9986429dd7f7_u256};
+        const AffinePoint e{
+            AffinePoint::E{0x40468d7704db3d11961ab9c222e35919d7e5d1baef59e0f46255d66bec3bd1d3_u256},
+            AffinePoint::E{0x6fff88d9f575236b6cc5c74e7d074832a460c2792fba888aea7b9986429dd7f7_u256},
+        };
         EXPECT_EQ(add(p1, p2), e);
     }
     {
-        const Point e = {0xd8e7b42b8c82e185bf0669ce0754697a6eb46c156497d5d1971bd6a23f38ed9e_u256,
-            0x628c3107fc73c92e7b8c534e239257fb2de95bd6b965dc1021f636da086a7e99_u256};
+        const AffinePoint e{
+            AffinePoint::E{0xd8e7b42b8c82e185bf0669ce0754697a6eb46c156497d5d1971bd6a23f38ed9e_u256},
+            AffinePoint::E{0x628c3107fc73c92e7b8c534e239257fb2de95bd6b965dc1021f636da086a7e99_u256},
+        };
         EXPECT_EQ(add(p1, p1), e);
     }
     {
-        const Point e = {0xdf592d726f42759020da10d3106db3880e514c783d6970d2a9085fb16879b37f_u256,
-            0x10aa0ef9fe224e3797792b4b286b9f63542d4c11fe26d449a845b9db0f5993f9_u256};
+        const AffinePoint e{
+            AffinePoint::E{0xdf592d726f42759020da10d3106db3880e514c783d6970d2a9085fb16879b37f_u256},
+            AffinePoint::E{0x10aa0ef9fe224e3797792b4b286b9f63542d4c11fe26d449a845b9db0f5993f9_u256},
+        };
         EXPECT_EQ(add(p1, p3), e);
     }
     {
-        const Point e = {0x12a5fd099bcd30e7290e58d63f8d5008287239500e6d0108020040497c5cb9c9_u256,
-            0x7f6bd83b5ac46e3b59e24af3bc9bfbb213ed13e21d754e4950ae635961742574_u256};
+        const AffinePoint e{
+            AffinePoint::E{0x12a5fd099bcd30e7290e58d63f8d5008287239500e6d0108020040497c5cb9c9_u256},
+            AffinePoint::E{0x7f6bd83b5ac46e3b59e24af3bc9bfbb213ed13e21d754e4950ae635961742574_u256},
+        };
         EXPECT_EQ(add(p1, p4), e);
     }
 }
 
 TEST(evmmax, secp256k1_pt_mul_inf)
 {
-    const Point p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
-        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
-    const Point inf;
-    ASSERT_TRUE(inf.is_inf());
+    const AffinePoint p1{
+        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
+        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
+    const AffinePoint inf;
 
     EXPECT_EQ(mul(p1, 0), inf);
-    EXPECT_EQ(mul(p1, evmmax::secp256k1::Order), inf);
+    EXPECT_EQ(mul(p1, Curve::ORDER), inf);
     EXPECT_EQ(mul(inf, 0), inf);
     EXPECT_EQ(mul(inf, 1), inf);
-    EXPECT_EQ(mul(inf, evmmax::secp256k1::Order - 1), inf);
-    EXPECT_EQ(mul(inf, evmmax::secp256k1::Order), inf);
+    EXPECT_EQ(mul(inf, Curve::ORDER - 1), inf);
+    EXPECT_EQ(mul(inf, Curve::ORDER), inf);
 }
 
 TEST(evmmax, secp256k1_pt_mul)
 {
-    const Point p1{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256,
-        0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256};
+    const AffinePoint p1{
+        AffinePoint::E{0x18f4057699e2d9679421de8f4e11d7df9fa4b9e7cb841ea48aed75f1567b9731_u256},
+        AffinePoint::E{0x6db5b7ecd8e226c06f538d15173267bf1e78acc02bb856e83b3d6daec6a68144_u256}};
 
     {
         const auto d{100000000000000000000_u256};
-        const Point e{0x4c34e6dc48badd579d1ce4702fd490fb98fa0e666417bfc2d4ff8e957d99c565_u256,
-            0xb53da5be179d80c7f07226ba79b6bce643d89496b37d6bc2d111b009e37cc28b_u256};
+        const AffinePoint e{
+            AffinePoint::E{0x4c34e6dc48badd579d1ce4702fd490fb98fa0e666417bfc2d4ff8e957d99c565_u256},
+            AffinePoint::E{0xb53da5be179d80c7f07226ba79b6bce643d89496b37d6bc2d111b009e37cc28b_u256},
+        };
         auto r = mul(p1, d);
         EXPECT_EQ(r, e);
     }
 
     {
         const auto d{100000000000000000000000000000000_u256};
-        const Point e{0xf86902594c8a4e4fc5f6dfb27886784271302c6bab3dc4350a0fe7c5b056af66_u256,
-            0xb5748aa8f9122bfdcbf5846f6f8ec76f41626642a3f2ea0f483c92bf915847ad_u256};
+        const AffinePoint e{
+            AffinePoint::E{0xf86902594c8a4e4fc5f6dfb27886784271302c6bab3dc4350a0fe7c5b056af66_u256},
+            AffinePoint::E{0xb5748aa8f9122bfdcbf5846f6f8ec76f41626642a3f2ea0f483c92bf915847ad_u256},
+        };
         auto r = mul(p1, d);
         EXPECT_EQ(r, e);
     }
 
     {
         const auto u1 = 0xd17a4c1f283fa5d67656ea81367b520eaa689207e5665620d4f51c7cf85fa220_u256;
-        const Point G{0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_u256,
-            0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_u256};
-        const Point e{0x39cb41b2567f68137aae52e99dbe91cd38d9faa3ba6be536a04355b63a7964fe_u256,
-            0xf31e6abd08cbd8e4896c9e0304b25000edcd52a9f6d2bac7cfbdad2c835c9a35_u256};
+        const AffinePoint G{
+            AffinePoint::E{0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_u256},
+            AffinePoint::E{0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_u256},
+        };
+        const AffinePoint e{
+            AffinePoint::E{0x39cb41b2567f68137aae52e99dbe91cd38d9faa3ba6be536a04355b63a7964fe_u256},
+            AffinePoint::E{0xf31e6abd08cbd8e4896c9e0304b25000edcd52a9f6d2bac7cfbdad2c835c9a35_u256},
+        };
         auto r = mul(G, u1);
         EXPECT_EQ(r, e);
     }
@@ -278,15 +299,20 @@ struct TestCaseECR
     uint256 r;
     uint256 s;
     bool parity = false;
-    Point pubkey;
+    AffinePoint pubkey;
 };
 
 static const TestCaseECR test_cases_ecr[] = {
-    {0x18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c_bytes32,
+    {
+        0x18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c_bytes32,
         0x7af9e73057870458f03c143483bc5fcb6f39d01c9b26d28ed9f3fe23714f6628_u256,
-        0x3134a4ba8fafe11b351a720538398a5635e235c0b3258dce19942000731079ec_u256, false,
-        {0x43ec87f8ee6f58605d947dac51b5e4cfe26705f509e5dad058212aadda180835_u256,
-            0x90ebad786ce091f5af1719bf30ee236a4e6ce8a7ab6c36a16c93c6177aa109df_u256}},
+        0x3134a4ba8fafe11b351a720538398a5635e235c0b3258dce19942000731079ec_u256,
+        false,
+        {
+            AffinePoint::E{0x43ec87f8ee6f58605d947dac51b5e4cfe26705f509e5dad058212aadda180835_u256},
+            AffinePoint::E{0x90ebad786ce091f5af1719bf30ee236a4e6ce8a7ab6c36a16c93c6177aa109df_u256},
+        },
+    },
 };
 
 TEST(evmmax, ecr)
@@ -298,7 +324,7 @@ TEST(evmmax, ecr)
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result->x, t.pubkey.x);
         EXPECT_EQ(result->y, t.pubkey.y);
-        // EXPECT_EQ(*result, t.pubkey);
+        EXPECT_EQ(*result, t.pubkey);
     }
 }
 


### PR DESCRIPTION
This introduces:

- `struct FieldElement` which wraps the `ModArith` operations. The values of this type always have the Montgomery form to this avoids mistakes in the implementation.
- `struct AffinePoint` which is the pair of `FieldElement` and is the replacement for `Point`.

This improves efficiency also: checking if a point is on curve and doing point multiplication / addition now can easily share the Montgomery form. This improves ecadd precompile performance by 6%.