### PR TITLE
build: Add PCH for evmone-unittests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -53,7 +53,7 @@ executors:
   linux-base:
     docker:
       - image: cimg/base:edge-22.04
-    resource_class: small
+    resource_class: medium
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   macos:

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -84,6 +84,13 @@ target_sources(
 )
 target_link_libraries(evmone-unittests PRIVATE evmone evmone::evmmax evmone::experimental evmone::state evmone::testutils GTest::gtest GTest::gtest_main)
 target_include_directories(evmone-unittests PRIVATE ${evmone_private_include_dir})
+target_precompile_headers(
+    evmone-unittests PRIVATE
+    <intx/intx.hpp>
+    <evmc/evmc.hpp>
+    <evmc/hex.hpp>
+    <gtest/gtest.h>
+)
 
 gtest_discover_tests(
     evmone-unittests

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -84,13 +84,15 @@ target_sources(
 )
 target_link_libraries(evmone-unittests PRIVATE evmone evmone::evmmax evmone::experimental evmone::state evmone::testutils GTest::gtest GTest::gtest_main)
 target_include_directories(evmone-unittests PRIVATE ${evmone_private_include_dir})
-target_precompile_headers(
-    evmone-unittests PRIVATE
-    <intx/intx.hpp>
-    <evmc/evmc.hpp>
-    <evmc/hex.hpp>
-    <gtest/gtest.h>
-)
+if(NOT CMAKE_CXX_CLANG_TIDY)
+    target_precompile_headers(
+        evmone-unittests PRIVATE
+        <intx/intx.hpp>
+        <evmc/evmc.hpp>
+        <evmc/hex.hpp>
+        <gtest/gtest.h>
+    )
+endif()
 
 gtest_discover_tests(
     evmone-unittests


### PR DESCRIPTION
The unittests target re-parses the same external headers in 70+ TUs. Cumulative parse time across the target was ~780s (gtest 183s, evmc/evmc 101s, evmc/hex 71s, intx 70s).

Precompile the four external headers used in nearly every TU. Clean rebuild measured on this machine (-j32, GCC 14, Release):

- baseline:  24.1s wall, 308s CPU
- with PCH:  20.0s wall, 233s CPU  (-17% wall, -24% CPU)

Wider PCH sets (adding mocked_host, gmock, nlohmann/json, bytecode.hpp) were tested but regressed GCC: the .gch file grows past 100MB and the per-TU load cost outweighs the parse savings on TUs that do not need those headers. The minimal external-only set is the sweet spot.