### PR TITLE
crypto: Fix compiler warnings in SHA256 x86-sha

### DIFF
--- a/lib/evmone_precompiles/sha256.cpp
+++ b/lib/evmone_precompiles/sha256.cpp
@@ -251,8 +251,11 @@ __attribute__((target("bmi,bmi2"))) static void sha_256_x86_bmi(
     sha_256_implementation(h, input, len);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-conversion"
+[[gnu::always_inline]] static __m128i set(uint64_t a, uint64_t b) noexcept
+{
+    // NOLINTNEXTLINE(*-runtime-int)
+    return _mm_set_epi64x(static_cast<long long>(a), static_cast<long long>(b));
+}
 
 // The following function was adapted from
 // https://github.com/noloader/SHA-Intrinsics/blob/master/sha256-x86.c
@@ -270,7 +273,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
     __m128i ABEF_SAVE, CDGH_SAVE;
     // NOLINTEND(readability-isolate-declaration)
 
-    const __m128i MASK = _mm_set_epi64x(0x0c0d0e0f08090a0bULL, 0x0405060700010203ULL);
+    const __m128i MASK = set(0x0c0d0e0f08090a0b, 0x0405060700010203);
 
     // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast)
     // NOLINTBEGIN(portability-simd-intrinsics)
@@ -297,8 +300,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         /* Rounds 0-3 */
         MSG = _mm_loadu_si128((const __m128i*)(chunk + 0));
         MSG0 = _mm_shuffle_epi8(MSG, MASK);
-        MSG = _mm_add_epi32(
-            MSG0, _mm_set_epi64x(0xE9B5DBA5B5C0FBCFULL, 0x71374491428A2F98ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG0, set(0xE9B5DBA5B5C0FBCF, 0x71374491428A2F98));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         MSG = _mm_shuffle_epi32(MSG, 0x0E);
         STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
@@ -306,8 +308,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         /* Rounds 4-7 */
         MSG1 = _mm_loadu_si128((const __m128i*)(chunk + 16));
         MSG1 = _mm_shuffle_epi8(MSG1, MASK);
-        MSG = _mm_add_epi32(
-            MSG1, _mm_set_epi64x(0xAB1C5ED5923F82A4ULL, 0x59F111F13956C25BULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG1, set(0xAB1C5ED5923F82A4, 0x59F111F13956C25B));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         MSG = _mm_shuffle_epi32(MSG, 0x0E);
         STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
@@ -316,8 +317,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         /* Rounds 8-11 */
         MSG2 = _mm_loadu_si128((const __m128i*)(chunk + 32));
         MSG2 = _mm_shuffle_epi8(MSG2, MASK);
-        MSG = _mm_add_epi32(
-            MSG2, _mm_set_epi64x(0x550C7DC3243185BEULL, 0x12835B01D807AA98ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG2, set(0x550C7DC3243185BE, 0x12835B01D807AA98));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         MSG = _mm_shuffle_epi32(MSG, 0x0E);
         STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
@@ -326,8 +326,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         /* Rounds 12-15 */
         MSG3 = _mm_loadu_si128((const __m128i*)(chunk + 48));
         MSG3 = _mm_shuffle_epi8(MSG3, MASK);
-        MSG = _mm_add_epi32(
-            MSG3, _mm_set_epi64x(0xC19BF1749BDC06A7ULL, 0x80DEB1FE72BE5D74ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG3, set(0xC19BF1749BDC06A7, 0x80DEB1FE72BE5D74));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
         MSG0 = _mm_add_epi32(MSG0, TMP);
@@ -337,8 +336,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
 
         /* Rounds 16-19 */
-        MSG = _mm_add_epi32(
-            MSG0, _mm_set_epi64x(0x240CA1CC0FC19DC6ULL, 0xEFBE4786E49B69C1ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG0, set(0x240CA1CC0FC19DC6, 0xEFBE4786E49B69C1));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
         MSG1 = _mm_add_epi32(MSG1, TMP);
@@ -348,8 +346,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
 
         /* Rounds 20-23 */
-        MSG = _mm_add_epi32(
-            MSG1, _mm_set_epi64x(0x76F988DA5CB0A9DCULL, 0x4A7484AA2DE92C6FULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG1, set(0x76F988DA5CB0A9DC, 0x4A7484AA2DE92C6F));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
         MSG2 = _mm_add_epi32(MSG2, TMP);
@@ -359,8 +356,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
 
         /* Rounds 24-27 */
-        MSG = _mm_add_epi32(
-            MSG2, _mm_set_epi64x(0xBF597FC7B00327C8ULL, 0xA831C66D983E5152ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG2, set(0xBF597FC7B00327C8, 0xA831C66D983E5152));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
         MSG3 = _mm_add_epi32(MSG3, TMP);
@@ -370,8 +366,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
 
         /* Rounds 28-31 */
-        MSG = _mm_add_epi32(
-            MSG3, _mm_set_epi64x(0x1429296706CA6351ULL, 0xD5A79147C6E00BF3ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG3, set(0x1429296706CA6351, 0xD5A79147C6E00BF3));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
         MSG0 = _mm_add_epi32(MSG0, TMP);
@@ -381,8 +376,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
 
         /* Rounds 32-35 */
-        MSG = _mm_add_epi32(
-            MSG0, _mm_set_epi64x(0x53380D134D2C6DFCULL, 0x2E1B213827B70A85ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG0, set(0x53380D134D2C6DFC, 0x2E1B213827B70A85));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
         MSG1 = _mm_add_epi32(MSG1, TMP);
@@ -392,8 +386,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
 
         /* Rounds 36-39 */
-        MSG = _mm_add_epi32(
-            MSG1, _mm_set_epi64x(0x92722C8581C2C92EULL, 0x766A0ABB650A7354ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG1, set(0x92722C8581C2C92E, 0x766A0ABB650A7354));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
         MSG2 = _mm_add_epi32(MSG2, TMP);
@@ -403,8 +396,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
 
         /* Rounds 40-43 */
-        MSG = _mm_add_epi32(
-            MSG2, _mm_set_epi64x(0xC76C51A3C24B8B70ULL, 0xA81A664BA2BFE8A1ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG2, set(0xC76C51A3C24B8B70, 0xA81A664BA2BFE8A1));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
         MSG3 = _mm_add_epi32(MSG3, TMP);
@@ -414,8 +406,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
 
         /* Rounds 44-47 */
-        MSG = _mm_add_epi32(
-            MSG3, _mm_set_epi64x(0x106AA070F40E3585ULL, 0xD6990624D192E819ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG3, set(0x106AA070F40E3585, 0xD6990624D192E819));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
         MSG0 = _mm_add_epi32(MSG0, TMP);
@@ -425,8 +416,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
 
         /* Rounds 48-51 */
-        MSG = _mm_add_epi32(
-            MSG0, _mm_set_epi64x(0x34B0BCB52748774CULL, 0x1E376C0819A4C116ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG0, set(0x34B0BCB52748774C, 0x1E376C0819A4C116));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
         MSG1 = _mm_add_epi32(MSG1, TMP);
@@ -436,8 +426,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
 
         /* Rounds 52-55 */
-        MSG = _mm_add_epi32(
-            MSG1, _mm_set_epi64x(0x682E6FF35B9CCA4FULL, 0x4ED8AA4A391C0CB3ULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG1, set(0x682E6FF35B9CCA4F, 0x4ED8AA4A391C0CB3));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
         MSG2 = _mm_add_epi32(MSG2, TMP);
@@ -446,8 +435,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
 
         /* Rounds 56-59 */
-        MSG = _mm_add_epi32(
-            MSG2, _mm_set_epi64x(0x8CC7020884C87814ULL, 0x78A5636F748F82EEULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG2, set(0x8CC7020884C87814, 0x78A5636F748F82EE));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
         MSG3 = _mm_add_epi32(MSG3, TMP);
@@ -456,8 +444,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
         STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
 
         /* Rounds 60-63 */
-        MSG = _mm_add_epi32(
-            MSG3, _mm_set_epi64x(0xC67178F2BEF9A3F7ULL, 0xA4506CEB90BEFFFAULL));  // NOLINT
+        MSG = _mm_add_epi32(MSG3, set(0xC67178F2BEF9A3F7, 0xA4506CEB90BEFFFA));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
         MSG = _mm_shuffle_epi32(MSG, 0x0E);
         STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
@@ -478,8 +465,6 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(
     // NOLINTEND(portability-simd-intrinsics)
     // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast)
 }
-
-#pragma GCC diagnostic pop
 
 // https://stackoverflow.com/questions/6121792/how-to-check-if-a-cpu-supports-the-sse3-instruction-set
 static void cpuid(int info[4], int InfoType)  // NOLINT(readability-non-const-parameter)


### PR DESCRIPTION
Fix compiler warnings, clang-tidy warnings and UBSan in the code of SHA256 x86 with sha extension implementation related to setting constant values in vector registers.