### PR TITLE
test: Add blob params for Amsterdam

### DIFF
--- a/test/utils/blob_schedule.cpp
+++ b/test/utils/blob_schedule.cpp
@@ -4,15 +4,15 @@
 
 namespace evmone::test
 {
-state::BlobParams get_blob_params(evmc_revision rev)
+state::BlobParams get_blob_params(evmc_revision rev) noexcept
 {
-    if (rev == EVMC_PRAGUE || rev == EVMC_EXPERIMENTAL)
+    if (rev >= EVMC_AMSTERDAM)
+        return {14, 21, 11684671};
+    if (rev >= EVMC_PRAGUE)
         return {6, 9, 5007716};
-    else if (rev > EVMC_PRAGUE)
-        throw std::invalid_argument{
-            "no hardcoded blob params for " + std::string{evmc::to_string(rev)}};
-    else
+    if (rev == EVMC_CANCUN)
         return {3, 6, 3338477};
+    return {0, 0, 1};
 }
 
 state::BlobParams get_blob_params(evmc_revision rev, const BlobSchedule& blob_schedule)

--- a/test/utils/blob_schedule.hpp
+++ b/test/utils/blob_schedule.hpp
@@ -10,8 +10,9 @@ namespace evmone::test
 using BlobSchedule = std::unordered_map<std::string, state::BlobParams>;
 
 /// Returns the hardcoded blob params for the given EVM revision.
-/// After Prague, the blob params must be derived from config.
-state::BlobParams get_blob_params(evmc_revision rev);
+/// After Prague, the blob params should be taken from a BPO config. However, for unit tests this
+/// function still can be used to get a reasonable default.
+state::BlobParams get_blob_params(evmc_revision rev) noexcept;
 
 /// Returns the blob params for the given EVM revision and a blob schedule.
 state::BlobParams get_blob_params(evmc_revision rev, const BlobSchedule& blob_schedule);


### PR DESCRIPTION
Unify the test::get_blob_params() to return reasonable value for each revision. Useful for new unit tests.