### PR TITLE
Implement EIP-7981: Increase Access List Cost

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -66,6 +66,8 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
     static constexpr auto TX_CREATE_COST = 32000;
     static constexpr auto ACCESS_LIST_ADDRESS_COST = 2400;
     static constexpr auto ACCESS_LIST_STORAGE_KEY_COST = 1900;
+    static constexpr auto ACCESS_LIST_ADDRESS_BYTES = 20;
+    static constexpr auto ACCESS_LIST_STORAGE_KEY_BYTES = 32;
     static constexpr auto DATA_TOKEN_COST = 4;
     static constexpr auto INITCODE_WORD_COST = 2;
     static constexpr auto TOTAL_COST_FLOOR_PER_TOKEN = 10;
@@ -80,7 +82,8 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
 
     const auto [num_addresses, num_storage_keys] = count_access_list(tx.access_list);
     const auto access_list_num_bytes =
-        static_cast<int64_t>(num_addresses * sizeof(address) + num_storage_keys * sizeof(bytes32));
+        static_cast<int64_t>(num_addresses * ACCESS_LIST_ADDRESS_BYTES +
+                             num_storage_keys * ACCESS_LIST_STORAGE_KEY_BYTES);
     const auto access_list_cost = static_cast<int64_t>(
         num_addresses * ACCESS_LIST_ADDRESS_COST + num_storage_keys * ACCESS_LIST_STORAGE_KEY_COST);
 

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -79,8 +79,8 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
     const auto data_cost = num_tokens * DATA_TOKEN_COST;
 
     const auto [num_addresses, num_storage_keys] = count_access_list(tx.access_list);
-    const auto access_list_num_bytes = static_cast<int64_t>(
-        num_addresses * sizeof(address) + num_storage_keys * sizeof(bytes32));
+    const auto access_list_num_bytes =
+        static_cast<int64_t>(num_addresses * sizeof(address) + num_storage_keys * sizeof(bytes32));
     const auto access_list_cost = static_cast<int64_t>(
         num_addresses * ACCESS_LIST_ADDRESS_COST + num_storage_keys * ACCESS_LIST_STORAGE_KEY_COST);
 

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -10,6 +10,7 @@
 #include <evmone/delegation.hpp>
 #include <evmone_precompiles/secp256k1.hpp>
 #include <algorithm>
+#include <ranges>
 
 using namespace intx;
 
@@ -38,15 +39,18 @@ size_t compute_tx_data_tokens(evmc_revision rev, bytes_view data) noexcept
     return (nonzero_byte_multiplier * num_nonzero_bytes) + num_zero_bytes;
 }
 
-int64_t compute_access_list_cost(const AccessList& access_list) noexcept
+struct AccessListCounts
 {
-    static constexpr auto ADDRESS_COST = 2400;
-    static constexpr auto STORAGE_KEY_COST = 1900;
+    size_t num_addresses = 0;
+    size_t num_storage_keys = 0;
+};
 
-    int64_t cost = 0;
-    for (const auto& [_, keys] : access_list)
-        cost += ADDRESS_COST + static_cast<int64_t>(keys.size()) * STORAGE_KEY_COST;
-    return cost;
+AccessListCounts count_access_list(const AccessList& access_list) noexcept
+{
+    size_t num_storage_keys = 0;
+    for (const auto& keys : access_list | std::views::values)
+        num_storage_keys += keys.size();
+    return {access_list.size(), num_storage_keys};
 }
 
 struct TransactionCost
