### PR TITLE
ci: Run clang-format check on evmc/

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -324,7 +324,7 @@ jobs:
           name: "Check code format"
           command: |
             clang-format --version
-            find include lib test tools -name '*.hpp' -o -name '*.cpp' -o -name '*.h' -o -name '*.c' | xargs clang-format -i
+            find evmc include lib test tools -name '*.hpp' -o -name '*.cpp' -o -name '*.h' -o -name '*.c' | xargs clang-format -i
             git diff --color --exit-code
       - run:
           name: "Check spelling"

--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -203,18 +203,18 @@ struct evmc_message
 /** The transaction and block data for execution. */
 struct evmc_tx_context
 {
-    evmc_uint256be tx_gas_price;       /**< The transaction gas price. */
-    evmc_address tx_origin;            /**< The transaction origin account. */
-    evmc_address block_coinbase;       /**< The miner of the block. */
-    int64_t block_number;              /**< The block number. */
-    int64_t block_timestamp;           /**< The block timestamp. */
-    int64_t block_gas_limit;           /**< The block gas limit. */
-    evmc_uint256be block_prev_randao;  /**< The block previous RANDAO (EIP-4399). */
-    evmc_uint256be chain_id;           /**< The blockchain's ChainID. */
-    evmc_uint256be block_base_fee;     /**< The block base fee per gas (EIP-1559, EIP-3198). */
-    evmc_uint256be blob_base_fee;      /**< The blob base fee (EIP-7516). */
-    const evmc_bytes32* blob_hashes;   /**< The array of blob hashes (EIP-4844). */
-    size_t blob_hashes_count;          /**< The number of blob hashes (EIP-4844). */
+    evmc_uint256be tx_gas_price;      /**< The transaction gas price. */
+    evmc_address tx_origin;           /**< The transaction origin account. */
+    evmc_address block_coinbase;      /**< The miner of the block. */
+    int64_t block_number;             /**< The block number. */
+    int64_t block_timestamp;          /**< The block timestamp. */
+    int64_t block_gas_limit;          /**< The block gas limit. */
+    evmc_uint256be block_prev_randao; /**< The block previous RANDAO (EIP-4399). */
+    evmc_uint256be chain_id;          /**< The blockchain's ChainID. */
+    evmc_uint256be block_base_fee;    /**< The block base fee per gas (EIP-1559, EIP-3198). */
+    evmc_uint256be blob_base_fee;     /**< The blob base fee (EIP-7516). */
+    const evmc_bytes32* blob_hashes;  /**< The array of blob hashes (EIP-4844). */
+    size_t blob_hashes_count;         /**< The number of blob hashes (EIP-4844). */
 };
 
 /**


### PR DESCRIPTION
The find roots in the format check excluded evmc/, so formatting issues there went undetected. Add evmc/ to the list and reformat existing offenders.