### PR TITLE
test/utils: Rename evmone::test::run to evmone::tooling::run

### DIFF
--- a/test/unittests/tooling_run_test.cpp
+++ b/test/unittests/tooling_run_test.cpp
@@ -10,6 +10,7 @@
 
 using namespace evmone;
 using namespace evmone::test;
+using namespace evmone::tooling;
 using namespace testing;
 
 TEST(tooling_run, execute)

--- a/test/utils/run.cpp
+++ b/test/utils/run.cpp
@@ -8,7 +8,7 @@
 #include <chrono>
 #include <ostream>
 
-namespace evmone::test
+namespace evmone::tooling
 {
 using namespace evmc;
 
@@ -94,7 +94,7 @@ int run(VM& vm, evmc_revision rev, int64_t gas, bytes_view code, bytes_view inpu
     const auto result = vm.execute(host, rev, msg, exec_code.data(), exec_code.size());
 
     if (bench)
-        test::bench(host, vm, rev, msg, exec_code, result, out);
+        tooling::bench(host, vm, rev, msg, exec_code, result, out);
 
     const auto gas_used = msg.gas - result.gas_left;
     out << "Result:   " << result.status_code << "\nGas used: " << gas_used << "\n";
@@ -104,4 +104,4 @@ int run(VM& vm, evmc_revision rev, int64_t gas, bytes_view code, bytes_view inpu
 
     return 0;
 }
-}  // namespace evmone::test
+}  // namespace evmone::tooling

--- a/test/utils/run.hpp
+++ b/test/utils/run.hpp
@@ -6,8 +6,8 @@
 #include <evmc/evmc.hpp>
 #include <iosfwd>
 
-namespace evmone::test
+namespace evmone::tooling
 {
 int run(evmc::VM& vm, evmc_revision rev, int64_t gas, evmc::bytes_view code, evmc::bytes_view input,
     bool create, bool bench, std::ostream& out);
-}  // namespace evmone::test
+}  // namespace evmone::tooling

--- a/tools/evmone/main.cpp
+++ b/tools/evmone/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, const char* const* argv) noexcept
                 // If code_arg or input_arg contains invalid hex string, an exception is thrown.
                 const auto code = load_from_hex(code_arg);
                 const auto input = load_from_hex(input_arg);
-                return evmone::test::run(vm, rev, gas, code, input, create, bench, std::cout);
+                return evmone::tooling::run(vm, rev, gas, code, input, create, bench, std::cout);
             }
 
             return 0;


### PR DESCRIPTION
The run() helper is the body of the evmone-cli `run` command, not test infrastructure. Move it into a dedicated evmone::tooling namespace so the CLI-tool helpers are separated from evmone::test (test fixtures, loaders, bytecode DSL). Sets the stage for extracting t8n() next to it.

Only one call site (tools/evmone/main.cpp) needed updating; the unit test keeps `using namespace evmone::test` for the bytecode DSL and adds `using namespace evmone::tooling` alongside.