### PR TITLE
crypto: Share Fq12 squaring across pairs in BN254 Miller loop

### DIFF
--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -5,6 +5,7 @@
 #include "../../bn254.hpp"
 #include "fields.hpp"
 #include "utils.hpp"
+#include <span>
 #include <vector>
 
 namespace evmmax::bn254
@@ -44,48 +45,71 @@ constexpr void multiply_by_lin_func_value(
 inline constexpr auto ATE_LOOP_COUNT_NAF = 0x1120804220120081204008212022011_u128;
 inline constexpr int LOG_ATE_LOOP_COUNT = 63;
 
-/// Miller loop according to https://eprint.iacr.org/2010/354.pdf Algorithm 1.
-Fq12 miller_loop(const ecc::Point<Fq2>& Q, const ecc::Point<Fq>& P) noexcept
+/// State carried across iterations for one pair in the Miller loop.
+struct MillerPairState
 {
-    auto T = ecc::JacPoint<Fq2>::from(Q);
-    auto nQ = -Q;
+    ecc::JacPoint<Fq2> T;  ///< running Jacobian point on the twisted curve
+    ecc::Point<Fq2> Q;     ///< the affine G2 input
+    ecc::Point<Fq2> nQ;    ///< -Q, precomputed
+    ecc::Point<Fq> P;      ///< the affine G1 input
+    Fq ny;                 ///< -P.y, precomputed
+};
+
+/// Multi-pair Miller loop computing prod_i e_miller(P_i, Q_i).
+///
+/// Algorithm: https://eprint.iacr.org/2010/354.pdf Algorithm 1, batched across
+/// all input pairs so the Fq12 squaring is shared instead of repeated per pair.
+/// For N valid pairs, saves (N-1) × (LOG_ATE_LOOP_COUNT + 1) Fq12 squarings
+/// vs. the per-pair-then-multiply approach.
+Fq12 multi_miller_loop(std::span<MillerPairState> pairs) noexcept
+{
     auto f = Fq12::one();
     std::array<Fq2, 3> t;
     auto naf = ATE_LOOP_COUNT_NAF;
-    const auto ny = -P.y;
 
     for (int i = 0; i <= LOG_ATE_LOOP_COUNT; ++i)
     {
-        T = lin_func_and_dbl(T, t);
-        f = square(f);
-        multiply_by_lin_func_value(f, t, P.x, ny);
+        f = square(f);  // single squaring shared by every pair this iteration
+
+        for (auto& s : pairs)
+        {
+            s.T = lin_func_and_dbl(s.T, t);
+            multiply_by_lin_func_value(f, t, s.P.x, s.ny);
+        }
 
         if (naf & 1)
         {
-            T = lin_func_and_add(T, Q, t);
-            multiply_by_lin_func_value(f, t, P.x, P.y);
+            for (auto& s : pairs)
+            {
+                s.T = lin_func_and_add(s.T, s.Q, t);
+                multiply_by_lin_func_value(f, t, s.P.x, s.P.y);
+            }
         }
         else if (naf & 2)
         {
-            T = lin_func_and_add(T, nQ, t);
-            multiply_by_lin_func_value(f, t, P.x, P.y);
+            for (auto& s : pairs)
+            {
+                s.T = lin_func_and_add(s.T, s.nQ, t);
+                multiply_by_lin_func_value(f, t, s.P.x, s.P.y);
+            }
         }
         naf >>= 2;
     }
 
-    // Frobenius endomorphism for point Q from twisted curve over Fq2 field.
-    // It's essentially untwist -> frobenius -> twist chain of transformation.
-    const auto Q1 = endomorphism<1>(Q);
+    // Post-loop Frobenius endomorphism steps, one set per pair.
+    for (auto& s : pairs)
+    {
+        // untwist -> Frobenius -> twist
+        const auto Q1 = endomorphism<1>(s.Q);
+        // untwist -> Frobenius^2 -> twist, plus negation per Miller-loop spec
+        const auto nQ2 = -endomorphism<2>(s.Q);
 
-    // Similar to above one. It makes untwist -> frobenius^2 -> twist transformation plus
-    // negation according to miller loop spec.
-    const auto nQ2 = -endomorphism<2>(Q);
+        s.T = lin_func_and_add(s.T, Q1, t);
+        multiply_by_lin_func_value(f, t, s.P.x, s.P.y);
 
-    T = lin_func_and_add(T, Q1, t);
-    multiply_by_lin_func_value(f, t, P.x, P.y);
-
-    lin_func(T, nQ2, t);
-    multiply_by_lin_func_value(f, t, P.x, P.y);
+        lin_func(s.T, nQ2, t);
+        multiply_by_lin_func_value(f, t, s.P.x, s.P.y);
+    }
 
     return f;
 }
@@ -133,7 +157,8 @@ std::optional<bool> pairing_check(std::span<const std::pair<Point, ExtPoint>> pa
     if (pairs.empty())
         return true;
 
-    auto f = Fq12::one();
+    std::vector<MillerPairState> states;
+    states.reserve(pairs.size());
 
     for (const auto& [p, q] : pairs)
     {
@@ -161,12 +186,15 @@ std::optional<bool> pairing_check(std::span<const std::pair<Point, ExtPoint>> pa
         if (!g2_is_inf && (!is_on_twisted_curve(Q_aff) || !g2_subgroup_check(Q_aff)))
             return std::nullopt;
 
-        // If any of the points is infinity it means that miller_loop returns 1. so we can skip it.
+        // Skip pairs where either point is at infinity — they contribute 1 to the product.
         if (!g1_is_inf && !g2_is_inf)
-            f = f * miller_loop(Q_aff, P_aff);
+            states.push_back({ecc::JacPoint<Fq2>::from(Q_aff), Q_aff, -Q_aff, P_aff, -P_aff.y});
     }
 
-    // final exp is calculated on accumulated value
+    if (states.empty())
+        return true;
+
+    const auto f = multi_miller_loop(states);
     return final_exp(f) == Fq12::one();
 }
 }  // namespace evmmax::bn254

--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -49,41 +49,66 @@ inline constexpr int8_t ATE_LOOP_COUNT_DIGITS[] = {
 };
 // clang-format on
 
-/// Miller loop according to https://eprint.iacr.org/2010/354.pdf Algorithm 1.
-Fq12 miller_loop(const ecc::AffinePoint<E2>& Q, const ecc::AffinePoint<Curve>& P) noexcept
+/// Miller loop for all the pairs at once,
+/// according to https://eprint.iacr.org/2010/354.pdf Algorithm 1.
+Fq12 multi_miller_loop(std::span<const std::pair<AffinePoint, ExtPoint>> pairs) noexcept
 {
-    auto T = ecc::ProjPoint{Q};  // Applies the omitted leading digit 1 of the loop count.
-    const auto nQ = -Q;
+    // The running point of every pair; starting at Q applies the omitted leading digit 1.
+    // TODO: Avoid the allocation: at most 492 pairs fit the transaction gas limit (EIP-7825).
+    // TODO: Caching -Q and -P.y next to the running points may be beneficial.
+    std::vector<ecc::ProjPoint<E2>> Ts;
+    Ts.reserve(pairs.size());
+    for (const auto& [_, Q] : pairs)
+        Ts.emplace_back(Q);
+
     auto f = Fq12::one();
     std::array<Fq2, 3> t;
-    const auto ny = -P.y;
 
     for (const auto digit : ATE_LOOP_COUNT_DIGITS)
     {
-        T = lin_func_and_dbl(T, t);
+        // The f <- f^2 * line recurrence is multiplicative over the pairs, so a single
+        // accumulator serves them all: one squaring per iteration instead of one per pair.
         f = square(f);
-        multiply_by_lin_func_value(f, t, P.x, ny);
 
-        if (digit != 0)
+        for (size_t j = 0; j != pairs.size(); ++j)
         {
-            T = lin_func_and_add(T, digit > 0 ? Q : nQ, t);
-            multiply_by_lin_func_value(f, t, P.x, P.y);
+            const auto& [P, Q] = pairs[j];
+            if (P == 0 || Q == 0)  // A pair with a point at infinity contributes 1.
+                continue;
+
+            auto& T = Ts[j];
+            T = lin_func_and_dbl(T, t);
+            multiply_by_lin_func_value(f, t, P.x, -P.y);
+
+            if (digit != 0)
+            {
+                T = lin_func_and_add(T, digit > 0 ? Q : -Q, t);
+                multiply_by_lin_func_value(f, t, P.x, P.y);
+            }
         }
     }
 
-    // Frobenius endomorphism for point Q from twisted curve over Fq2 field.
-    // It's essentially untwist -> frobenius -> twist chain of transformation.
-    const auto Q1 = endomorphism<1>(Q);
+    for (size_t j = 0; j != pairs.size(); ++j)
+    {
+        const auto& [P, Q] = pairs[j];
+        if (P == 0 || Q == 0)
+            continue;
 
-    // Similar to above one. It makes untwist -> frobenius^2 -> twist transformation plus
-    // negation according to miller loop spec.
-    const auto nQ2 = -endomorphism<2>(Q);
+        // Frobenius endomorphism for point Q from twisted curve over Fq2 field.
+        // It's essentially untwist -> frobenius -> twist chain of transformation.
+        const auto Q1 = endomorphism<1>(Q);
 
-    T = lin_func_and_add(T, Q1, t);
-    multiply_by_lin_func_value(f, t, P.x, P.y);
+        // Similar to above one. It makes untwist -> frobenius^2 -> twist transformation plus
+        // negation according to miller loop spec.
+        const auto nQ2 = -endomorphism<2>(Q);
 
-    lin_func(T, nQ2, t);
-    multiply_by_lin_func_value(f, t, P.x, P.y);
+        auto& T = Ts[j];
+        T = lin_func_and_add(T, Q1, t);
+        multiply_by_lin_func_value(f, t, P.x, P.y);
+
+        lin_func(T, nQ2, t);
+        multiply_by_lin_func_value(f, t, P.x, P.y);
+    }
 
     return f;
 }
@@ -131,26 +156,18 @@ std::optional<bool> pairing_check(std::span<const std::pair<AffinePoint, ExtPoin
     if (pairs.empty())
         return true;
 
-    auto f = Fq12::one();
-
     for (const auto& [p, q] : pairs)
     {
         if (!validate(p))
             return std::nullopt;
 
-        const bool g2_is_inf = q == 0;
-
         // Verify that Q is on the curve and in the proper subgroup. This subgroup is much smaller
         // than the group containing all the points from the twisted curve over Fq2 field.
-        if (!g2_is_inf && (!is_on_twisted_curve(q) || !g2_subgroup_check(q)))
+        // TODO: Fold q != 0 check into curve/subgroup checks.
+        if (q != 0 && (!is_on_twisted_curve(q) || !g2_subgroup_check(q)))
             return std::nullopt;
-
-        // If either point is infinity, miller_loop returns 1, so skip it.
-        if (p != 0 && !g2_is_inf)
-            f = f * miller_loop(q, p);
     }
 
-    // final exp is calculated on accumulated value
-    return final_exp(f) == Fq12::one();
+    return final_exp(multi_miller_loop(pairs)) == Fq12::one();
 }
 }  // namespace evmmax::bn254


### PR DESCRIPTION
pairing_check ran an independent Miller loop per pair, each paying 64 Fq12
squarings, and multiplied the results. The f <- f^2 * line recurrence is
multiplicative over the pairs, so a single accumulator serves them all,
dropping (N-1)*64 squarings and the N-1 Fq12 multiplications that combined
the per-pair results.

Measured on the ECPAIRING benchmark inputs, which carry 2 to 4 pairs:
instructions -13.4%, cycles -13.7%, IPC unchanged at 1.80. The saving grows
with the pair count, towards about a quarter of the cycles.

The only per-pair state the loop needs is the running point, so those are
held in a vector parallel to the input and the pairs with a point at
infinity are skipped in place. A single pair breaks even: the allocation
replaces the Fq12 multiplication that combined the per-pair results.
Building the running points up front also defers the Miller loop until
every pair has been validated, so an invalid pair no longer costs the
Miller loops of the pairs preceding it.
