### PR TITLE
ci: Don't run legacy state tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -442,23 +442,6 @@ jobs:
       - download_execution_tests:
           rev: v17.2
       - run:
-          name: "State tests"
-          working_directory: ~/build
-          environment:
-            # Filter out long-running and incorrect tests.
-            GTEST_FILTER: "-stCreateTest.CreateOOGafterMaxCodesize:\
-            stQuadraticComplexityTest.Call50000_sha256:\
-            stTimeConsuming.*:\
-            VMTests/vmPerformance.*:\
-            stExample.*:\
-            stTransactionTest.*"
-          command: >
-            LLVM_PROFILE_FILE=state_tests.profraw
-            bin/evmone-statetest
-            --gtest_filter=$GTEST_FILTER
-            ~/tests/LegacyTests/Cancun/GeneralStateTests
-            ~/tests/LegacyTests/Constantinople/GeneralStateTests
-      - run:
           name: "Blockchain tests (ValidBlocks)"
           working_directory: ~/build
           command: >


### PR DESCRIPTION
Don't run legacy state tests because we later want to use some new JSON test features available only in EEST files.

The lost coverage is minimal and also covered by internal unit tests.