### PR TITLE
crypto: Remove special case checks from point multiplication

### DIFF
--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -19,13 +19,6 @@ bool validate(const AffinePoint& pt) noexcept
 AffinePoint mul(const AffinePoint& pt, const uint256& c) noexcept
 {
     static constexpr auto B3 = Curve::Fp.to_mont(3 * 3);
-
-    if (pt == 0)
-        return pt;
-
-    if (c == 0)
-        return {};
-
     const auto pr = ecc::mul(pt, c, B3);
     return ecc::to_affine<Curve>(pr);
 }

--- a/lib/evmone_precompiles/secp256k1.cpp
+++ b/lib/evmone_precompiles/secp256k1.cpp
@@ -32,12 +32,6 @@ std::optional<uint256> calculate_y(
 
 AffinePoint mul(const AffinePoint& p, const uint256& c) noexcept
 {
-    if (p == 0)
-        return p;
-
-    if (c == 0)
-        return {};
-
     const auto r = ecc::mul(p, c, B3);
     return ecc::to_affine<Curve>(r);
 }


### PR DESCRIPTION
These are not needed as the computation will produce correct results.