### PR TITLE
crypto: Migrate BN254 pairing internals to AffinePoint<Curve>

### DIFF
--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -54,9 +54,9 @@ struct Curve
 
 using AffinePoint = ecc::AffinePoint<Curve>;
 
-using Point = ecc::Point<uint256>;
 /// Note that real part of G2 value goes first and imaginary part is the second. i.e (a + b*i)
 /// The pairing check precompile EVM ABI presumes that imaginary part goes first.
+/// TODO: Migrate G2 input handling to AffinePoint<E2> for symmetry with G1.
 using ExtPoint = ecc::Point<std::pair<uint256, uint256>>;
 
 /// Validates that point is from the bn254 curve group
@@ -75,6 +75,6 @@ AffinePoint mul(const AffinePoint& pt, const uint256& c) noexcept;
 ///               followed by a point from twisted curve G2 group over extension field Fq^2.
 /// @return       `true` when  ∏e(vG2[i], vG1[i]) == 1 for i in [0, n] else `false`.
 ///               std::nullopt on error.
-std::optional<bool> pairing_check(std::span<const std::pair<Point, ExtPoint>> pairs) noexcept;
+std::optional<bool> pairing_check(std::span<const std::pair<AffinePoint, ExtPoint>> pairs) noexcept;
 
 }  // namespace evmmax::bn254

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -141,8 +141,11 @@ struct AffinePoint
     AffinePoint() = default;
     constexpr AffinePoint(const FE& x_, const FE& y_) noexcept : x{x_}, y{y_} {}
 
-    /// Create the point from literal values.
-    consteval AffinePoint(const Curve::uint_type& x_value, const Curve::uint_type& y_value) noexcept
+    /// Create the point from literal values. Only available when Curve defines uint_type.
+    template <typename C = Curve>
+        requires requires { typename C::uint_type; }
+    consteval AffinePoint(
+        const typename C::uint_type& x_value, const typename C::uint_type& y_value) noexcept
       : x{x_value}, y{y_value}
     {}
 
@@ -152,6 +155,8 @@ struct AffinePoint
     {
         return p == AffinePoint{};
     }
+
+    friend constexpr AffinePoint operator-(const AffinePoint& p) noexcept { return {p.x, -p.y}; }
 
     static constexpr std::optional<AffinePoint> from_bytes(
         std::span<const uint8_t, sizeof(FE) * 2> b) noexcept
@@ -185,11 +190,6 @@ struct ProjPoint
     constexpr explicit ProjPoint(const AffinePoint<Curve>& p) noexcept
       : x{p.x}, y{p.y}, z{FE::one()}
     {}
-
-    /// Constructs a projective point from the legacy untyped Point<T> form.
-    /// Prefer the AffinePoint<Curve> constructor for new code; this exists
-    /// to bridge call sites that haven't migrated yet.
-    static constexpr ProjPoint from(const Point<FE>& p) noexcept { return {p.x, p.y, FE::one()}; }
 
     friend constexpr bool operator==(const ProjPoint& p, zero_t) noexcept { return p.z == 0; }
 

--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -5,7 +5,6 @@
 #include "../../bn254.hpp"
 #include "fields.hpp"
 #include "utils.hpp"
-#include <vector>
 
 namespace evmmax::bn254
 {
@@ -45,10 +44,10 @@ inline constexpr auto ATE_LOOP_COUNT_NAF = 0x1120804220120081204008212022011_u12
 inline constexpr int LOG_ATE_LOOP_COUNT = 63;
 
 /// Miller loop according to https://eprint.iacr.org/2010/354.pdf Algorithm 1.
-Fq12 miller_loop(const ecc::Point<Fq2>& Q, const ecc::Point<Fq>& P) noexcept
+Fq12 miller_loop(const ecc::AffinePoint<E2>& Q, const ecc::AffinePoint<Curve>& P) noexcept
 {
-    auto T = ecc::ProjPoint<E2>::from(Q);
-    auto nQ = -Q;
+    auto T = ecc::ProjPoint{Q};
+    const auto nQ = -Q;
     auto f = Fq12::one();
     std::array<Fq2, 3> t;
     auto naf = ATE_LOOP_COUNT_NAF;
@@ -128,7 +127,7 @@ Fq12 final_exp(const Fq12& v) noexcept
 }
 }  // namespace
 
