### PR TITLE
Implement EIP-7976: Increase Calldata Floor Cost

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -55,7 +55,7 @@ struct TransactionCost
     int64_t min = 0;
 };
 
-/// Compute the transaction intrinsic gas 𝑔₀ (Yellow Paper, 6.2) and minimal gas (EIP-7623).
+/// Compute the transaction intrinsic gas 𝑔₀ (Yellow Paper, 6.2) and minimal gas (floor cost).
 TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& tx) noexcept
 {
     static constexpr auto TX_BASE_COST = 21000;
@@ -63,6 +63,7 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
     static constexpr auto DATA_TOKEN_COST = 4;
     static constexpr auto INITCODE_WORD_COST = 2;
     static constexpr auto TOTAL_COST_FLOOR_PER_TOKEN = 10;
+    static constexpr auto TOTAL_COST_FLOOR_PER_BYTE = 16 * 4;
 
     const auto is_create = !tx.to.has_value();
 
@@ -82,9 +83,11 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
     const auto intrinsic_cost =
         TX_BASE_COST + create_cost + data_cost + access_list_cost + auth_list_cost + initcode_cost;
 
-    // EIP-7623: Compute the minimum cost for the transaction by. If disabled, just use 0.
-    const auto min_cost =
-        rev >= EVMC_PRAGUE ? TX_BASE_COST + num_tokens * TOTAL_COST_FLOOR_PER_TOKEN : 0;
+    int64_t min_cost = 0;
+    if (rev >= EVMC_AMSTERDAM)  // EIP-7976: unified cost per byte
+        min_cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_BYTE * static_cast<int64_t>(tx.data.size());
+    else if (rev >= EVMC_PRAGUE)  // EIP-7623: cost per token capturing num of zero-nonzero bytes.
+        min_cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * num_tokens;
 
     return {intrinsic_cost, min_cost};
 }

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -150,3 +150,78 @@ TEST_F(state_transition, tx_data_min_cost_exec_51)
     expect.gas_used = 21000 + MIN_GAS + 1;
     expect.post[To].exists = true;
 }
+
+TEST_F(state_transition, tx_data_floor_amsterdam_exec_0)
+{
+    // EIP-7976: the floor is 64 gas per calldata byte. Execution gas is 0.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.data = "0001"_hex;
+    static constexpr auto MIN_GAS = 64 * 2;
+
+    expect.gas_used = 21000 + MIN_GAS;
+}
+
+TEST_F(state_transition, tx_data_floor_amsterdam_exec_below_floor)
+{
+    // EIP-7976: standard cost (intrinsic data + execution) is 1 below the floor.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.data = "0001"_hex;
+    static constexpr auto DATA_GAS = 16 + 4;
+    static constexpr auto MIN_GAS = 64 * 2;
+
+    pre[To] = {.code = (MIN_GAS - DATA_GAS - 1) * OP_JUMPDEST};
+    expect.gas_used = 21000 + MIN_GAS;
+    expect.post[To].exists = true;
+}
+
+TEST_F(state_transition, tx_data_floor_amsterdam_exec_at_floor)
+{
+    // EIP-7976: standard cost (intrinsic data + execution) equals the floor.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.data = "0001"_hex;
+    static constexpr auto DATA_GAS = 16 + 4;
+    static constexpr auto MIN_GAS = 64 * 2;
+
+    pre[To] = {.code = (MIN_GAS - DATA_GAS) * OP_JUMPDEST};
+    expect.gas_used = 21000 + MIN_GAS;
+    expect.post[To].exists = true;
+}
+
+TEST_F(state_transition, tx_data_floor_amsterdam_exec_above_floor)
+{
+    // EIP-7976: standard cost (intrinsic data + execution) is 1 above the floor.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.data = "0001"_hex;
+    static constexpr auto DATA_GAS = 16 + 4;
+    static constexpr auto MIN_GAS = 64 * 2;
+
+    pre[To] = {.code = (MIN_GAS - DATA_GAS + 1) * OP_JUMPDEST};
+    expect.gas_used = 21000 + MIN_GAS + 1;
+    expect.post[To].exists = true;
+}
+
+TEST_F(state_transition, tx_data_floor_amsterdam_zero_bytes)
+{
+    // EIP-7976: zero bytes pay the same 64-gas floor as nonzero bytes.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.data = "0000"_hex;
+    static constexpr auto MIN_GAS = 64 * 2;
+
+    expect.gas_used = 21000 + MIN_GAS;
+}
+
+TEST_F(state_transition, tx_data_floor_osaka_uses_eip7623)
+{
+    // EIP-7976 is not yet active in Osaka; the EIP-7623 floor (10 gas per token) still applies.
+    rev = EVMC_OSAKA;
+    tx.to = To;
+    tx.data = "0001"_hex;  // tokens = 4 (nonzero) + 1 (zero) = 5
+    static constexpr auto MIN_GAS = 10 * 5;
+
+    expect.gas_used = 21000 + MIN_GAS;
+}


### PR DESCRIPTION
Raise TOTAL_COST_FLOOR_PER_TOKEN from 10 to 16, and count every calldata byte (including zero bytes) as 4 tokens in the floor calculation. This yields a 64-gas floor cost per calldata byte. Regular intrinsic gas is unchanged (zero bytes still cost 4 gas via DATA_TOKEN_COST * 1 token).

https://eips.ethereum.org/EIPS/eip-7976