### PR TITLE
Implement EIP-7843: SLOTNUM opcode

### DIFF
--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -215,6 +215,7 @@ struct evmc_tx_context
     evmc_uint256be blob_base_fee;     /**< The blob base fee (EIP-7516). */
     const evmc_bytes32* blob_hashes;  /**< The array of blob hashes (EIP-4844). */
     size_t blob_hashes_count;         /**< The number of blob hashes (EIP-4844). */
+    uint64_t block_slot_number;       /**< The beacon chain slot number (EIP-7843). */
 };
 
 /**

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -568,6 +568,11 @@ inline void blobbasefee(StackTop stack, ExecutionState& state) noexcept
     stack.push(intx::be::load<uint256>(state.get_tx_context().blob_base_fee));
 }
 
+inline void slotnum(StackTop stack, ExecutionState& state) noexcept
+{
+    stack.push(state.get_tx_context().block_slot_number);
+}
+
 inline Result extcodesize(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
 {
     auto& x = stack.top();

--- a/lib/evmone/instructions_opcodes.hpp
+++ b/lib/evmone/instructions_opcodes.hpp
@@ -73,6 +73,7 @@ enum Opcode : uint8_t  // NOLINT(*-use-enum-class)
     OP_BASEFEE = 0x48,
     OP_BLOBHASH = 0x49,
     OP_BLOBBASEFEE = 0x4a,
+    OP_SLOTNUM = 0x4b,
 
     OP_POP = 0x50,
     OP_MLOAD = 0x51,

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -177,6 +177,7 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
     table[EVMC_OSAKA][OP_CLZ] = 5;
 
     table[EVMC_AMSTERDAM] = table[EVMC_OSAKA];
+    table[EVMC_AMSTERDAM][OP_SLOTNUM] = 2;
     table[EVMC_AMSTERDAM][OP_DUPN] = 3;
     table[EVMC_AMSTERDAM][OP_SWAPN] = 3;
     table[EVMC_AMSTERDAM][OP_EXCHANGE] = 3;
@@ -292,6 +293,7 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_BASEFEE] = {"BASEFEE", 0, false, 0, 1, EVMC_LONDON};
     table[OP_BLOBHASH] = {"BLOBHASH", 0, false, 1, 0, EVMC_CANCUN};
     table[OP_BLOBBASEFEE] = {"BLOBBASEFEE", 0, false, 0, 1, EVMC_CANCUN};
+    table[OP_SLOTNUM] = {"SLOTNUM", 0, false, 0, 1, EVMC_AMSTERDAM};
 
     table[OP_POP] = {"POP", 0, false, 1, -1, EVMC_FRONTIER};
     table[OP_MLOAD] = {"MLOAD", 0, false, 1, 0, EVMC_FRONTIER};

--- a/lib/evmone/instructions_xmacro.hpp
+++ b/lib/evmone/instructions_xmacro.hpp
@@ -111,7 +111,7 @@
     ON_OPCODE_IDENTIFIER(OP_BASEFEE, basefee)               \
     ON_OPCODE_IDENTIFIER(OP_BLOBHASH, blobhash)             \
     ON_OPCODE_IDENTIFIER(OP_BLOBBASEFEE, blobbasefee)       \
-    ON_OPCODE_UNDEFINED(0x4b)                               \
+    ON_OPCODE_IDENTIFIER(OP_SLOTNUM, slotnum)               \
     ON_OPCODE_UNDEFINED(0x4c)                               \
     ON_OPCODE_UNDEFINED(0x4d)                               \
     ON_OPCODE_UNDEFINED(0x4e)                               \

--- a/test/state/block.hpp
+++ b/test/state/block.hpp
@@ -61,6 +61,9 @@ struct BlockInfo
     /// Blob gas price from EIP-4844, computed from excess_blob_gas.
     std::optional<intx::uint256> blob_base_fee;
 
+    /// The beacon chain slot number (EIP-7843).
+    uint64_t slot_number = 0;
+
     std::vector<Ommer> ommers;
     std::vector<Withdrawal> withdrawals;
 };

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -422,6 +422,7 @@ evmc_tx_context Host::get_tx_context() const noexcept
         intx::be::store<uint256be>(m_block.blob_base_fee.value_or(0)),
         m_tx.blob_hashes.data(),
         m_tx.blob_hashes.size(),
+        m_block.slot_number,
     };
 }
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
     evm_eip3860_initcode_test.cpp
     evm_eip4844_blobhash_test.cpp
     evm_eip7516_blobbasefee_test.cpp
+    evm_eip7843_slotnum_test.cpp
     evm_eip7939_clz_test.cpp
     evm_eip8024_swapn_dupn_exchange_test.cpp
     evm_memory_test.cpp

--- a/test/unittests/evm_eip7843_slotnum_test.cpp
+++ b/test/unittests/evm_eip7843_slotnum_test.cpp
@@ -1,0 +1,42 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This file contains EVM unit tests for EIP-7843: SLOTNUM opcode.
+/// https://eips.ethereum.org/EIPS/eip-7843
+
+#include "evm_fixture.hpp"
+
+using namespace evmone::test;
+
+TEST_P(evm, slotnum_values)
+{
+    rev = EVMC_AMSTERDAM;
+    for (const auto slot_number : {0ull, 0x123456789abcdef0ull, 0xffffffffffffffffull})
+    {
+        host.tx_context.block_slot_number = slot_number;
+        execute(OP_SLOTNUM + ret_top());
+        EXPECT_STATUS(EVMC_SUCCESS);
+        EXPECT_OUTPUT_INT(slot_number);
+    }
+}
+
+TEST_P(evm, slotnum_gas_cost)
+{
+    rev = EVMC_AMSTERDAM;
+    host.tx_context.block_slot_number = 1;
+    execute(bytecode{} + OP_SLOTNUM);
+    EXPECT_STATUS(EVMC_SUCCESS);
+    EXPECT_EQ(gas_used, 2);
+}
+
+TEST_P(evm, slotnum_undefined_before_amsterdam)
+{
+    // SLOTNUM (opcode 0x4b) is introduced in Amsterdam; undefined in earlier forks.
+    for (const auto r : {EVMC_FRONTIER, EVMC_OSAKA})
+    {
+        rev = r;
+        execute(bytecode{} + OP_SLOTNUM);
+        EXPECT_EQ(result.status_code, EVMC_UNDEFINED_INSTRUCTION) << "fork " << r;
+    }
+}

--- a/test/utils/blockchaintest.hpp
+++ b/test/utils/blockchaintest.hpp
@@ -42,6 +42,7 @@ struct BlockHeader
     std::optional<uint64_t> blob_gas_used;
     std::optional<uint64_t> excess_blob_gas;
     hash256 requests_hash;
+    uint64_t slot_number = 0;
 };
 
 struct TestBlock

--- a/test/utils/blockchaintest_loader.cpp
+++ b/test/utils/blockchaintest_loader.cpp
@@ -51,6 +51,7 @@ BlockHeader from_json<BlockHeader>(const json::json& j)
         .blob_gas_used = load_optional<uint64_t>(j, "blobGasUsed"),
         .excess_blob_gas = load_optional<uint64_t>(j, "excessBlobGas"),
         .requests_hash = load_if_exists<hash256>(j, "requestsHash"),
+        .slot_number = load_if_exists<uint64_t>(j, "slotNumber"),
     };
 }
 
@@ -81,6 +82,7 @@ static TestBlock load_test_block(
         tb.block_info.parent_beacon_block_root = tb.expected_block_header.parent_beacon_block_root;
         tb.block_info.blob_gas_used = tb.expected_block_header.blob_gas_used;
         tb.block_info.excess_blob_gas = tb.expected_block_header.excess_blob_gas;
+        tb.block_info.slot_number = tb.expected_block_header.slot_number;
 
         tb.block_info.blob_base_fee = tb.block_info.excess_blob_gas.has_value() ?
                                           std::optional(state::compute_blob_gas_price(

--- a/test/utils/statetest_loader.cpp
+++ b/test/utils/statetest_loader.cpp
@@ -325,6 +325,7 @@ state::BlockInfo from_json_with_rev(
         .blob_gas_used = load_if_exists<uint64_t>(j, "blobGasUsed"),
         .excess_blob_gas = excess_blob_gas,
         .blob_base_fee = state::compute_blob_gas_price(blob_params, excess_blob_gas),
+        .slot_number = load_if_exists<uint64_t>(j, "slotNumber"),
         .ommers = std::move(ommers),
         .withdrawals = std::move(withdrawals),
     };


### PR DESCRIPTION
Add SLOTNUM instruction (opcode 0x4b) that returns the beacon chain slot number. Gas cost: 2. Available since Amsterdam.

https://eips.ethereum.org/EIPS/eip-7843