-std::optional<bool> pairing_check(std::span<const std::pair<Point, ExtPoint>> pairs) noexcept
+std::optional<bool> pairing_check(std::span<const std::pair<AffinePoint, ExtPoint>> pairs) noexcept
 {
     if (pairs.empty())
         return true;
@@ -137,24 +136,19 @@ std::optional<bool> pairing_check(std::span<const std::pair<Point, ExtPoint>> pa
 
     for (const auto& [p, q] : pairs)
     {
-        if (!is_field_element(p.x) || !is_field_element(p.y) || !is_field_element(q.x.first) ||
-            !is_field_element(q.x.second) || !is_field_element(q.y.first) ||
-            !is_field_element(q.y.second))
+        if (!is_field_element(q.x.first) || !is_field_element(q.x.second) ||
+            !is_field_element(q.y.first) || !is_field_element(q.y.second))
         {
             return std::nullopt;
         }
 
-        // Converts points' coefficients in Montgomery form.
-        const auto P_aff = ecc::Point<Fq>{Fq(p.x), Fq(p.y)};
-        const auto Q_aff = ecc::Point<Fq2>{
+        if (!validate(p))
+            return std::nullopt;
+
+        const auto Q_aff = ecc::AffinePoint<E2>{
             Fq2({Fq(q.x.first), Fq(q.x.second)}), Fq2({Fq(q.y.first), Fq(q.y.second)})};
 
-        const bool g1_is_inf = is_infinity(P_aff);
-        const bool g2_is_inf = g2_is_infinity(Q_aff);
-
-        // Verify that P in on curve. For this group it also means that P is in G1.
-        if (!g1_is_inf && !is_on_curve(P_aff))
-            return std::nullopt;
+        const bool g2_is_inf = Q_aff == 0;
 
         // Verify that Q in on curve and in proper subgroup. This subgroup is much smaller than
         // group containing all the points from twisted curve over Fq2 field.
@@ -162,8 +156,8 @@ std::optional<bool> pairing_check(std::span<const std::pair<Point, ExtPoint>> pa
             return std::nullopt;
 
         // If any of the points is infinity it means that miller_loop returns 1. so we can skip it.
-        if (!g1_is_inf && !g2_is_inf)
-            f = f * miller_loop(Q_aff, P_aff);
+        if (p != 0 && !g2_is_inf)
+            f = f * miller_loop(Q_aff, p);
     }
 
     // final exp is calculated on accumulated value

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -73,36 +73,13 @@ constexpr bool is_field_element(const uint256& v)
     return v < Curve::FIELD_PRIME;
 }
 
-/// Verifies that affine point is on the curve (not twisted)
-constexpr bool is_on_curve(const ecc::Point<Fq>& p) noexcept
-{
-    // TODO(C++23): make static
-    constexpr auto B = Fq(3);
-
-    const auto x3 = p.x * p.x * p.x;
-    const auto y2 = p.y * p.y;
-    return y2 == x3 + B;
-}
-
 /// Verifies that affine point over Fq^2 field is on the twisted curve.
-constexpr bool is_on_twisted_curve(const evmmax::ecc::Point<Fq2>& p)
+constexpr bool is_on_twisted_curve(const evmmax::ecc::AffinePoint<E2>& p)
 {
     const auto x3 = p.x * p.x * p.x;
     const auto y2 = p.y * p.y;
 
     return y2 == x3 + Fq6Config::_3_ksi_inv;
-}
-
-/// Verifies that affine point over the base field is infinity.
-constexpr bool is_infinity(const evmmax::ecc::Point<Fq>& p)
-{
-    return p.x == 0 && p.y == 0;
-}
-
-/// Verifies that affine point over the Fq^2 extended field is infinity.
-constexpr bool g2_is_infinity(const evmmax::ecc::Point<Fq2>& p)
-{
-    return p.x == Fq2::zero() && p.y == Fq2::zero();
 }
 
 // Frobenius endomorphism related functions are implemented based on
@@ -143,7 +120,7 @@ constexpr ecc::ProjPoint<E2> endomorphism(const ecc::ProjPoint<E2>& p) noexcept
 /// over Fq^2 extended field.
 /// This specialisation computes Frobenius and Frobenius^3
 template <int P>
-constexpr ecc::Point<Fq2> endomorphism(const ecc::Point<Fq2>& p) noexcept
+constexpr ecc::AffinePoint<E2> endomorphism(const ecc::AffinePoint<E2>& p) noexcept
     requires(P == 1 || P == 3)
 {
     return {
@@ -156,7 +133,7 @@ constexpr ecc::Point<Fq2> endomorphism(const ecc::Point<Fq2>& p) noexcept
 /// over Fq^2 extended field.
 /// This specialisation computes Frobenius^2
 template <int P>
-constexpr ecc::Point<Fq2> endomorphism(const ecc::Point<Fq2>& p) noexcept
+constexpr ecc::AffinePoint<E2> endomorphism(const ecc::AffinePoint<E2>& p) noexcept
     requires(P == 2)
 {
     return {
@@ -323,9 +300,9 @@ constexpr ecc::ProjPoint<E2> mul_by_X(const ecc::ProjPoint<E2>& a) noexcept
 
 /// Checks that point `p_aff` is in proper subgroup of points from twisted curve over Fq2 field.
 /// For more details see https://eprint.iacr.org/2022/348.pdf Example 1 from 3.1.2 Examples
-constexpr bool g2_subgroup_check(const ecc::Point<Fq2>& p_aff)
+constexpr bool g2_subgroup_check(const ecc::AffinePoint<E2>& p_aff)
 {
-    const auto p = ecc::ProjPoint<E2>::from(p_aff);
+    const auto p = ecc::ProjPoint<E2>{p_aff};
 
     const auto px = mul_by_X(p);
     const auto px1 = add(px, p);
@@ -379,7 +356,7 @@ constexpr ecc::ProjPoint<E2> lin_func_and_dbl(
 /// points on the curve (not twisted curve) evaluated at point P. Formula is simplified for P1.z
 /// == 1. For more details see https://notes.ethereum.org/@ipsilon/Hkn2a2qk0
 [[nodiscard]] constexpr ecc::ProjPoint<E2> lin_func_and_add(
-    const ecc::ProjPoint<E2>& P0, const ecc::Point<Fq2>& P1, std::array<Fq2, 3>& t) noexcept
+    const ecc::ProjPoint<E2>& P0, const ecc::AffinePoint<E2>& P1, std::array<Fq2, 3>& t) noexcept
 {
     const auto& x0 = P0.x;
     const auto& y0 = P0.y;
@@ -417,7 +394,7 @@ constexpr ecc::ProjPoint<E2> lin_func_and_dbl(
 /// points on the curve (not twisted curve) evaluated at point P. Formula is simplified for P1.z
 /// == 1. For more details see https://notes.ethereum.org/@ipsilon/Hkn2a2qk0
 constexpr void lin_func(
-    const ecc::ProjPoint<E2>& P0, const ecc::Point<Fq2>& P1, std::array<Fq2, 3>& t) noexcept
+    const ecc::ProjPoint<E2>& P0, const ecc::AffinePoint<E2>& P1, std::array<Fq2, 3>& t) noexcept
 {
     const auto& x0 = P0.x;
     const auto& y0 = P0.y;

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -546,21 +546,22 @@ ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8
     if (input_size % PAIR_SIZE != 0)
         return {EVMC_PRECOMPILE_FAILURE, 0};
 
-    std::vector<std::pair<evmmax::bn254::Point, evmmax::bn254::ExtPoint>> pairs;
+    std::vector<std::pair<evmmax::bn254::AffinePoint, evmmax::bn254::ExtPoint>> pairs;
     pairs.reserve(input_size / PAIR_SIZE);  // TODO: may throw std::bad_alloc.
     for (auto input_ptr = input; input_ptr != input + input_size; input_ptr += PAIR_SIZE)
     {
-        const evmmax::bn254::Point p{
-            intx::be::unsafe::load<intx::uint256>(input_ptr),
-            intx::be::unsafe::load<intx::uint256>(input_ptr + 32),
-        };
+        const auto p =
+            evmmax::bn254::AffinePoint::from_bytes(std::span<const uint8_t, 64>{input_ptr, 64});
+        if (!p.has_value()) [[unlikely]]
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+
         const evmmax::bn254::ExtPoint q{
             {intx::be::unsafe::load<intx::uint256>(input_ptr + 96),
                 intx::be::unsafe::load<intx::uint256>(input_ptr + 64)},
             {intx::be::unsafe::load<intx::uint256>(input_ptr + 160),
                 intx::be::unsafe::load<intx::uint256>(input_ptr + 128)},
         };
-        pairs.emplace_back(p, q);
+        pairs.emplace_back(*p, q);
     }
 
     const auto res = evmmax::bn254::pairing_check(pairs);

--- a/test/unittests/evmmax_bn254_pairing_test.cpp
+++ b/test/unittests/evmmax_bn254_pairing_test.cpp
@@ -11,14 +11,14 @@ using namespace intx;
 
 TEST(evmmax, bn254_pairing)
 {
-    const auto P1 = Point{
+    const auto P1 = AffinePoint{
         0x1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f59_u256,
         0x3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41_u256,
     };
     // -P1:
-    const auto nP1 = Point{P1.x, Curve::FIELD_PRIME - P1.y};
+    const auto nP1 = -P1;
     // P1 * 17:
-    const auto P1_17 = Point{
+    const auto P1_17 = AffinePoint{
         0x22980b2e458ec77e258b19ca3a7b46181f63c6536307acae03eea236f6919eeb_u256,
         0x4eab993e2ba2cca2b08c216645e3fbcf80ae67515b2c49806c17b90c9d3cad3_u256,
     };
@@ -61,7 +61,7 @@ TEST(evmmax, bn254_pairing)
 
     {
         // p1*q1 - (-p1*q1) = 0?
-        const std::vector<std::pair<Point, ExtPoint>> pairs{
+        const std::vector<std::pair<AffinePoint, ExtPoint>> pairs{
             {P1, Q1},
             {nP1, Q1},
         };
@@ -70,7 +70,7 @@ TEST(evmmax, bn254_pairing)
 
     {
         // p1*q1 - (p1*-q1) = 0?
-        const std::vector<std::pair<Point, ExtPoint>> pairs{
+        const std::vector<std::pair<AffinePoint, ExtPoint>> pairs{
             {P1, Q1},
             {P1, nQ1},
         };
@@ -79,7 +79,7 @@ TEST(evmmax, bn254_pairing)
 
     {
         // p1*17*q1 - (p1*-q1*16) = 0?
-        const std::vector<std::pair<Point, ExtPoint>> pairs{
+        const std::vector<std::pair<AffinePoint, ExtPoint>> pairs{
             {P1_17, Q1},
             {P1, nQ1_16},
         };
@@ -88,7 +88,7 @@ TEST(evmmax, bn254_pairing)
 
     {
         // p1*17 * q1 - (p1 * -q1*17) = 0?
-        const std::vector<std::pair<Point, ExtPoint>> pairs{
+        const std::vector<std::pair<AffinePoint, ExtPoint>> pairs{
             {P1_17, Q1},
             {P1, nQ1_17},
         };
@@ -103,7 +103,7 @@ TEST(evmmax, bn254_pairing)
 
 TEST(evmmax, bn254_pairing_invalid_input)
 {
-    const std::vector<std::pair<Point, ExtPoint>> valid_input{{
+    const std::vector<std::pair<AffinePoint, ExtPoint>> valid_input{{
         {
             0x22980b2e458ec77e258b19ca3a7b46181f63c6536307acae03eea236f6919eeb_u256,
             0x4eab993e2ba2cca2b08c216645e3fbcf80ae67515b2c49806c17b90c9d3cad3_u256,
@@ -125,13 +125,6 @@ TEST(evmmax, bn254_pairing_invalid_input)
     {
         // Coordinate not a field element
         auto input = valid_input;
-        input[0].first.x = Curve::FIELD_PRIME;
-        EXPECT_EQ(pairing_check(input), std::nullopt);
-    }
-
-    {
-        // Coordinate not a field element
-        auto input = valid_input;
         input[0].second.x.second = Curve::FIELD_PRIME;
         EXPECT_EQ(pairing_check(input), std::nullopt);
     }
@@ -139,7 +132,7 @@ TEST(evmmax, bn254_pairing_invalid_input)
     {
         // Point P (G1) not on curve
         auto input = valid_input;
-        input[0].first.x += 1;
+        input[0].first.x += Curve::Fp{1};
         EXPECT_EQ(pairing_check(input), std::nullopt);
     }
 
@@ -173,7 +166,7 @@ TEST(evmmax, bn254_pairing_invalid_input)
 TEST(evmmax_bn254, evm_codes_example)
 {
     // Pair 1
-    const auto p1 = Point{
+    const auto p1 = AffinePoint{
         0x2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da_u256,
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
@@ -189,7 +182,7 @@ TEST(evmmax_bn254, evm_codes_example)
     };
 
     // Pair 2
-    const auto p2 = Point{
+    const auto p2 = AffinePoint{
         0x0000000000000000000000000000000000000000000000000000000000000001_u256,
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
@@ -204,7 +197,7 @@ TEST(evmmax_bn254, evm_codes_example)
         },
     };
 
-    const std::vector<std::pair<Point, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};
+    const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};
     const auto result = pairing_check(pairs);
 
     ASSERT_TRUE(result.has_value()) << "Pairing check should return a value.";
@@ -214,7 +207,7 @@ TEST(evmmax_bn254, evm_codes_example)
 TEST(evmmax_bn254, evm_codes_example_changed_order)
 {
     // Pair 1
-    const auto p1 = Point{
+    const auto p1 = AffinePoint{
         0x2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da_u256,
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
@@ -230,7 +223,7 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
     };
 
     // Pair 2
-    const auto p2 = Point{
+    const auto p2 = AffinePoint{
         0x0000000000000000000000000000000000000000000000000000000000000001_u256,
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
@@ -245,7 +238,7 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
         },
     };
 
-    const std::vector<std::pair<Point, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};
+    const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};
     const auto result = pairing_check(pairs);
 
     ASSERT_TRUE(!result.has_value())


### PR DESCRIPTION
The pairing module's affine point arguments used the legacy untyped ecc::Point<T> while the rest of the precompile already uses the curve-parameterised ecc::AffinePoint<Curve>. Migrate Point<> to AffinePoint<>.