### PR TITLE
ci: set LLVM_PROFILE_FILE per run in ethereum-tests job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -453,6 +453,7 @@ jobs:
             stExample.*:\
             stTransactionTest.*"
           command: >
+            LLVM_PROFILE_FILE=state_tests.profraw
             bin/evmone-statetest
             --gtest_filter=$GTEST_FILTER
             ~/tests/LegacyTests/Cancun/GeneralStateTests
@@ -461,6 +462,7 @@ jobs:
           name: "Blockchain tests (ValidBlocks)"
           working_directory: ~/build
           command: >
+            LLVM_PROFILE_FILE=blockchain_tests_valid.profraw
             bin/evmone-blockchaintest
             --gtest_filter='-bcValidBlockTest.SimpleTx3LowS'
             ~/tests/BlockchainTests/ValidBlocks
@@ -469,6 +471,7 @@ jobs:
           name: "Blockchain tests (InvalidBlocks)"
           working_directory: ~/build
           command: >
+            LLVM_PROFILE_FILE=blockchain_tests_invalid.profraw
             bin/evmone-blockchaintest
             --gtest_filter='-bc4895-withdrawals.shanghaiWithoutWithdrawalsRLP:bcInvalidHeaderTest.*:bcUncleHeaderValidity.gasLimitTooLowExactBound'
             ~/tests/BlockchainTests/InvalidBlocks


### PR DESCRIPTION
The job ran evmone-statetest and two evmone-blockchaintest invocations back-to-back without setting LLVM_PROFILE_FILE. Each instrumented binary wrote to the default location (default.profraw), so every subsequent run truncated the previous one. By the time collect_coverage_clang merged *.profraw, only the last invocation's profile remained — the State tests coverage was silently lost.

Give each run its own profile file so all three survive the merge.