@@ -60,6 +64,8 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
 {
     static constexpr auto TX_BASE_COST = 21000;
     static constexpr auto TX_CREATE_COST = 32000;
+    static constexpr auto ACCESS_LIST_ADDRESS_COST = 2400;
+    static constexpr auto ACCESS_LIST_STORAGE_KEY_COST = 1900;
     static constexpr auto DATA_TOKEN_COST = 4;
     static constexpr auto INITCODE_WORD_COST = 2;
     static constexpr auto TOTAL_COST_FLOOR_PER_TOKEN = 10;
@@ -72,7 +78,11 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
     const auto num_tokens = static_cast<int64_t>(compute_tx_data_tokens(rev, tx.data));
     const auto data_cost = num_tokens * DATA_TOKEN_COST;
 
-    const auto access_list_cost = compute_access_list_cost(tx.access_list);
+    const auto [num_addresses, num_storage_keys] = count_access_list(tx.access_list);
+    const auto access_list_num_bytes = static_cast<int64_t>(
+        num_addresses * sizeof(address) + num_storage_keys * sizeof(bytes32));
+    const auto access_list_cost = static_cast<int64_t>(
+        num_addresses * ACCESS_LIST_ADDRESS_COST + num_storage_keys * ACCESS_LIST_STORAGE_KEY_COST);
 
     const auto auth_list_cost =
         static_cast<int64_t>(tx.authorization_list.size()) * AUTHORIZATION_EMPTY_ACCOUNT_COST;
@@ -80,8 +90,12 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
     const auto initcode_cost =
         (is_create && rev >= EVMC_SHANGHAI) ? INITCODE_WORD_COST * num_words(tx.data.size()) : 0;
 
-    const auto intrinsic_cost =
-        TX_BASE_COST + create_cost + data_cost + access_list_cost + auth_list_cost + initcode_cost;
+    // Charge a flat cost per access-list byte (EIP-7981).
+    const auto access_list_data_cost =
+        (rev >= EVMC_AMSTERDAM) ? access_list_num_bytes * TOTAL_COST_FLOOR_PER_BYTE : 0;
+
+    const auto intrinsic_cost = TX_BASE_COST + create_cost + data_cost + access_list_data_cost +
+                                access_list_cost + auth_list_cost + initcode_cost;
 
     int64_t data_min_cost = 0;
     if (rev >= EVMC_AMSTERDAM)  // Unified cost per byte (EIP-7976).
@@ -90,7 +104,8 @@ TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& 
         data_min_cost = TOTAL_COST_FLOOR_PER_TOKEN * num_tokens;
 
     // Compute "floor" cost (EIP-7623).
-    const auto min_cost = (rev >= EVMC_PRAGUE) ? TX_BASE_COST + data_min_cost : 0;
+    const auto min_cost =
+        (rev >= EVMC_PRAGUE) ? TX_BASE_COST + data_min_cost + access_list_data_cost : 0;
 
     return {intrinsic_cost, min_cost};
 }

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -257,3 +257,14 @@ TEST_F(state_transition, access_list_floor_amsterdam)
     // floor     = 21000 + 64*(100 + 20)       = 28680  (dominates)
     expect.gas_used = 28680;
 }
+
+TEST_F(state_transition, invalid_access_list_amsterdam_gas_limit_below_floor)
+{
+    // EIP-7981: gas limit must cover the floor (28680) — pre-7981 intrinsic (23800) is not enough.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.data = bytes(100, 0x00);
+    tx.access_list = {{To, {}}};
+    tx.gas_limit = 28679;
+    expect.tx_error = INTRINSIC_GAS_TOO_LOW;
+}

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -225,3 +225,59 @@ TEST_F(state_transition, tx_data_floor_osaka_uses_eip7623)
 
     expect.gas_used = 21000 + MIN_GAS;
 }
+
+TEST_F(state_transition, access_list_cost_amsterdam_address_only)
+{
+    // EIP-7981: an access-list address adds 64 * 20 = 1280 gas to the intrinsic cost.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.access_list = {{To, {}}};
+    // intrinsic = 21000 + 2400 (address) + 1280 (EIP-7981 address) = 24680
+    // floor     = 21000 + 64 * 20                                  = 22280
+    expect.gas_used = 24680;
+}
+
+TEST_F(state_transition, access_list_cost_amsterdam_with_key)
+{
+    // EIP-7981: a storage key adds 64 * 32 = 2048 gas to the intrinsic cost.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.access_list = {{To, {0x01_bytes32}}};
+    // intrinsic = 21000 + 2400 + 1900 + 1280 + 2048 = 28628
+    // floor     = 21000 + 64 * (20 + 32)            = 24328
+    expect.gas_used = 28628;
+}
+
+TEST_F(state_transition, access_list_cost_amsterdam_multiple)
+{
+    // EIP-7981: 2 addresses + 3 storage keys.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.access_list = {{To, {0x01_bytes32}}, {Sender, {0x02_bytes32, 0x03_bytes32}}};
+    // intrinsic = 21000 + 2*2400 + 3*1900 + 2*1280 + 3*2048 = 40204
+    // floor     = 21000 + 64 * (2*20 + 3*32)                = 29704
+    expect.gas_used = 40204;
+}
+
+TEST_F(state_transition, access_list_cost_osaka_unchanged)
+{
+    // EIP-7981 is not yet active in Osaka; the access-list cost is unchanged.
+    rev = EVMC_OSAKA;
+    tx.to = To;
+    tx.access_list = {{To, {0x01_bytes32}}};
+    // intrinsic = 21000 + 2400 + 1900 = 25300
+    expect.gas_used = 25300;
+}
+
+TEST_F(state_transition, access_list_floor_amsterdam)
+{
+    // EIP-7981: access-list bytes also bump the floor when execution is small.
+    // 100 zero calldata bytes + 1 access-list address.
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.data = bytes(100, 0x00);
+    tx.access_list = {{To, {}}};
+    // intrinsic = 21000 + 100*4 + 2400 + 1280 = 25080
+    // floor     = 21000 + 64*(100 + 20)       = 28680   <-- dominates
+    expect.gas_used = 28680;
+}

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -226,42 +226,19 @@ TEST_F(state_transition, tx_data_floor_osaka_uses_eip7623)
     expect.gas_used = 21000 + MIN_GAS;
 }
 
