### PR TITLE
tests: Support EIP-7934 - MAX_RLP_BLOCK_SIZE

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -407,7 +407,7 @@ jobs:
           command: >
             LLVM_PROFILE_FILE=blockchain_tests.profraw
             bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
-            --gtest_filter='-osaka/eip7918_blob_reserve_price.*:osaka/eip7934_block_rlp_limit.*'
+            --gtest_filter='-osaka/eip7918_blob_reserve_price.*'
       - collect_coverage_clang:
           ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(blockchaintest|experimental|statetest|t8n|unittests|utils)
       - upload_coverage:

--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -48,6 +48,7 @@ struct TestBlock
 {
     state::BlockInfo block_info;
     std::vector<state::Transaction> transactions;
+    size_t rlp_size = 0;
     bool withdrawals_parse_success = true;
     bool valid = true;
 

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -156,10 +156,15 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
 
             auto test_block = load_test_block(el.at("rlp_decoded"), bt.rev);
             test_block.valid = false;
+            test_block.rlp_size = from_json<bytes>(el.at("rlp")).size();
             bt.test_blocks.emplace_back(test_block);
         }
         else
-            bt.test_blocks.emplace_back(load_test_block(el, bt.rev));
+        {
+            auto test_block = load_test_block(el, bt.rev);
+            test_block.rlp_size = from_json<bytes>(el.at("rlp")).size();
+            bt.test_blocks.emplace_back(test_block);
+        }
     }
 
     bt.expectation.last_block_hash = from_json<hash256>(j.at("lastblockhash"));

--- a/test/unittests/blockchaintest_loader_test.cpp
+++ b/test/unittests/blockchaintest_loader_test.cpp
@@ -12,6 +12,7 @@ using namespace testing;
 
 TEST(json_loader, blockchain_test)
 {
+    // NOTE: fake `rlp` field! Never decoded by loader, only size is read and checked.
     std::istringstream input{R"({
         "000-fork=Shanghai-fill_stack": {
             "blocks": [
@@ -75,7 +76,8 @@ TEST(json_loader, blockchain_test)
                         "amount" : "0x0186a0",
                         "index" : "0x00",
                         "validatorIndex" : "0x00"
-                    }]
+                    }],
+                    "rlp": "0x00ff00ff00ff"
                 }
             ],
             "genesisBlockHeader": {
@@ -164,6 +166,7 @@ TEST(json_loader, blockchain_test)
 
 TEST(json_loader, blockchain_test_post_state_hash)
 {
+    // NOTE: fake `rlp` field! Never decoded by loader, only size is read and checked.
     std::istringstream input{R"({
         "000-fork=Shanghai-fill_stack": {
             "blocks": [
@@ -205,7 +208,8 @@ TEST(json_loader, blockchain_test_post_state_hash)
                         }
                     ],
                     "uncleHeaders": [],
-                    "withdrawals": []
+                    "withdrawals": [],
+                    "rlp": "0x00ff00ff00ff"
                 }
             ],
             "genesisBlockHeader": {
@@ -272,6 +276,7 @@ TEST(json_loader, blockchain_test_post_state_hash)
 
 TEST(json_loader, blockchain_test_pre_paris)
 {
+    // NOTE: fake `rlp` field! Never decoded by loader, only size is read and checked.
     std::istringstream input{R"({
         "000-fork=Shanghai-fill_stack": {
             "blocks": [
@@ -313,7 +318,8 @@ TEST(json_loader, blockchain_test_pre_paris)
                         }
                     ],
                     "uncleHeaders": [],
-                    "withdrawals": []
+                    "withdrawals": [],
+                    "rlp": "0x00ff00ff00ff"
                 }
             ],
             "genesisBlockHeader": {


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-7934

Since `evmone` doesn't decode RLP blocks, but always uses `rlp_decoded`, the `rlp` bytes are not managed, just the size used for the limit check.