### PR TITLE
test/blockchaintest: Assert lastblockhash matches canonical chain tip

### DIFF
--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -292,6 +292,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
         std::unordered_map<hash256, BlockData> block_data{{{c.genesis_block_header.hash,
             {&c.genesis_block_header, false, c.pre_state, c.genesis_block_header.difficulty}}}};
         const auto* canonical_state = &c.pre_state;
+        hash256 canonical_tip_hash = c.genesis_block_header.hash;
         intx::uint256 max_total_difficulty = c.genesis_block_header.difficulty;
 
         for (size_t i = 0; i < c.test_blocks.size(); ++i)
@@ -339,6 +340,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 if (inserted_it->second.total_difficulty >= max_total_difficulty)
                 {
                     canonical_state = &inserted_it->second.post_state;
+                    canonical_tip_hash = test_block.expected_block_header.hash;
                     max_total_difficulty = inserted_it->second.total_difficulty;
                 }
 
@@ -410,6 +412,9 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 EXPECT_TRUE(false) << "Expected block to be invalid but resulted valid";
             }
         }
+        EXPECT_EQ(canonical_tip_hash, c.expectation.last_block_hash)
+            << "Canonical chain tip differs from expected `lastblockhash`";
+
         const auto expected_post_hash =
             std::holds_alternative<TestState>(c.expectation.post_state) ?
                 state::mpt_hash(std::get<TestState>(c.expectation.post_state)) :


### PR DESCRIPTION
The blockchain-test fixture's top-level `lastblockhash` field was loaded into `BlockchainTest::Expectation::last_block_hash` but never compared against the runner's computed canonical chain tip. A runner that picks the wrong block as canonical (e.g. wrong total_difficulty comparison on an ommer-heavy chain) would silently pass.

Track the expected hash of the canonical tip alongside the existing `canonical_state` pointer (initialized from the genesis hash, updated when total_difficulty advances) and assert it equals `expectation.last_block_hash` after the block loop.