### PR TITLE
crypto: Implement wNAF MSM in ECC

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
     baseline_analysis_test.cpp
     blockchaintest_loader_test.cpp
     bytecode_test.cpp
+    crypto_wnaf.cpp
     evm_fixture.cpp
     evm_fixture.hpp
     evm_test.cpp

--- a/test/unittests/crypto_wnaf.cpp
+++ b/test/unittests/crypto_wnaf.cpp
@@ -1,0 +1,116 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <evmone_precompiles/ecc.hpp>
+#include <gtest/gtest.h>
+#include <intx/intx.hpp>
+#include <random>
+
+using namespace evmmax::ecc;
+
+namespace
+{
+template <typename UIntT>
+UIntT evaluate(NAF<UIntT> naf)
+{
+    UIntT result = 0;
+    UIntT base = 1;
+    for (size_t i = 0; i < naf.width(); ++i)
+    {
+        const auto d = naf[i];
+        const auto d_abs = static_cast<unsigned>(std::abs(d));
+        const auto d_sign = d < 0;
+        const auto r_abs = UIntT{d_abs};
+        const auto r = d_sign ? -r_abs : r_abs;
+        result += r * base;
+        base <<= 1;
+    }
+
+    if (naf.width() == 0)
+    {
+        // NAF == 0 <=> result == 0.
+        EXPECT_EQ(result, 0);
+    }
+    else
+    {
+        // The most significant digit must be non-zero.
+        EXPECT_NE(naf[naf.width() - 1], 0);
+    }
+    return result;
+}
+}  // namespace
+
+TEST(crypto_wnaf, example1)
+{
+    const auto naf = to_wnaf<3>(uint32_t{21});
+    EXPECT_EQ(naf.width(), 4u);
+    EXPECT_EQ(naf[0], -3);
+    EXPECT_EQ(naf[1], 0);
+    EXPECT_EQ(naf[2], 0);
+    EXPECT_EQ(naf[3], 3);
+    EXPECT_EQ(naf[4], 0);
+    EXPECT_EQ(evaluate(naf), 21u);
+}
+
+TEST(crypto_wnaf, zero)
+{
+    const auto naf = to_wnaf<7>(uint64_t{0});
+    EXPECT_EQ(naf.width(), 0);
+    for (size_t i = 0; i <= 32; ++i)
+        EXPECT_EQ(naf[i], 0);
+    EXPECT_EQ(evaluate(naf), 0);
+}
+
+TEST(crypto_wnaf, max_width)
+{
+    const auto x = uint32_t{0xfffffffe};
+    const auto naf = to_wnaf<4>(x);
+    EXPECT_EQ(naf.width(), 33u);
+    EXPECT_EQ(naf[0], 0);
+    EXPECT_EQ(naf[1], -1);
+    for (size_t i = 2; i <= 31; ++i)
+        EXPECT_EQ(naf[i], 0);
+    EXPECT_EQ(naf[32], 1);
+    EXPECT_EQ(evaluate(naf), x);
+}
+
+TEST(crypto_wnaf, max_digit)
+{
+    const auto x = uint32_t{0xfffffcfe};
+    const auto naf = to_wnaf<8>(x);
+    EXPECT_EQ(naf.width(), 33u);
+    EXPECT_EQ(naf[1], 127);
+    EXPECT_EQ(evaluate(naf), x);
+}
+
+TEST(crypto_wnaf, min_digit)
+{
+    const auto x = uint32_t{0x102};
+    const auto naf = to_wnaf<8>(x);
+    EXPECT_EQ(naf.width(), 10u);
+    EXPECT_EQ(naf[1], -127);
+    EXPECT_EQ(evaluate(naf), x);
+}
+
+TEST(crypto_wnaf, uint256_fuzz)
+{
+    std::mt19937_64 rng{std::random_device{}()};
+    std::uniform_int_distribution<uint64_t> dist{};
+    const intx::uint256 start{dist(rng), dist(rng), dist(rng), dist(rng)};
+
+    for (size_t i = 0; i < 100; ++i)
+    {
+        const auto x = start + i;
+        const auto naf2 = to_wnaf<2>(x);
+        ASSERT_EQ(evaluate(naf2), x);
+        const auto naf3 = to_wnaf<3>(x);
+        ASSERT_EQ(evaluate(naf3), x);
+        const auto naf4 = to_wnaf<4>(x);
+        ASSERT_EQ(evaluate(naf4), x);
+        const auto naf5 = to_wnaf<5>(x);
+        ASSERT_EQ(evaluate(naf5), x);
+        const auto naf8 = to_wnaf<8>(x);
+        ASSERT_EQ(evaluate(naf8), x);
+    }
+}


