### PR TITLE
precompiles: Optimize KZG point evaluation via joint G1 MSM

### DIFF
--- a/lib/evmone_precompiles/kzg.cpp
+++ b/lib/evmone_precompiles/kzg.cpp
@@ -12,29 +12,12 @@ namespace evmone::crypto
 {
 namespace
 {
-/// The field element 1 in Montgomery form.
-constexpr blst_fp ONE = {0x760900000002fffd, 0xebf4000bc40c0002, 0x5f48985753c758ba,
-    0x77ce585370525745, 0x5c071a97a256ec6d, 0x15f65ec3fa80e493};
-
-/// The negation of the subgroup G1 generator -[1]₁ (Jacobian coordinates in Montgomery form).
-constexpr blst_p1 G1_GENERATOR_NEGATIVE = {
+/// The negation of the subgroup G1 generator -[1]₁ (affine coordinates in Montgomery form).
+constexpr blst_p1_affine G1_GENERATOR_NEGATIVE{
     {0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1, 0xf0ae6acdf3d0e747,
         0xedce6ecc21dbf440, 0x120177419e0bfb75},
     {0xff526c2af318883a, 0x92899ce4383b0270, 0x89d7738d9fa9d055, 0x12caf35ba344c12a,
-        0x3cff1b76964b5317, 0x0e44d2ede9774430},
-    ONE};
-
-/// The negation of the subgroup G2 generator -[1]₂ (Jacobian coordinates in Montgomery form).
-constexpr blst_p2 G2_GENERATOR_NEGATIVE{
-    {{{0xf5f28fa202940a10, 0xb3f5fb2687b4961a, 0xa1a893b53e2ae580, 0x9894999d1a3caee9,
-          0x6f67b7631863366b, 0x058191924350bcd7},
-        {0xa5a9c0759e23f606, 0xaaa0c59dbccd60c3, 0x3bb17e18e2867806, 0x1b1ab6cc8541b367,
-            0xc2b6ed0ef2158547, 0x11922a097360edf3}}},
-    {{{0x6d8bf5079fb65e61, 0xc52f05df531d63a5, 0x7f4a4d344ca692c9, 0xa887959b8577c95f,
-          0x4347fe40525c8734, 0x197d145bbaff0bb5},
-        {0x0c3e036d209afa4e, 0x0601d8f4863f9e23, 0xe0832636bacc0a84, 0xeb2def362a476f84,
-            0x64044f659f0ee1e9, 0x0ed54f48d5a1caa7}}},
-    {{ONE, {}}}};
+        0x3cff1b76964b5317, 0x0e44d2ede9774430}};
 
 /// The point from the G2 series, index 1 of the Ethereum KZG trusted setup,
 /// i.e. [s]₂ where s is the trusted setup's secret.
@@ -85,36 +68,13 @@ blst_p1_affine add_or_double(const blst_p1_affine& p, const blst_p1& q) noexcept
     return ra;
 }
 