-TEST_F(state_transition, access_list_cost_amsterdam_address_only)
+TEST_F(state_transition, access_list_cost_amsterdam)
 {
-    // EIP-7981: an access-list address adds 64 * 20 = 1280 gas to the intrinsic cost.
-    rev = EVMC_AMSTERDAM;
-    tx.to = To;
-    tx.access_list = {{To, {}}};
-    // intrinsic = 21000 + 2400 (address) + 1280 (EIP-7981 address) = 24680
-    // floor     = 21000 + 64 * 20                                  = 22280
-    expect.gas_used = 24680;
-}
-
-TEST_F(state_transition, access_list_cost_amsterdam_with_key)
-{
-    // EIP-7981: a storage key adds 64 * 32 = 2048 gas to the intrinsic cost.
+    // EIP-7981: 1280 gas (64*20) per address, 2048 gas (64*32) per storage key.
     rev = EVMC_AMSTERDAM;
     tx.to = To;
     tx.access_list = {{To, {0x01_bytes32}}};
     // intrinsic = 21000 + 2400 + 1900 + 1280 + 2048 = 28628
-    // floor     = 21000 + 64 * (20 + 32)            = 24328
     expect.gas_used = 28628;
-}
-
-TEST_F(state_transition, access_list_cost_amsterdam_multiple)
-{
-    // EIP-7981: 2 addresses + 3 storage keys.
-    rev = EVMC_AMSTERDAM;
-    tx.to = To;
-    tx.access_list = {{To, {0x01_bytes32}}, {Sender, {0x02_bytes32, 0x03_bytes32}}};
-    // intrinsic = 21000 + 2*2400 + 3*1900 + 2*1280 + 3*2048 = 40204
-    // floor     = 21000 + 64 * (2*20 + 3*32)                = 29704
-    expect.gas_used = 40204;
 }
 
 TEST_F(state_transition, access_list_cost_osaka_unchanged)
 {
-    // EIP-7981 is not yet active in Osaka; the access-list cost is unchanged.
+    // EIP-7981 is inactive before Amsterdam.
     rev = EVMC_OSAKA;
     tx.to = To;
     tx.access_list = {{To, {0x01_bytes32}}};
@@ -271,13 +248,12 @@ TEST_F(state_transition, access_list_cost_osaka_unchanged)
 
 TEST_F(state_transition, access_list_floor_amsterdam)
 {
-    // EIP-7981: access-list bytes also bump the floor when execution is small.
-    // 100 zero calldata bytes + 1 access-list address.
+    // EIP-7981: access-list bytes count toward the floor.
     rev = EVMC_AMSTERDAM;
     tx.to = To;
     tx.data = bytes(100, 0x00);
     tx.access_list = {{To, {}}};
     // intrinsic = 21000 + 100*4 + 2400 + 1280 = 25080
-    // floor     = 21000 + 64*(100 + 20)       = 28680   <-- dominates
+    // floor     = 21000 + 64*(100 + 20)       = 28680  (dominates)
     expect.gas_used = 28680;
 }


### PR DESCRIPTION
Charge a flat surcharge of 64 gas per access-list byte on top of the existing EIP-2930 access-list cost.
The surcharge applies from Amsterdam and is added to both the regular intrinsic gas and the EIP-7976 floor, preventing access lists from being used to circumvent the EIP-7623 floor pricing.

https://eips.ethereum.org/EIPS/eip-7981