### PR DESCRIPTION
- Replace Straus-Shamir MSM with windowed NAF (sliding window) method.
- Set conservative initial windows size w=4.
- Add NAF helper class, wNAF recoding, and shared MSM utility.
- Cover NAF encoding/decoding with new crypto_wnaf unit tests.

### Benchmark results

```
                                                    │   o/ec.txt   │           o/ec-wnaf-4.txt            │
                                                    │    sec/op    │    sec/op     vs base                │
precompile<PrecompileId::ecrecover,_evmmax_cpp>-14    126.3µ ±  0%   111.0µ ±  0%  -12.13% (p=0.001 n=11)
precompile<PrecompileId::ecmul,_evmmax_cpp>-14        53.91µ ±  0%   46.83µ ±  0%  -13.13% (p=0.000 n=11)
precompile<PrecompileId::p256verify,_evmone_cpp>-14   124.4µ ± 90%   107.2µ ± 90%  -13.83% (p=0.028 n=11)
geomean                                               94.61µ         82.28µ        -13.03%

                                                    │  o/ec.txt   │           o/ec-wnaf-4.txt            │
                                                    │   gas/op    │   gas/op     vs base                 │
precompile<PrecompileId::ecrecover,_evmmax_cpp>-14    30.00k ± 0%   30.00k ± 0%       ~ (p=1.000 n=11) ¹
precompile<PrecompileId::ecmul,_evmmax_cpp>-14        60.00k ± 0%   60.00k ± 0%       ~ (p=1.000 n=11) ¹
precompile<PrecompileId::p256verify,_evmone_cpp>-14   69.00k ± 0%   69.00k ± 0%       ~ (p=1.000 n=11) ¹
geomean                                               49.89k        49.89k       +0.00%
¹ all samples are equal

                                                    │  o/ec.txt   │           o/ec-wnaf-4.txt           │
                                                    │    gas/s    │    gas/s     vs base                │
precompile<PrecompileId::ecrecover,_evmmax_cpp>-14    23.75M ± 0%   27.04M ± 0%  +13.86% (p=0.000 n=11)
precompile<PrecompileId::ecmul,_evmmax_cpp>-14        111.3M ± 0%   128.1M ± 1%  +15.09% (p=0.000 n=11)
precompile<PrecompileId::p256verify,_evmone_cpp>-14   55.39M ± 0%   64.30M ± 0%  +16.09% (p=0.000 n=11)
geomean                                               52.71M        60.62M       +15.01%

                                                    │   o/ec.txt   │           o/ec-wnaf-4.txt           │
                                                    │  cycles/op   │  cycles/op   vs base                │
precompile<PrecompileId::ecrecover,_evmmax_cpp>-14    503.5k ±  1%   441.4k ± 0%  -12.33% (p=0.000 n=11)
precompile<PrecompileId::ecmul,_evmmax_cpp>-14        214.9k ±  0%   186.5k ± 0%  -13.22% (p=0.000 n=11)
precompile<PrecompileId::p256verify,_evmone_cpp>-14   495.8k ± 90%   427.4k ± 0%  -13.79% (p=0.010 n=11)
geomean                                               377.1k         327.7k       -13.11%

                                                    │    o/ec.txt     │             o/ec-wnaf-4.txt             │
                                                    │ instructions/op │ instructions/op  vs base                │
precompile<PrecompileId::ecrecover,_evmmax_cpp>-14        1.537M ± 0%       1.382M ± 0%  -10.12% (p=0.000 n=11)
precompile<PrecompileId::ecmul,_evmmax_cpp>-14            737.5k ± 0%       663.6k ± 0%  -10.03% (p=0.000 n=11)
precompile<PrecompileId::p256verify,_evmone_cpp>-14       1.552M ± 0%       1.386M ± 0%  -10.74% (p=0.000 n=11)
geomean                                                   1.207M            1.083M       -10.29%
```