-blst_p1 mult(const blst_p1& p, const blst_scalar& v) noexcept
-{
-    blst_p1 r;
-    blst_p1_mult(&r, &p, v.b, BLS_MODULUS_BITS);
-    return r;
-}
-
-/// Add two points from E2 and convert the result to affine form.
-/// The conversion to affine is very costly so use only if the affine of the result is needed.
-blst_p2_affine add_or_double(const blst_p2_affine& p, const blst_p2& q) noexcept
-{
-    blst_p2 r;
-    blst_p2_add_or_double_affine(&r, &q, &p);
-    blst_p2_affine ra;
-    blst_p2_to_affine(&ra, &r);
-    return ra;
-}
-
-blst_p2 mult(const blst_p2& p, const blst_scalar& v) noexcept
-{
-    blst_p2 r;
-    blst_p2_mult(&r, &p, v.b, BLS_MODULUS_BITS);
-    return r;
-}
-
 bool pairings_verify(
     const blst_p1_affine& a1, const blst_p1_affine& b1, const blst_p2_affine& b2) noexcept
 {
     blst_fp12 left;
+    // Uses precomputed Miller loop lines for the G2 generator.
     blst_aggregated_in_g1(&left, &a1);
+    // TODO: Precompute Miller loop lines for KZG_SETUP_G2_1 ([s]₂).
     blst_fp12 right;
     blst_miller_loop(&right, &b2, &b1);
     return blst_fp12_finalverify(&left, &right);
@@ -150,19 +110,23 @@ bool kzg_verify_proof(const std::byte versioned_hash[VERSIONED_HASH_SIZE], const
     if (!Pi)
         return false;
 
-    // Compute -Y as [y * -1]₁.
-    const auto neg_Y = mult(G1_GENERATOR_NEGATIVE, *yy);
+    // The standard KZG verification equation
+    //     e(C - [y]₁, [1]₂) =? e(π, [s - z]₂)
+    // is rearranged via bilinearity into
+    //     e(C + [z]π - [y]₁, [1]₂) =? e(π, [s]₂)
+    // which eliminates the G2 multiplication and uses the 2-point MSM for G1.
 
-    // Compute C - Y. It can happen that C == -Y so doubling may be needed.
-    const auto C_sub_Y = add_or_double(*C, neg_Y);
+    // Compute [z]π + [y](-[1]₁).
+    const blst_p1_affine* const points[]{&*Pi, &G1_GENERATOR_NEGATIVE};
+    const byte* const scalars[]{zz->b, yy->b};
+    // For 2 points this actually doesn't use the Pippenger, and we can skip the scratch allocation.
+    blst_p1 z_pi_minus_y_g1;
+    blst_p1s_mult_pippenger(&z_pi_minus_y_g1, points, 2, scalars, BLS_MODULUS_BITS, nullptr);
 
-    // Compute -Z as [z * -1]₂.
-    const auto neg_Z = mult(G2_GENERATOR_NEGATIVE, *zz);
+    // Compute C + ([z]π - [y]₁). The addends may be the same / opposite points.
+    const auto lsh_g1 = add_or_double(*C, z_pi_minus_y_g1);
 
-    // Compute X - Z which is [s - z]₂.
-    const auto X_sub_Z = add_or_double(KZG_SETUP_G2_1, neg_Z);
-
-    // e(C - [y]₁, [1]₂) =? e(Pi, [s - z]₂)
-    return pairings_verify(C_sub_Y, *Pi, X_sub_Z);
+    // e(C + [z]π - [y]₁, [1]₂) =? e(π, [s]₂)
+    return pairings_verify(lsh_g1, *Pi, KZG_SETUP_G2_1);
 }
 }  // namespace evmone::crypto

--- a/test/unittests/precompiles_kzg_test.cpp
+++ b/test/unittests/precompiles_kzg_test.cpp
@@ -61,3 +61,23 @@ TEST(kzg, verify_proof_constant)
     const auto r = kzg_verify_proof(hash.data(), z, y, c, POINT_AT_INFINITY);
     EXPECT_TRUE(r);
 }
+
+TEST(kzg, verify_proof_final_add_doubling)
+{
+    // Force the final G1 addition to be a doubling.
+    //
+    // Setup: π = O, y = 1, z = 0 ⇒ [z]π − [y]G1 = −G1.
+    std::byte z[32]{};
+    std::byte y[32]{};
+    y[31] = std::byte{1};
+
+    // C = −G1 (compressed): same X as G1 with the compressed flag (0x80)
+    // and the Y-sign flag (0x20) set, since y(G1) is the lexicographically
+    // smaller of the two square roots.
+    std::byte c[48]{};
+    intx::be::unsafe::store(reinterpret_cast<uint8_t*>(c), G1_GENERATOR_X);
+    c[0] |= std::byte{0xA0};
+
+    const auto hash = versioned_hash(c);
+    EXPECT_FALSE(kzg_verify_proof(hash.data(), z, y, c, POINT_AT_INFINITY));
+}


### PR DESCRIPTION
Rearrange the standard KZG verification equation

    e(C - [y]₁, [1]₂) =? e(π, [s - z]₂)

into

    e(C + [z]π - [y]₁, [1]₂) =? e(π, [s]₂)

by moving the [z] factor from G2 to G1 via the pairing's bilinearity.

The new form:
  - eliminates the G2 scalar multiplication entirely (was [z](-G2_gen)),
  - eliminates the G2 point addition (was [s]G2 - [z]G2),
  - merges the two remaining G1 scalar multiplications ([z]π and [y]₁)
    into a single 2-point Pippenger MSM,
  - keeps both G2 pairing arguments as fixed constants ([1]₂ via
    blst_aggregated_in_g1's precomputed lines and the [s]₂ point from
    the trusted setup).

G2_GENERATOR_NEGATIVE and the blst_p2 mult/add helpers are no longer
needed. G1_GENERATOR_NEGATIVE is redeclared as blst_p1_affine since
the Pippenger MSM consumes affine points.