### PR TITLE
crypto: Fix handling of the input point-at-infinity in secp256r1

### DIFF
--- a/lib/evmone_precompiles/secp256r1.cpp
+++ b/lib/evmone_precompiles/secp256r1.cpp
@@ -27,11 +27,14 @@ bool verify(const ethash::hash256& h, const uint256& r, const uint256& s, const 
     if (r == 0 || r >= Curve::ORDER || s == 0 || s >= Curve::ORDER)
         return false;
 
-    if (qx == 0 || qx >= Curve::FIELD_PRIME || qy == 0 || qy >= Curve::FIELD_PRIME)
+    // Check that Q is not equal to the identity element O, and its coordinates are otherwise valid.
+    if (qx >= Curve::FIELD_PRIME || qy >= Curve::FIELD_PRIME)
+        return false;
+    const AffinePoint Q{AffinePoint::FE{qx}, AffinePoint::FE{qy}};
+    if (Q == 0)
         return false;
 
-    const AffinePoint Q{AffinePoint::FE{qx}, AffinePoint::FE{qy}};
-
+    // Check that Q lies on the curve.
     if (!is_on_curve(Q))
         return false;
 

--- a/test/unittests/precompiles_secp256r1_test.cpp
+++ b/test/unittests/precompiles_secp256r1_test.cpp
@@ -27,6 +27,14 @@ const P256VerifyInput VALID_INPUTS[]{
         0x2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838_u256,
         0xc7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e_u256,
     },
+    {
+        // Valid public key with 0 x-coordinate.
+        0xc3d3be9eb3577f217ae0ab360529a30b18adc751aec886328593d7d6fe042809_u256,
+        0x3a4e97b44cbf88b90e6205a45ba957e520f63f3c6072b53c244653278a1819d8_u256,
+        0x6a184aa037688a5ebd25081fd2c0b10bb64fa558b671bd81955ca86e09d9d722_u256,
+        0,
+        0x66485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4_u256,
+    },
 };
 
 const P256VerifyInput INVALID_INPUTS[]{


### PR DESCRIPTION
Fix handling of the input public key being the point-at-infinity. Previosly, the implementation rejected also valid points with x-coordinate being 0.