### PR TITLE
Optimize ecrecover with the field endomorphism and shamir trick.

### DIFF
--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -572,44 +572,39 @@ inline ProjPoint<Curve> shamir_multiply(const typename Curve::uint_type& u1,
     if (bit_width == 0)
         return r;
 
-    const auto jp1 = ProjPoint{p1};
-    const auto jp2 = ProjPoint{p2};
-    const auto jp3 = ProjPoint{p3};
-    const auto jp4 = ProjPoint{p4};
+    const auto jp1p2 = add(p1, p2);
+    const auto jp1p3 = add(p1, p3);
+    const auto jp1p4 = add(p1, p4);
+    const auto jp2p3 = add(p2, p3);
+    const auto jp2p4 = add(p2, p4);
+    const auto jp3p4 = add(p3, p4);
 
-    const auto p1p2 = add(p1, p2);
-    const auto p1p3 = add(p1, p3);
-    const auto p1p4 = add(p1, p4);
-    const auto p2p3 = add(p2, p3);
-    const auto p2p4 = add(p2, p4);
-    const auto p3p4 = add(p3, p4);
+    const auto jp1p2p3 = add(jp1p2, p3);
+    const auto jp1p2p4 = add(jp1p2, p4);
 
-    const auto p1p2p3 = add(p1p2, p3);
-    const auto p1p2p4 = add(p1p2, p4);
+    const auto jp1p3p4 = add(jp1p3, p4);
 
-    const auto p1p3p4 = add(p1p3, p4);
+    const auto jp2p3p4 = add(jp2p3, p4);
 
-    const auto p2p3p4 = add(p2p3, p4);
+    const auto jp1p2p3p4 = add(jp1p2, jp3p4);
 
-    const auto p1p2p3p4 = add(p1p2, p3p4);
-
-    const ProjPoint<Curve> points[]{
-        ProjPoint<Curve>{},
-        jp1,       // 0001
-        jp2,       // 0010
-        p1p2,      // 0011
-        jp3,       // 0100
-        p1p3,      // 0101
-        p2p3,      // 0110
-        p1p2p3,    // 0111
-        jp4,       // 1000
-        p1p4,      // 1001
-        p2p4,      // 1010
-        p1p2p4,    // 1011
-        p3p4,      // 1100
-        p1p3p4,    // 1101
-        p2p3p4,    // 1110
-        p1p2p3p4,  // 1111
+    const AffinePoint<Curve> points[]{
+        AffinePoint<Curve>{},
+        p1,                    // 0001
+        p2,                    // 0010
+        to_affine(jp1p2),      // 0011
+        p3,                    // 0100
+        to_affine(jp1p3),      // 0101
+        to_affine(jp2p3),      // 0110
+        to_affine(jp1p2p3),    // 0111
+        p4,                    // 1000
+        to_affine(jp1p4),      // 1001
+        to_affine(jp2p4),      // 1010
+        to_affine(jp1p2p4),    // 1011
+        to_affine(jp3p4),      // 1100
+        to_affine(jp1p3p4),    // 1101
+        to_affine(jp2p3p4),    // 1110
+        to_affine(jp1p2p3p4),  // 1111
     };
 
     for (auto i = bit_width; i != 0; --i)

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -311,7 +311,7 @@ ProjPoint<Curve> add(const ProjPoint<Curve>& p, const ProjPoint<Curve>& q) noexc
     // Handle point doubling in case p == q, i.e. when u1 == u2 and s1 == s2.
     // TODO: Untested case of two points having the same y coordinate but different x.
     //       The following assertion (r == 0) => (h == 0) should fail in that case.
-    assert(r != 0 || h == 0);
+    // assert(r != 0 || h == 0);
     if (h == 0 && r == 0) [[unlikely]]
         return dbl(p);
 
@@ -529,12 +529,16 @@ inline ProjPoint<Curve> shamir_multiply(const typename Curve::uint_type& u1,
     if (bit_width == 0)
         return r;
 
-    const auto p1p2 = add(p1, p2);
-    const auto p1p3 = add(p1, p3);
-    const auto p1p4 = add(p1, p4);
-    const auto p2p3 = add(p2, p3);
-    const auto p2p4 = add(p2, p4);
-    const auto p3p4 = add(p3, p4);
+    const auto jp1 = ProjPoint{p1};
+    const auto jp2 = ProjPoint{p2};
+    const auto jp3 = ProjPoint{p3};
+    const auto jp4 = ProjPoint{p4};
+    const auto p1p2 = add(jp1, p2);
+    const auto p1p3 = add(jp1, p3);
+    const auto p1p4 = add(jp1, p4);
+    const auto p2p3 = add(jp2, p3);
+    const auto p2p4 = add(jp2, p4);
+    const auto p3p4 = add(jp3, p4);
 
     const auto p1p2p3 = add(p1p2, p3);
     const auto p1p2p4 = add(p1p2, p4);
@@ -545,16 +549,16 @@ inline ProjPoint<Curve> shamir_multiply(const typename Curve::uint_type& u1,
 
     const auto p1p2p3p4 = add(p1p2, p3p4);
 
-    const AffinePoint<Curve>* const points[]{
+    const ProjPoint<Curve>* const points[]{
         nullptr,
-        &p1,        // 0001
-        &p2,        // 0010
+        &jp1,        // 0001
+        &jp2,        // 0010
         &p1p2,      // 0011
-        &p3,        // 0100
+        &jp3,        // 0100
         &p1p3,      // 0101
         &p2p3,      // 0110
         &p1p2p3,    // 0111
-        &p4,        // 1000
+        &jp4,        // 1000
         &p1p4,      // 1001
         &p2p4,      // 1010
         &p1p2p4,    // 1011

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -621,8 +621,6 @@ inline ProjPoint<Curve> shamir_multiply(const typename Curve::uint_type& u1,
         const auto u3_bit = bit_test(u3, i - 1);
         const auto u4_bit = bit_test(u4, i - 1);
         const auto idx = u1_bit | (u2_bit << 1) | (u3_bit << 2) | (u4_bit << 3);
-        if (idx == 0)
-            continue;
         r = add(r, points[idx]);
     }
 

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -576,12 +576,13 @@ inline ProjPoint<Curve> shamir_multiply(const typename Curve::uint_type& u1,
     const auto jp2 = ProjPoint{p2};
     const auto jp3 = ProjPoint{p3};
     const auto jp4 = ProjPoint{p4};
-    const auto p1p2 = add(jp1, p2);
-    const auto p1p3 = add(jp1, p3);
-    const auto p1p4 = add(jp1, p4);
-    const auto p2p3 = add(jp2, p3);
-    const auto p2p4 = add(jp2, p4);
-    const auto p3p4 = add(jp3, p4);
+
+    const auto p1p2 = add(p1, p2);
+    const auto p1p3 = add(p1, p3);
+    const auto p1p4 = add(p1, p4);
+    const auto p2p3 = add(p2, p3);
+    const auto p2p4 = add(p2, p4);
+    const auto p3p4 = add(p3, p4);
 
     const auto p1p2p3 = add(p1p2, p3);
     const auto p1p2p4 = add(p1p2, p4);

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -695,10 +695,10 @@ std::array<SignedScalar<typename Curve::uint_type>, 2> decompose(
     // static_assert(Curve::Y2 < Curve::X1);
     // static_assert(Curve::X2 < Curve::Y2);
     // static_assert(Curve::MINUS_Y1 < Curve::X2);
-    // [[maybe_unused]] static constexpr auto K1_MAX = Curve::Y2;
-    // [[maybe_unused]] static constexpr auto K2_MAX = Curve::X2 - 1;
-    // assert(k1.value <= K1_MAX);
-    // assert(k2.value <= K2_MAX);
+    [[maybe_unused]] static constexpr auto K1_MAX = std::numeric_limits<intx::uint128>::max();
+    [[maybe_unused]] static constexpr auto K2_MAX = K1_MAX;
+    assert(k1.value <= K1_MAX);
+    assert(k2.value <= K2_MAX);
 
     return {k1, k2};
 }

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -625,6 +625,16 @@ std::array<SignedScalar<typename Curve::uint_type>, 2> decompose(
     const SignedScalar k1{k1_is_neg, k1_abs};
     const SignedScalar k2{k2_is_neg, k2_abs};
     assert(verify_scalar_decomposition<Curve>(k, k1, k2));
+
+    // FIXME: Bounds for fuzzing, remove.
+    // static_assert(Curve::Y2 < Curve::X1);
+    // static_assert(Curve::X2 < Curve::Y2);
+    // static_assert(Curve::MINUS_Y1 < Curve::X2);
+    // [[maybe_unused]] static constexpr auto K1_MAX = Curve::Y2;
+    // [[maybe_unused]] static constexpr auto K2_MAX = Curve::X2 - 1;
+    // assert(k1.value <= K1_MAX);
+    // assert(k2.value <= K2_MAX);
+
     return {k1, k2};
 }
 

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -389,7 +389,7 @@ ProjPoint<Curve> add(const AffinePoint<Curve>& p, const AffinePoint<Curve>& q) n
 {
     if (q == 0)
         // TODO: Untested and untestable via precompile call (for secp256r1).
-            return ProjPoint(p);
+        return ProjPoint(p);
     if (p == 0)
         return ProjPoint(q);
 
@@ -593,23 +593,23 @@ inline ProjPoint<Curve> shamir_multiply(const typename Curve::uint_type& u1,
 
     const auto p1p2p3p4 = add(p1p2, p3p4);
 
-    const ProjPoint<Curve>* const points[]{
-        nullptr,
-        &jp1,        // 0001
-        &jp2,        // 0010
-        &p1p2,      // 0011
-        &jp3,        // 0100
-        &p1p3,      // 0101
-        &p2p3,      // 0110
-        &p1p2p3,    // 0111
-        &jp4,        // 1000
-        &p1p4,      // 1001
-        &p2p4,      // 1010
-        &p1p2p4,    // 1011
-        &p3p4,      // 1100
-        &p1p3p4,    // 1101
-        &p2p3p4,    // 1110
-        &p1p2p3p4,  // 1111
+    const ProjPoint<Curve> points[]{
+        ProjPoint<Curve>{},
+        jp1,       // 0001
+        jp2,       // 0010
+        p1p2,      // 0011
+        jp3,       // 0100
+        p1p3,      // 0101
+        p2p3,      // 0110
+        p1p2p3,    // 0111
+        jp4,       // 1000
+        p1p4,      // 1001
+        p2p4,      // 1010
+        p1p2p4,    // 1011
+        p3p4,      // 1100
+        p1p3p4,    // 1101
+        p2p3p4,    // 1110
+        p1p2p3p4,  // 1111
     };
 
     for (auto i = bit_width; i != 0; --i)
@@ -623,7 +623,7 @@ inline ProjPoint<Curve> shamir_multiply(const typename Curve::uint_type& u1,
         const auto idx = u1_bit | (u2_bit << 1) | (u3_bit << 2) | (u4_bit << 3);
         if (idx == 0)
             continue;
-        r = add(r, *points[idx]);
+        r = add(r, points[idx]);
     }
 
     return r;

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -401,27 +401,27 @@ ProjPoint<Curve> add(const AffinePoint<Curve>& p, const AffinePoint<Curve>& q) n
     const auto& [x2, y2] = q;
 
     const auto h = x2 - x1;
-    const auto t1 = h + h;
-    const auto i = t1 * t1;
+    const auto h2 = h + h;
+    const auto i = h2 * h2;
     const auto j = h * i;
-    const auto t2 = y2 - y1;
+    const auto t0 = y2 - y1;
 
     // Handle point doubling in case p == q.
     // p == q if and only if x1 == x2 and y1 = y2
-    if (h == 0 && t2 == 0) [[unlikely]]
+    if (h == 0 && t0 == 0) [[unlikely]]
         return dbl(ProjPoint(p));
 
-    const auto r = t2 + t2;
+    const auto r = t0 + t0;
     const auto v = x1 * i;
-    const auto t3 = r * r;
-    const auto t4 = v + v;
-    const auto t5 = t3 - j;
-    const auto x3 = t5 - t4;
-    const auto t6 = v - x3;
-    const auto t7 = y1 * j;
-    const auto t8 = t7 + t7;
-    const auto t9 = r * t6;
-    const auto y3 = t9 - t8;
+    const auto t1 = r * r;
+    const auto t2 = v + v;
+    const auto t3 = t1 - j;
+    const auto x3 = t3 - t2;
+    const auto t4 = v - x3;
+    const auto t5 = y1 * j;
+    const auto t6 = t5 + t5;
+    const auto t7 = r * t4;
+    const auto y3 = t7 - t6;
     const auto z3 = h + h;
 
     return {x3, y3, z3};

--- a/lib/evmone_precompiles/secp256k1.cpp
+++ b/lib/evmone_precompiles/secp256k1.cpp
@@ -57,6 +57,8 @@ std::optional<AffinePoint> secp256k1_ecdsa_recover(std::span<const uint8_t, 32> 
     if (r == 0 || r >= Curve::ORDER || s == 0 || s >= Curve::ORDER) [[unlikely]]
         return std::nullopt;
 
+    // static_assert(Curve::BETA.value() == 0x851695D49A83F8F47C65C9F7A2F5D6C71AE3A4617C510EA45F0E1E4A1E6D8B63_u256);
+
     // 3. Hash of the message is already calculated in e.
     // 4. Convert hash e to z field element by doing z = e % n.
     //    https://www.rfc-editor.org/rfc/rfc6979#section-2.3.2
@@ -85,8 +87,20 @@ std::optional<AffinePoint> secp256k1_ecdsa_recover(std::span<const uint8_t, 32> 
         return std::nullopt;
 
     // 6. Calculate public key point Q = u1×G + u2×R.
-    const auto R = AffinePoint{r_mont, *y};
-    const auto Q = msm(u1, G, u2, R);
+    const auto R = AffinePoint{r_mont, *y_mont};
+
+    // u1 and u2 are less than `Curve::ORDER`, so the multiplications will not reduce.
+    const auto [u1k1, u1k2] = ecc::decompose<Curve>(u1);
+    const auto [u2k1, u2k2] = ecc::decompose<Curve>(u2);
+
+    const auto LG = AffinePoint{Curve::BETA * G.x, !u1k2.sign ? G.y : -G.y};
+    const auto LR = AffinePoint{Curve::BETA * R.x, !u2k2.sign ? R.y : -R.y};
+
+    const auto T1 = msm(u1k1.value, !u1k1.sign ? G : AffinePoint{G.x, -G.y}, u1k2.value, LG);
+    const auto T2 = msm(u2k1.value, !u2k1.sign ? R : AffinePoint{R.x, -R.y}, u2k2.value, LR);
+    assert(T2 != 0);  // Because u2 != 0 and R != 0.
+
+    const auto Q = ecc::add(T1, T2);
 
     // The public key mustn't be the point at infinity. This check is cheaper on a non-affine point.
     if (Q == 0) [[unlikely]]

--- a/lib/evmone_precompiles/secp256k1.cpp
+++ b/lib/evmone_precompiles/secp256k1.cpp
@@ -88,7 +88,7 @@ std::optional<AffinePoint> secp256k1_ecdsa_recover(std::span<const uint8_t, 32> 
         return std::nullopt;
 
     // 6. Calculate public key point Q = u1×G + u2×R.
-    const auto R = AffinePoint{r_mont, *y_mont};
+    const auto R = AffinePoint{r_mont, *y};
 
     // u1 and u2 are less than `Curve::ORDER`, so the multiplications will not reduce.
     const auto [u1k1, u1k2] = ecc::decompose<Curve>(u1);

--- a/lib/evmone_precompiles/secp256k1.hpp
+++ b/lib/evmone_precompiles/secp256k1.hpp
@@ -27,6 +27,14 @@ struct Curve
     static constexpr ModArith Fp{FIELD_PRIME};
 
     static constexpr auto A = 0;
+
+    static constexpr auto LAMBDA = 0x5363ad4cc05c30e0a5261c028812645a122e22ea20816678df02967c1b23bd72_u256;
+    static constexpr auto X1 = 64502973549206556628585045361533709077_u256;
+    static constexpr auto MINUS_Y1 = 303414439467246543595250775667605759171_u256;
+    static constexpr auto X2 = 367917413016453100223835821029139468248_u256;
+    static constexpr auto Y2 = 64502973549206556628585045361533709077_u256;
+    static constexpr auto BETA = ecc::FieldElement<Curve>::wrap(
+        55313291615161283318657529331139468956476901535073802794763309073431015819598_u256);
 };
 
 using AffinePoint = ecc::AffinePoint<Curve>;


### PR DESCRIPTION
- ecrecover is optimized using curve endomorphism
- Based on [Faster Point Multiplication on Elliptic Curves
with Efficient Endomorphisms](https://www.iacr.org/archive/crypto2001/21390189.pdf)
- v1 and v2 vectors taken from [Implementation of PSEC-KEM (secp256r1 and secp256k1) on
Hardware and Software Platforms](https://cse.iitkgp.ac.in/~debdeep/osscrypto/psec/downloads/PSEC-KEM_prime.pdf)

Depends on: https://github.com/ipsilon/evmone/pull/1390

Before:
```
(vvenv) rodia@MacBook-Pro-2 evmone % ./build/bin/evmone-precompiles-bench --benchmark_filter=ecrecover
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
This does not affect benchmark measurements, only the metadata output.
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2025-12-02T15:19:01+01:00
Running ./build/bin/evmone-precompiles-bench
Run on (12 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x12)
Load Average: 3.56, 2.97, 2.78
----------------------------------------------------------------------------------------------------------
Benchmark                                                Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------------
precompile<PrecompileId::ecrecover, evmmax_cpp>     106896 ns       106887 ns         6520 gas_rate=28.067M/s gas_used=30k
```

After:
```
(vvenv) rodia@MacBook-Pro-2 evmone % ./build/bin/evmone-precompiles-bench --benchmark_filter=ecrecover
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
This does not affect benchmark measurements, only the metadata output.
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2025-12-02T15:34:58+01:00
Running ./build/bin/evmone-precompiles-bench
Run on (12 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x12)
Load Average: 1.50, 2.15, 2.37
----------------------------------------------------------------------------------------------------------
Benchmark                                                Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------------
precompile<PrecompileId::ecrecover, evmmax_cpp>      82527 ns        82527 ns         8470 gas_rate=36.3516M/s gas_used=30k
```