### PR TITLE
crypto: Migrate ExtPoint to AffinePoint<E2> 

### DIFF
--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ecc.hpp"
+#include "pairing/field_template.hpp"
 #include <optional>
 #include <span>
 #include <vector>
@@ -52,12 +53,30 @@ struct Curve
     /// @}
 };
 
+using Fq = Curve::Fp;
+
 using AffinePoint = ecc::AffinePoint<Curve>;
 
-/// Note that real part of G2 value goes first and imaginary part is the second. i.e (a + b*i)
-/// The pairing check precompile EVM ABI presumes that imaginary part goes first.
-/// TODO: Migrate G2 input handling to AffinePoint<E2> for symmetry with G1.
-using ExtPoint = ecc::Point<std::pair<uint256, uint256>>;
+/// Specifies Fq² extension field for bn254 curve. Base field extended with irreducible `u² + 1`
+/// polynomial over the base field. `u` is the Fq² element.
+struct Fq2Config
+{
+    using BaseFieldT = Fq;
+    using ValueT = Fq;
+    static constexpr auto DEGREE = 2;
+};
+using Fq2 = ecc::ExtFieldElem<Fq2Config>;
+
+/// The BN254 twisted curve E₂: y² = x³ + b/ξ over Fq². G2 lives here.
+/// Note: coefficient order is (real, imaginary). The pairing-check EVM ABI feeds
+/// the imaginary part first, so the boundary swaps before constructing Fq2 values.
+struct E2
+{
+    using Fp = Fq2;
+    static constexpr auto A = 0;
+};
+
+using ExtPoint = ecc::AffinePoint<E2>;
 
 /// Validates that point is from the bn254 curve group
 ///

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -57,19 +57,18 @@ using Fq = Curve::Fp;
 
 using AffinePoint = ecc::AffinePoint<Curve>;
 
-/// Specifies Fq² extension field for bn254 curve. Base field extended with irreducible `u² + 1`
-/// polynomial over the base field. `u` is the Fq² element.
+/// Fq² extension field config: base field extended by the irreducible `u² + 1`.
+/// Stays in this namespace so ADL finds multiply()/inverse() (defined in pairing/bn254/fields.hpp).
 struct Fq2Config
 {
     using BaseFieldT = Fq;
     using ValueT = Fq;
     static constexpr auto DEGREE = 2;
 };
+/// Fq² element with coefficients in (real, imaginary) order.
 using Fq2 = ecc::ExtFieldElem<Fq2Config>;
 
 /// The BN254 twisted curve E₂: y² = x³ + b/ξ over Fq². G2 lives here.
-/// Note: coefficient order is (real, imaginary). The pairing-check EVM ABI feeds
-/// the imaginary part first, so the boundary swaps before constructing Fq2 values.
 struct E2
 {
     using Fp = Fq2;

--- a/lib/evmone_precompiles/pairing/bn254/fields.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/fields.hpp
@@ -10,19 +10,9 @@
 namespace evmmax::bn254
 {
 using namespace intx;
-using Fq = Curve::Fp;
 
 // Extension fields implemented based on https://hackmd.io/@jpw/bn254#Field-extension-towers
-
-/// Specifies Fq^2 extension field for bn254 curve. Base field extended with irreducible `u^2 + 1`
-/// polynomial over the base field. `u` is the Fq^2 element.
-struct Fq2Config
-{
-    using BaseFieldT = Fq;
-    using ValueT = Fq;
-    static constexpr auto DEGREE = 2;
-};
-using Fq2 = ecc::ExtFieldElem<Fq2Config>;
+// Fq, Fq2Config, Fq2, and E2 live in bn254.hpp to be reachable from the precompile boundary.
 
 /// Specifies Fq^6 extension field for bn254 curve. Fq^2 field extended with irreducible
 /// `v^3 - (9 + u)` polynomial over the Fq^2 field. `v` is the Fq^6 field element.
@@ -50,13 +40,6 @@ struct Fq12Config
     static constexpr uint8_t DEGREE = 2;
 };
 using Fq12 = ecc::ExtFieldElem<Fq12Config>;
-
-/// The BN254 twisted curve E₂: y² = x³ + b/ξ over Fq².
-struct E2
-{
-    using Fp = Fq2;
-    static constexpr auto A = 0;
-};
 
 /// Multiplies two Fq^2 field elements
 constexpr Fq2 multiply(const Fq2& a, const Fq2& b)

--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -141,8 +141,8 @@ std::optional<bool> pairing_check(std::span<const std::pair<AffinePoint, ExtPoin
 
         const bool g2_is_inf = q == 0;
 
-        // Verify Q is on the twisted curve and in the proper subgroup. The subgroup is much
-        // smaller than the group of all points on the twisted curve over Fq².
+        // G2 must be on the twisted curve and in the small subgroup (Q is part of the full
+        // twisted-curve group otherwise, which would still satisfy is_on_twisted_curve alone).
         if (!g2_is_inf && (!is_on_twisted_curve(q) || !g2_subgroup_check(q)))
             return std::nullopt;
 

--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -141,8 +141,8 @@ std::optional<bool> pairing_check(std::span<const std::pair<AffinePoint, ExtPoin
 
         const bool g2_is_inf = q == 0;
 
-        // G2 must be on the twisted curve and in the small subgroup (Q is part of the full
-        // twisted-curve group otherwise, which would still satisfy is_on_twisted_curve alone).
+        // Verify that Q is on the curve and in the proper subgroup. This subgroup is much smaller
+        // than the group containing all the points from the twisted curve over Fq2 field.
         if (!g2_is_inf && (!is_on_twisted_curve(q) || !g2_subgroup_check(q)))
             return std::nullopt;
 

--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -136,28 +136,19 @@ std::optional<bool> pairing_check(std::span<const std::pair<AffinePoint, ExtPoin
 
     for (const auto& [p, q] : pairs)
     {
-        if (!is_field_element(q.x.first) || !is_field_element(q.x.second) ||
-            !is_field_element(q.y.first) || !is_field_element(q.y.second))
-        {
-            return std::nullopt;
-        }
-
         if (!validate(p))
             return std::nullopt;
 
-        const auto Q_aff = ecc::AffinePoint<E2>{
-            Fq2({Fq(q.x.first), Fq(q.x.second)}), Fq2({Fq(q.y.first), Fq(q.y.second)})};
+        const bool g2_is_inf = q == 0;
 
-        const bool g2_is_inf = Q_aff == 0;
-
-        // Verify that Q in on curve and in proper subgroup. This subgroup is much smaller than
-        // group containing all the points from twisted curve over Fq2 field.
-        if (!g2_is_inf && (!is_on_twisted_curve(Q_aff) || !g2_subgroup_check(Q_aff)))
+        // Verify Q is on the twisted curve and in the proper subgroup. The subgroup is much
+        // smaller than the group of all points on the twisted curve over Fq².
+        if (!g2_is_inf && (!is_on_twisted_curve(q) || !g2_subgroup_check(q)))
             return std::nullopt;
 
-        // If any of the points is infinity it means that miller_loop returns 1. so we can skip it.
+        // If either point is infinity, miller_loop returns 1, so skip it.
         if (p != 0 && !g2_is_inf)
-            f = f * miller_loop(Q_aff, p);
+            f = f * miller_loop(q, p);
     }
 
     // final exp is calculated on accumulated value

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -7,45 +7,40 @@
 
 namespace evmmax::bn254
 {
-consteval Fq2 make_fq2(const uint256& a, const uint256& b) noexcept
-{
-    return Fq2({Fq(a), Fq(b)});
-}
-
 /// Defines coefficients needed for fast Frobenius endomorphism computation.
 /// For more ref see https://eprint.iacr.org/2010/354.pdf 3.2 Frobenius Operator.
 inline constexpr std::array<std::array<Fq2, 5>, 3> FROBENIUS_COEFFS = {
     {
         {
-            make_fq2(0x1284b71c2865a7dfe8b99fdd76e68b605c521e08292f2176d60b35dadcc9e470_u256,
-                0x246996f3b4fae7e6a6327cfe12150b8e747992778eeec7e5ca5cf05f80f362ac_u256),
-            make_fq2(0x2fb347984f7911f74c0bec3cf559b143b78cc310c2c3330c99e39557176f553d_u256,
-                0x16c9e55061ebae204ba4cc8bd75a079432ae2a1d0b7c9dce1665d51c640fcba2_u256),
-            make_fq2(0x63cf305489af5dcdc5ec698b6e2f9b9dbaae0eda9c95998dc54014671a0135a_u256,
-                0x7c03cbcac41049a0704b5a7ec796f2b21807dc98fa25bd282d37f632623b0e3_u256),
-            make_fq2(0x5b54f5e64eea80180f3c0b75a181e84d33365f7be94ec72848a1f55921ea762_u256,
-                0x2c145edbe7fd8aee9f3a80b03b0b1c923685d2ea1bdec763c13b4711cd2b8126_u256),
-            make_fq2(0x183c1e74f798649e93a3661a4353ff4425c459b55aa1bd32ea2c810eab7692f_u256,
-                0x12acf2ca76fd0675a27fb246c7729f7db080cb99678e2ac024c6b8ee6e0c2c4b_u256),
+            Fq2{0x1284b71c2865a7dfe8b99fdd76e68b605c521e08292f2176d60b35dadcc9e470_u256,
+                0x246996f3b4fae7e6a6327cfe12150b8e747992778eeec7e5ca5cf05f80f362ac_u256},
+            Fq2{0x2fb347984f7911f74c0bec3cf559b143b78cc310c2c3330c99e39557176f553d_u256,
+                0x16c9e55061ebae204ba4cc8bd75a079432ae2a1d0b7c9dce1665d51c640fcba2_u256},
+            Fq2{0x63cf305489af5dcdc5ec698b6e2f9b9dbaae0eda9c95998dc54014671a0135a_u256,
+                0x7c03cbcac41049a0704b5a7ec796f2b21807dc98fa25bd282d37f632623b0e3_u256},
+            Fq2{0x5b54f5e64eea80180f3c0b75a181e84d33365f7be94ec72848a1f55921ea762_u256,
+                0x2c145edbe7fd8aee9f3a80b03b0b1c923685d2ea1bdec763c13b4711cd2b8126_u256},
+            Fq2{0x183c1e74f798649e93a3661a4353ff4425c459b55aa1bd32ea2c810eab7692f_u256,
+                0x12acf2ca76fd0675a27fb246c7729f7db080cb99678e2ac024c6b8ee6e0c2c4b_u256},
         },
         {
-            make_fq2(0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd49_u256, 0),
-            make_fq2(0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd48_u256, 0),
-            make_fq2(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46_u256, 0),
-            make_fq2(0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177fffffe_u256, 0),
-            make_fq2(0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177ffffff_u256, 0),
+            Fq2{0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd49_u256, 0_u256},
+            Fq2{0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd48_u256, 0_u256},
+            Fq2{0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46_u256, 0_u256},
+            Fq2{0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177fffffe_u256, 0_u256},
+            Fq2{0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177ffffff_u256, 0_u256},
         },
         {
-            make_fq2(0x19dc81cfcc82e4bbefe9608cd0acaa90894cb38dbe55d24ae86f7d391ed4a67f_u256,
-                0xabf8b60be77d7306cbeee33576139d7f03a5e397d439ec7694aa2bf4c0c101_u256),
-            make_fq2(0x856e078b755ef0abaff1c77959f25ac805ffd3d5d6942d37b746ee87bdcfb6d_u256,
-                0x4f1de41b3d1766fa9f30e6dec26094f0fdf31bf98ff2631380cab2baaa586de_u256),
-            make_fq2(0x2a275b6d9896aa4cdbf17f1dca9e5ea3bbd689a3bea870f45fcc8ad066dce9ed_u256,
-                0x28a411b634f09b8fb14b900e9507e9327600ecc7d8cf6ebab94d0cb3b2594c64_u256),
-            make_fq2(0xbc58c6611c08dab19bee0f7b5b2444ee633094575b06bcb0e1a92bc3ccbf066_u256,
-                0x23d5e999e1910a12feb0f6ef0cd21d04a44a9e08737f96e55fe3ed9d730c239f_u256),
-            make_fq2(0x13c49044952c0905711699fa3b4d3f692ed68098967c84a5ebde847076261b43_u256,
-                0x16db366a59b1dd0b9fb1b2282a48633d3e2ddaea200280211f25041384282499_u256),
+            Fq2{0x19dc81cfcc82e4bbefe9608cd0acaa90894cb38dbe55d24ae86f7d391ed4a67f_u256,
+                0xabf8b60be77d7306cbeee33576139d7f03a5e397d439ec7694aa2bf4c0c101_u256},
+            Fq2{0x856e078b755ef0abaff1c77959f25ac805ffd3d5d6942d37b746ee87bdcfb6d_u256,
+                0x4f1de41b3d1766fa9f30e6dec26094f0fdf31bf98ff2631380cab2baaa586de_u256},
+            Fq2{0x2a275b6d9896aa4cdbf17f1dca9e5ea3bbd689a3bea870f45fcc8ad066dce9ed_u256,
+                0x28a411b634f09b8fb14b900e9507e9327600ecc7d8cf6ebab94d0cb3b2594c64_u256},
+            Fq2{0xbc58c6611c08dab19bee0f7b5b2444ee633094575b06bcb0e1a92bc3ccbf066_u256,
+                0x23d5e999e1910a12feb0f6ef0cd21d04a44a9e08737f96e55fe3ed9d730c239f_u256},
+            Fq2{0x13c49044952c0905711699fa3b4d3f692ed68098967c84a5ebde847076261b43_u256,
+                0x16db366a59b1dd0b9fb1b2282a48633d3e2ddaea200280211f25041384282499_u256},
         },
     },
 };

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -9,44 +9,42 @@ namespace evmmax::bn254
 {
 /// Defines coefficients needed for fast Frobenius endomorphism computation.
 /// For more ref see https://eprint.iacr.org/2010/354.pdf 3.2 Frobenius Operator.
-inline constexpr std::array<std::array<Fq2, 5>, 3> FROBENIUS_COEFFS = {
-    {
-        {
-            Fq2{0x1284b71c2865a7dfe8b99fdd76e68b605c521e08292f2176d60b35dadcc9e470_u256,
-                0x246996f3b4fae7e6a6327cfe12150b8e747992778eeec7e5ca5cf05f80f362ac_u256},
-            Fq2{0x2fb347984f7911f74c0bec3cf559b143b78cc310c2c3330c99e39557176f553d_u256,
-                0x16c9e55061ebae204ba4cc8bd75a079432ae2a1d0b7c9dce1665d51c640fcba2_u256},
-            Fq2{0x63cf305489af5dcdc5ec698b6e2f9b9dbaae0eda9c95998dc54014671a0135a_u256,
-                0x7c03cbcac41049a0704b5a7ec796f2b21807dc98fa25bd282d37f632623b0e3_u256},
-            Fq2{0x5b54f5e64eea80180f3c0b75a181e84d33365f7be94ec72848a1f55921ea762_u256,
-                0x2c145edbe7fd8aee9f3a80b03b0b1c923685d2ea1bdec763c13b4711cd2b8126_u256},
-            Fq2{0x183c1e74f798649e93a3661a4353ff4425c459b55aa1bd32ea2c810eab7692f_u256,
-                0x12acf2ca76fd0675a27fb246c7729f7db080cb99678e2ac024c6b8ee6e0c2c4b_u256},
-        },
-        {
-            Fq2{0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd49_u256, 0_u256},
-            Fq2{0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd48_u256, 0_u256},
-            Fq2{0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46_u256, 0_u256},
-            Fq2{0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177fffffe_u256, 0_u256},
-            Fq2{0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177ffffff_u256, 0_u256},
-        },
-        {
-            Fq2{0x19dc81cfcc82e4bbefe9608cd0acaa90894cb38dbe55d24ae86f7d391ed4a67f_u256,
-                0xabf8b60be77d7306cbeee33576139d7f03a5e397d439ec7694aa2bf4c0c101_u256},
-            Fq2{0x856e078b755ef0abaff1c77959f25ac805ffd3d5d6942d37b746ee87bdcfb6d_u256,
-                0x4f1de41b3d1766fa9f30e6dec26094f0fdf31bf98ff2631380cab2baaa586de_u256},
-            Fq2{0x2a275b6d9896aa4cdbf17f1dca9e5ea3bbd689a3bea870f45fcc8ad066dce9ed_u256,
-                0x28a411b634f09b8fb14b900e9507e9327600ecc7d8cf6ebab94d0cb3b2594c64_u256},
-            Fq2{0xbc58c6611c08dab19bee0f7b5b2444ee633094575b06bcb0e1a92bc3ccbf066_u256,
-                0x23d5e999e1910a12feb0f6ef0cd21d04a44a9e08737f96e55fe3ed9d730c239f_u256},
-            Fq2{0x13c49044952c0905711699fa3b4d3f692ed68098967c84a5ebde847076261b43_u256,
-                0x16db366a59b1dd0b9fb1b2282a48633d3e2ddaea200280211f25041384282499_u256},
-        },
-    },
-};
+inline constexpr std::array<std::array<Fq2, 5>, 3> FROBENIUS_COEFFS = {{
+    {{
+        {0x1284b71c2865a7dfe8b99fdd76e68b605c521e08292f2176d60b35dadcc9e470_u256,
+            0x246996f3b4fae7e6a6327cfe12150b8e747992778eeec7e5ca5cf05f80f362ac_u256},
+        {0x2fb347984f7911f74c0bec3cf559b143b78cc310c2c3330c99e39557176f553d_u256,
+            0x16c9e55061ebae204ba4cc8bd75a079432ae2a1d0b7c9dce1665d51c640fcba2_u256},
+        {0x63cf305489af5dcdc5ec698b6e2f9b9dbaae0eda9c95998dc54014671a0135a_u256,
+            0x7c03cbcac41049a0704b5a7ec796f2b21807dc98fa25bd282d37f632623b0e3_u256},
+        {0x5b54f5e64eea80180f3c0b75a181e84d33365f7be94ec72848a1f55921ea762_u256,
+            0x2c145edbe7fd8aee9f3a80b03b0b1c923685d2ea1bdec763c13b4711cd2b8126_u256},
+        {0x183c1e74f798649e93a3661a4353ff4425c459b55aa1bd32ea2c810eab7692f_u256,
+            0x12acf2ca76fd0675a27fb246c7729f7db080cb99678e2ac024c6b8ee6e0c2c4b_u256},
+    }},
+    {{
+        {0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd49_u256, 0_u256},
+        {0x30644e72e131a0295e6dd9e7e0acccb0c28f069fbb966e3de4bd44e5607cfd48_u256, 0_u256},
+        {0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46_u256, 0_u256},
+        {0x000000000000000059e26bcea0d48bacd4f263f1acdb5c4f5763473177fffffe_u256, 0_u256},
+        {0x000000000000000059e26bcea0d48bacd4f263f1acdb5c4f5763473177ffffff_u256, 0_u256},
+    }},
+    {{
+        {0x19dc81cfcc82e4bbefe9608cd0acaa90894cb38dbe55d24ae86f7d391ed4a67f_u256,
+            0xabf8b60be77d7306cbeee33576139d7f03a5e397d439ec7694aa2bf4c0c101_u256},
+        {0x856e078b755ef0abaff1c77959f25ac805ffd3d5d6942d37b746ee87bdcfb6d_u256,
+            0x4f1de41b3d1766fa9f30e6dec26094f0fdf31bf98ff2631380cab2baaa586de_u256},
+        {0x2a275b6d9896aa4cdbf17f1dca9e5ea3bbd689a3bea870f45fcc8ad066dce9ed_u256,
+            0x28a411b634f09b8fb14b900e9507e9327600ecc7d8cf6ebab94d0cb3b2594c64_u256},
+        {0xbc58c6611c08dab19bee0f7b5b2444ee633094575b06bcb0e1a92bc3ccbf066_u256,
+            0x23d5e999e1910a12feb0f6ef0cd21d04a44a9e08737f96e55fe3ed9d730c239f_u256},
+        {0x13c49044952c0905711699fa3b4d3f692ed68098967c84a5ebde847076261b43_u256,
+            0x16db366a59b1dd0b9fb1b2282a48633d3e2ddaea200280211f25041384282499_u256},
+    }},
+}};
 
 /// Verifies that affine point over Fq^2 field is on the twisted curve.
-constexpr bool is_on_twisted_curve(const evmmax::ecc::AffinePoint<E2>& p)
+constexpr bool is_on_twisted_curve(const ecc::AffinePoint<E2>& p)
 {
     const auto x3 = p.x * p.x * p.x;
     const auto y2 = p.y * p.y;

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -50,12 +50,6 @@ inline constexpr std::array<std::array<Fq2, 5>, 3> FROBENIUS_COEFFS = {
     },
 };
 
-/// Verifies that value is in the proper prime field.
-constexpr bool is_field_element(const uint256& v)
-{
-    return v < Curve::FIELD_PRIME;
-}
-
 /// Verifies that affine point over Fq^2 field is on the twisted curve.
 constexpr bool is_on_twisted_curve(const evmmax::ecc::AffinePoint<E2>& p)
 {

--- a/lib/evmone_precompiles/pairing/field_template.hpp
+++ b/lib/evmone_precompiles/pairing/field_template.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <array>
+#include <concepts>
+#include <type_traits>
 
 namespace evmmax::ecc
 {
@@ -25,6 +27,17 @@ struct ExtFieldElem
     /// Create an element from an array of coefficients.
     /// TODO: This constructor may be optimized to avoid copying the array.
     explicit constexpr ExtFieldElem(const CoeffArrT& cs) noexcept : coeffs{cs} {}
+
+    /// Create an element from literal coefficient values, each converted to ValueT in
+    /// Montgomery form at compile time. Mirrors AffinePoint's literal constructor, so points
+    /// over extension fields can be written with plain integer literals (e.g. Fq2{a, b}).
+    /// Constrained to non-ValueT arguments so it never competes with the array constructor
+    /// (which all ValueT-typed constructions, e.g. Fq2({Fq(a), Fq(b)}), continue to use).
+    template <typename... Ts>
+        requires(sizeof...(Ts) == DEGREE && (std::constructible_from<ValueT, Ts> && ...) &&
+                 (!std::same_as<std::remove_cvref_t<Ts>, ValueT> && ...))
+    consteval ExtFieldElem(const Ts&... cs) noexcept : coeffs{ValueT{cs}...}
+    {}
 
     /// Returns the conjugate of a degree-2 extension field element: (a, b) → (a, -b).
     constexpr ExtFieldElem conjugate() const noexcept

--- a/lib/evmone_precompiles/pairing/field_template.hpp
+++ b/lib/evmone_precompiles/pairing/field_template.hpp
@@ -14,8 +14,8 @@ namespace evmmax::ecc
 template <typename ConfigT>
 struct ExtFieldElem
 {
-    using ValueT = typename ConfigT::ValueT;
-    using Base = typename ConfigT::BaseFieldT;
+    using ValueT = ConfigT::ValueT;
+    using Base = ConfigT::BaseFieldT;
     static constexpr auto DEGREE = ConfigT::DEGREE;
     using CoeffArrT = std::array<ValueT, DEGREE>;
 
@@ -28,11 +28,8 @@ struct ExtFieldElem
     /// TODO: This constructor may be optimized to avoid copying the array.
     explicit constexpr ExtFieldElem(const CoeffArrT& cs) noexcept : coeffs{cs} {}
 
-    /// Create an element from literal coefficient values, each converted to ValueT in
-    /// Montgomery form at compile time. Mirrors AffinePoint's literal constructor, so points
-    /// over extension fields can be written with plain integer literals (e.g. Fq2{a, b}).
-    /// Constrained to non-ValueT arguments so it never competes with the array constructor
-    /// (which all ValueT-typed constructions, e.g. Fq2({Fq(a), Fq(b)}), continue to use).
+    /// Create an element from literal coefficient values, converted to the underlying
+    /// representation at compile-time. Allows defining constants as e.g. Fq2{1, 2}.
     template <typename... Ts>
         requires(sizeof...(Ts) == DEGREE && (std::constructible_from<ValueT, Ts> && ...) &&
                  (!std::same_as<std::remove_cvref_t<Ts>, ValueT> && ...))

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -551,7 +551,7 @@ ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8
     for (auto input_ptr = input; input_ptr != input + input_size; input_ptr += PAIR_SIZE)
     {
         namespace bn = evmmax::bn254;
-        auto p = bn::AffinePoint::from_bytes(std::span<const uint8_t, 64>{input_ptr, 64});
+        const auto p = bn::AffinePoint::from_bytes(std::span<const uint8_t, 64>{input_ptr, 64});
         if (!p.has_value()) [[unlikely]]
             return {EVMC_PRECOMPILE_FAILURE, 0};
 
@@ -563,8 +563,8 @@ ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8
         const auto qy_imag = bn::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 128, 32});
         if (!qx_real || !qx_imag || !qy_real || !qy_imag) [[unlikely]]
             return {EVMC_PRECOMPILE_FAILURE, 0};
-        bn::ExtPoint q{bn::Fq2({*qx_real, *qx_imag}), bn::Fq2({*qy_real, *qy_imag})};
-        pairs.emplace_back(std::move(*p), std::move(q));
+        const bn::ExtPoint q{bn::Fq2({*qx_real, *qx_imag}), bn::Fq2({*qy_real, *qy_imag})};
+        pairs.emplace_back(*p, q);
     }
 
     const auto res = evmmax::bn254::pairing_check(pairs);

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -550,28 +550,21 @@ ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8
     pairs.reserve(input_size / PAIR_SIZE);  // TODO: may throw std::bad_alloc.
     for (auto input_ptr = input; input_ptr != input + input_size; input_ptr += PAIR_SIZE)
     {
-        const auto p =
-            evmmax::bn254::AffinePoint::from_bytes(std::span<const uint8_t, 64>{input_ptr, 64});
+        namespace bn = evmmax::bn254;
+        auto p = bn::AffinePoint::from_bytes(std::span<const uint8_t, 64>{input_ptr, 64});
         if (!p.has_value()) [[unlikely]]
             return {EVMC_PRECOMPILE_FAILURE, 0};
 
-        // G2 EVM ABI order: x.imag, x.real, y.imag, y.real (each 32 bytes).
-        // Fq2 coefficient order is (real, imaginary), so swap.
-        const auto qx_real =
-            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 96, 32});
-        const auto qx_imag =
-            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 64, 32});
-        const auto qy_real =
-            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 160, 32});
-        const auto qy_imag =
-            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 128, 32});
+        // G2 EVM ABI feeds the imaginary coefficient before the real one for each Fq²,
+        // so swap the offsets when reading into (real, imaginary) order.
+        const auto qx_real = bn::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 96, 32});
+        const auto qx_imag = bn::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 64, 32});
+        const auto qy_real = bn::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 160, 32});
+        const auto qy_imag = bn::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 128, 32});
         if (!qx_real || !qx_imag || !qy_real || !qy_imag) [[unlikely]]
             return {EVMC_PRECOMPILE_FAILURE, 0};
-        const evmmax::bn254::ExtPoint q{
-            evmmax::bn254::Fq2({*qx_real, *qx_imag}),
-            evmmax::bn254::Fq2({*qy_real, *qy_imag}),
-        };
-        pairs.emplace_back(*p, q);
+        bn::ExtPoint q{bn::Fq2({*qx_real, *qx_imag}), bn::Fq2({*qy_real, *qy_imag})};
+        pairs.emplace_back(std::move(*p), std::move(q));
     }
 
     const auto res = evmmax::bn254::pairing_check(pairs);

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -555,11 +555,21 @@ ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8
         if (!p.has_value()) [[unlikely]]
             return {EVMC_PRECOMPILE_FAILURE, 0};
 
+        // G2 EVM ABI order: x.imag, x.real, y.imag, y.real (each 32 bytes).
+        // Fq2 coefficient order is (real, imaginary), so swap.
+        const auto qx_real =
+            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 96, 32});
+        const auto qx_imag =
+            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 64, 32});
+        const auto qy_real =
+            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 160, 32});
+        const auto qy_imag =
+            evmmax::bn254::Fq::from_bytes(std::span<const uint8_t, 32>{input_ptr + 128, 32});
+        if (!qx_real || !qx_imag || !qy_real || !qy_imag) [[unlikely]]
+            return {EVMC_PRECOMPILE_FAILURE, 0};
         const evmmax::bn254::ExtPoint q{
-            {intx::be::unsafe::load<intx::uint256>(input_ptr + 96),
-                intx::be::unsafe::load<intx::uint256>(input_ptr + 64)},
-            {intx::be::unsafe::load<intx::uint256>(input_ptr + 160),
-                intx::be::unsafe::load<intx::uint256>(input_ptr + 128)},
+            evmmax::bn254::Fq2({*qx_real, *qx_imag}),
+            evmmax::bn254::Fq2({*qy_real, *qy_imag}),
         };
         pairs.emplace_back(*p, q);
     }

--- a/test/unittests/evmmax_bn254_pairing_test.cpp
+++ b/test/unittests/evmmax_bn254_pairing_test.cpp
@@ -24,26 +24,26 @@ TEST(evmmax, bn254_pairing)
     };
 
     const auto Q1 = ExtPoint{
-        Fq2({Fq(0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256),
-            Fq(0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256)}),
-        Fq2({Fq(0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256),
-            Fq(0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256)}),
+        {0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
+            0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256},
+        {0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
+            0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256},
     };
     // -Q1:
     const auto nQ1 = -Q1;
     // -Q1 * 16:
     const auto nQ1_16 = ExtPoint{
-        Fq2({Fq(0x14191bd65f51663a1d4ad71d8480c3c3260d598aab6ed95681f773abade7fd7a_u256),
-            Fq(0x299c79589dfb51fd6925fce3a7fc15c441fdafaa24f0d09b7c443befdddde4e5_u256)}),
-        Fq2({Fq(0x1d710ac19a995c6395f33be7f3dcd75e0632a006d196da6b4c9ba78708b6bb78_u256),
-            Fq(0xcae1001513ae5ddf742aa6dc2f52457d9b14e17765dd74fc098ad06045d434e_u256)}),
+        {0x14191bd65f51663a1d4ad71d8480c3c3260d598aab6ed95681f773abade7fd7a_u256,
+            0x299c79589dfb51fd6925fce3a7fc15c441fdafaa24f0d09b7c443befdddde4e5_u256},
+        {0x1d710ac19a995c6395f33be7f3dcd75e0632a006d196da6b4c9ba78708b6bb78_u256,
+            0xcae1001513ae5ddf742aa6dc2f52457d9b14e17765dd74fc098ad06045d434e_u256},
     };
     // -Q1 * 17:
     const auto nQ1_17 = ExtPoint{
-        Fq2({Fq(0x11eeb08db4fe0df9d7617f11f5f8f488d643510f825f3730ffb038c84c9260fd_u256),
-            Fq(0x12bf46039aa40a61762bf97b1bb028cebc6d42e46bbbe67f715eda54808b74c4_u256)}),
-        Fq2({Fq(0x42b65e62de1fd24534db81fd72e7ee832637948c1c466ccb08171e503f23e72_u256),
-            Fq(0x197a5efb333448885788690df5af2211c1697dd8b7b1f8845b4e30a909d2b0f5_u256)}),
+        {0x11eeb08db4fe0df9d7617f11f5f8f488d643510f825f3730ffb038c84c9260fd_u256,
+            0x12bf46039aa40a61762bf97b1bb028cebc6d42e46bbbe67f715eda54808b74c4_u256},
+        {0x42b65e62de1fd24534db81fd72e7ee832637948c1c466ccb08171e503f23e72_u256,
+            0x197a5efb333448885788690df5af2211c1697dd8b7b1f8845b4e30a909d2b0f5_u256},
     };
 
     {
@@ -96,10 +96,10 @@ TEST(evmmax, bn254_pairing_invalid_input)
             0x4eab993e2ba2cca2b08c216645e3fbcf80ae67515b2c49806c17b90c9d3cad3_u256,
         },
         ExtPoint{
-            Fq2({Fq(0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256),
-                Fq(0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256)}),
-            Fq2({Fq(0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256),
-                Fq(0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256)}),
+            {0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
+                0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256},
+            {0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
+                0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256},
         },
     }};
 
@@ -122,10 +122,10 @@ TEST(evmmax, bn254_pairing_invalid_input)
     {
         // Q not in proper group. Q is a member of small subgroup on twisted curve over Fq^2.
         const ExtPoint Q{
-            Fq2({Fq(0x13d841ba7ff3c6efd6870c3fea13a3ecab0423af5e4db9c5d28a6b46a05cd57b_u256),
-                Fq(0x1a2b1eaa7b20faae36d26eff4db6e336c34434b66eded3cc5303d51ae353f478_u256)}),
-            Fq2({Fq(0x2d3e8808aa7a7fffa8f871f10df8d59c6dd725889c46e9136e01cb2465b20723_u256),
-                Fq(0x1d5224817b8714531fc77e20b975178b1b3044f4b729fa3230db03dc0088ebdb_u256)}),
+            {0x13d841ba7ff3c6efd6870c3fea13a3ecab0423af5e4db9c5d28a6b46a05cd57b_u256,
+                0x1a2b1eaa7b20faae36d26eff4db6e336c34434b66eded3cc5303d51ae353f478_u256},
+            {0x2d3e8808aa7a7fffa8f871f10df8d59c6dd725889c46e9136e01cb2465b20723_u256,
+                0x1d5224817b8714531fc77e20b975178b1b3044f4b729fa3230db03dc0088ebdb_u256},
         };
 
         auto input = valid_input;
@@ -143,10 +143,10 @@ TEST(evmmax_bn254, evm_codes_example)
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
     const auto q1 = ExtPoint{
-        Fq2({Fq(0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256),
-            Fq(0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256)}),
-        Fq2({Fq(0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256),
-            Fq(0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256)}),
+        {0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256,
+            0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256},
+        {0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256,
+            0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256},
     };
 
     // Pair 2
@@ -155,10 +155,10 @@ TEST(evmmax_bn254, evm_codes_example)
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
     const auto q2 = ExtPoint{
-        Fq2({Fq(0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256),
-            Fq(0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256)}),
-        Fq2({Fq(0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256),
-            Fq(0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256)}),
+        {0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256,
+            0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256},
+        {0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256,
+            0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256},
     };
 
     const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};
@@ -176,10 +176,10 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
     const auto q1 = ExtPoint{
-        Fq2({Fq(0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256),
-            Fq(0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256)}),
-        Fq2({Fq(0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256),
-            Fq(0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256)}),
+        {0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256,
+            0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256},
+        {0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256,
+            0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256},
     };
 
     // Pair 2
@@ -188,10 +188,10 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
     const auto q2 = ExtPoint{
-        Fq2({Fq(0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256),
-            Fq(0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256)}),
-        Fq2({Fq(0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256),
-            Fq(0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256)}),
+        {0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256,
+            0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256},
+        {0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256,
+            0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256},
     };
 
     const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};

--- a/test/unittests/evmmax_bn254_pairing_test.cpp
+++ b/test/unittests/evmmax_bn254_pairing_test.cpp
@@ -24,26 +24,38 @@ TEST(evmmax, bn254_pairing)
     };
 
     const auto Q1 = ExtPoint{
-        {0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
-            0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256},
-        {0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
-            0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256},
+        {
+            0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
+            0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256,
+        },
+        {
+            0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
+            0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256,
+        },
     };
     // -Q1:
     const auto nQ1 = -Q1;
     // -Q1 * 16:
     const auto nQ1_16 = ExtPoint{
-        {0x14191bd65f51663a1d4ad71d8480c3c3260d598aab6ed95681f773abade7fd7a_u256,
-            0x299c79589dfb51fd6925fce3a7fc15c441fdafaa24f0d09b7c443befdddde4e5_u256},
-        {0x1d710ac19a995c6395f33be7f3dcd75e0632a006d196da6b4c9ba78708b6bb78_u256,
-            0xcae1001513ae5ddf742aa6dc2f52457d9b14e17765dd74fc098ad06045d434e_u256},
+        {
+            0x14191bd65f51663a1d4ad71d8480c3c3260d598aab6ed95681f773abade7fd7a_u256,
+            0x299c79589dfb51fd6925fce3a7fc15c441fdafaa24f0d09b7c443befdddde4e5_u256,
+        },
+        {
+            0x1d710ac19a995c6395f33be7f3dcd75e0632a006d196da6b4c9ba78708b6bb78_u256,
+            0xcae1001513ae5ddf742aa6dc2f52457d9b14e17765dd74fc098ad06045d434e_u256,
+        },
     };
     // -Q1 * 17:
     const auto nQ1_17 = ExtPoint{
-        {0x11eeb08db4fe0df9d7617f11f5f8f488d643510f825f3730ffb038c84c9260fd_u256,
-            0x12bf46039aa40a61762bf97b1bb028cebc6d42e46bbbe67f715eda54808b74c4_u256},
-        {0x42b65e62de1fd24534db81fd72e7ee832637948c1c466ccb08171e503f23e72_u256,
-            0x197a5efb333448885788690df5af2211c1697dd8b7b1f8845b4e30a909d2b0f5_u256},
+        {
+            0x11eeb08db4fe0df9d7617f11f5f8f488d643510f825f3730ffb038c84c9260fd_u256,
+            0x12bf46039aa40a61762bf97b1bb028cebc6d42e46bbbe67f715eda54808b74c4_u256,
+        },
+        {
+            0x42b65e62de1fd24534db81fd72e7ee832637948c1c466ccb08171e503f23e72_u256,
+            0x197a5efb333448885788690df5af2211c1697dd8b7b1f8845b4e30a909d2b0f5_u256,
+        },
     };
 
     {
@@ -95,11 +107,15 @@ TEST(evmmax, bn254_pairing_invalid_input)
             0x22980b2e458ec77e258b19ca3a7b46181f63c6536307acae03eea236f6919eeb_u256,
             0x4eab993e2ba2cca2b08c216645e3fbcf80ae67515b2c49806c17b90c9d3cad3_u256,
         },
-        ExtPoint{
-            {0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
-                0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256},
-            {0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
-                0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256},
+        {
+            {
+                0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
+                0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256,
+            },
+            {
+                0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
+                0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256,
+            },
         },
     }};
 
@@ -122,10 +138,14 @@ TEST(evmmax, bn254_pairing_invalid_input)
     {
         // Q not in proper group. Q is a member of small subgroup on twisted curve over Fq^2.
         const ExtPoint Q{
-            {0x13d841ba7ff3c6efd6870c3fea13a3ecab0423af5e4db9c5d28a6b46a05cd57b_u256,
-                0x1a2b1eaa7b20faae36d26eff4db6e336c34434b66eded3cc5303d51ae353f478_u256},
-            {0x2d3e8808aa7a7fffa8f871f10df8d59c6dd725889c46e9136e01cb2465b20723_u256,
-                0x1d5224817b8714531fc77e20b975178b1b3044f4b729fa3230db03dc0088ebdb_u256},
+            {
+                0x13d841ba7ff3c6efd6870c3fea13a3ecab0423af5e4db9c5d28a6b46a05cd57b_u256,
+                0x1a2b1eaa7b20faae36d26eff4db6e336c34434b66eded3cc5303d51ae353f478_u256,
+            },
+            {
+                0x2d3e8808aa7a7fffa8f871f10df8d59c6dd725889c46e9136e01cb2465b20723_u256,
+                0x1d5224817b8714531fc77e20b975178b1b3044f4b729fa3230db03dc0088ebdb_u256,
+            },
         };
 
         auto input = valid_input;
@@ -143,10 +163,14 @@ TEST(evmmax_bn254, evm_codes_example)
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
     const auto q1 = ExtPoint{
-        {0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256,
-            0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256},
-        {0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256,
-            0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256},
+        {
+            0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256,
+            0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256,
+        },
+        {
+            0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256,
+            0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256,
+        },
     };
 
     // Pair 2
@@ -155,10 +179,14 @@ TEST(evmmax_bn254, evm_codes_example)
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
     const auto q2 = ExtPoint{
-        {0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256,
-            0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256},
-        {0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256,
-            0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256},
+        {
+            0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256,
+            0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256,
+        },
+        {
+            0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256,
+            0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256,
+        },
     };
 
     const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};
@@ -176,10 +204,14 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
     const auto q1 = ExtPoint{
-        {0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256,
-            0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256},
-        {0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256,
-            0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256},
+        {
+            0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256,
+            0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256,
+        },
+        {
+            0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256,
+            0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256,
+        },
     };
 
     // Pair 2
@@ -188,10 +220,14 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
     const auto q2 = ExtPoint{
-        {0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256,
-            0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256},
-        {0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256,
-            0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256},
+        {
+            0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256,
+            0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256,
+        },
+        {
+            0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256,
+            0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256,
+        },
     };
 
     const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};

--- a/test/unittests/evmmax_bn254_pairing_test.cpp
+++ b/test/unittests/evmmax_bn254_pairing_test.cpp
@@ -24,39 +24,26 @@ TEST(evmmax, bn254_pairing)
     };
 
     const auto Q1 = ExtPoint{
-        {
-            0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
-            0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256,
-        },
-        {
-            0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
-            0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256,
-        },
+        Fq2({Fq(0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256),
+            Fq(0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256)}),
+        Fq2({Fq(0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256),
+            Fq(0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256)}),
     };
     // -Q1:
-    const auto nQ1 =
-        ExtPoint{Q1.x, {Curve::FIELD_PRIME - Q1.y.first, Curve::FIELD_PRIME - Q1.y.second}};
+    const auto nQ1 = -Q1;
     // -Q1 * 16:
     const auto nQ1_16 = ExtPoint{
-        {
-            0x14191bd65f51663a1d4ad71d8480c3c3260d598aab6ed95681f773abade7fd7a_u256,
-            0x299c79589dfb51fd6925fce3a7fc15c441fdafaa24f0d09b7c443befdddde4e5_u256,
-        },
-        {
-            0x1d710ac19a995c6395f33be7f3dcd75e0632a006d196da6b4c9ba78708b6bb78_u256,
-            0xcae1001513ae5ddf742aa6dc2f52457d9b14e17765dd74fc098ad06045d434e_u256,
-        },
+        Fq2({Fq(0x14191bd65f51663a1d4ad71d8480c3c3260d598aab6ed95681f773abade7fd7a_u256),
+            Fq(0x299c79589dfb51fd6925fce3a7fc15c441fdafaa24f0d09b7c443befdddde4e5_u256)}),
+        Fq2({Fq(0x1d710ac19a995c6395f33be7f3dcd75e0632a006d196da6b4c9ba78708b6bb78_u256),
+            Fq(0xcae1001513ae5ddf742aa6dc2f52457d9b14e17765dd74fc098ad06045d434e_u256)}),
     };
     // -Q1 * 17:
     const auto nQ1_17 = ExtPoint{
-        {
-            0x11eeb08db4fe0df9d7617f11f5f8f488d643510f825f3730ffb038c84c9260fd_u256,
-            0x12bf46039aa40a61762bf97b1bb028cebc6d42e46bbbe67f715eda54808b74c4_u256,
-        },
-        {
-            0x42b65e62de1fd24534db81fd72e7ee832637948c1c466ccb08171e503f23e72_u256,
-            0x197a5efb333448885788690df5af2211c1697dd8b7b1f8845b4e30a909d2b0f5_u256,
-        },
+        Fq2({Fq(0x11eeb08db4fe0df9d7617f11f5f8f488d643510f825f3730ffb038c84c9260fd_u256),
+            Fq(0x12bf46039aa40a61762bf97b1bb028cebc6d42e46bbbe67f715eda54808b74c4_u256)}),
+        Fq2({Fq(0x42b65e62de1fd24534db81fd72e7ee832637948c1c466ccb08171e503f23e72_u256),
+            Fq(0x197a5efb333448885788690df5af2211c1697dd8b7b1f8845b4e30a909d2b0f5_u256)}),
     };
 
     {
@@ -108,26 +95,15 @@ TEST(evmmax, bn254_pairing_invalid_input)
             0x22980b2e458ec77e258b19ca3a7b46181f63c6536307acae03eea236f6919eeb_u256,
             0x4eab993e2ba2cca2b08c216645e3fbcf80ae67515b2c49806c17b90c9d3cad3_u256,
         },
-        {
-            {
-                0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256,
-                0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256,
-            },
-            {
-                0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256,
-                0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256,
-            },
+        ExtPoint{
+            Fq2({Fq(0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678_u256),
+                Fq(0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7_u256)}),
+            Fq2({Fq(0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550_u256),
+                Fq(0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d_u256)}),
         },
     }};
 
     EXPECT_EQ(pairing_check(valid_input), false);
-
-    {
-        // Coordinate not a field element
-        auto input = valid_input;
-        input[0].second.x.second = Curve::FIELD_PRIME;
-        EXPECT_EQ(pairing_check(input), std::nullopt);
-    }
 
     {
         // Point P (G1) not on curve
@@ -139,21 +115,17 @@ TEST(evmmax, bn254_pairing_invalid_input)
     {
         // Point Q (G2) not on curve
         auto input = valid_input;
-        input[0].second.x.first += 1;
+        input[0].second.x.coeffs[0] += Fq{1};
         EXPECT_EQ(pairing_check(input), std::nullopt);
     }
 
     {
-        // Q not in proper group. Q id a member of small subgroup on twisted curve over Fq^2
+        // Q not in proper group. Q is a member of small subgroup on twisted curve over Fq^2.
         const ExtPoint Q{
-            {
-                0x13d841ba7ff3c6efd6870c3fea13a3ecab0423af5e4db9c5d28a6b46a05cd57b_u256,
-                0x1a2b1eaa7b20faae36d26eff4db6e336c34434b66eded3cc5303d51ae353f478_u256,
-            },
-            {
-                0x2d3e8808aa7a7fffa8f871f10df8d59c6dd725889c46e9136e01cb2465b20723_u256,
-                0x1d5224817b8714531fc77e20b975178b1b3044f4b729fa3230db03dc0088ebdb_u256,
-            },
+            Fq2({Fq(0x13d841ba7ff3c6efd6870c3fea13a3ecab0423af5e4db9c5d28a6b46a05cd57b_u256),
+                Fq(0x1a2b1eaa7b20faae36d26eff4db6e336c34434b66eded3cc5303d51ae353f478_u256)}),
+            Fq2({Fq(0x2d3e8808aa7a7fffa8f871f10df8d59c6dd725889c46e9136e01cb2465b20723_u256),
+                Fq(0x1d5224817b8714531fc77e20b975178b1b3044f4b729fa3230db03dc0088ebdb_u256)}),
         };
 
         auto input = valid_input;
@@ -171,14 +143,10 @@ TEST(evmmax_bn254, evm_codes_example)
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
     const auto q1 = ExtPoint{
-        {
-            0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256,
-            0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256,
-        },
-        {
-            0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256,
-            0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256,
-        },
+        Fq2({Fq(0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256),
+            Fq(0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256)}),
+        Fq2({Fq(0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256),
+            Fq(0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256)}),
     };
 
     // Pair 2
@@ -187,14 +155,10 @@ TEST(evmmax_bn254, evm_codes_example)
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
     const auto q2 = ExtPoint{
-        {
-            0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256,
-            0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256,
-        },
-        {
-            0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256,
-            0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256,
-        },
+        Fq2({Fq(0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256),
+            Fq(0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256)}),
+        Fq2({Fq(0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256),
+            Fq(0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256)}),
     };
 
     const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};
@@ -212,14 +176,10 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
         0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6_u256,
     };
     const auto q1 = ExtPoint{
-        {
-            0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256,
-            0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256,
-        },
-        {
-            0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256,
-            0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256,
-        },
+        Fq2({Fq(0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc_u256),
+            Fq(0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9_u256)}),
+        Fq2({Fq(0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90_u256),
+            Fq(0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e_u256)}),
     };
 
     // Pair 2
@@ -228,14 +188,10 @@ TEST(evmmax_bn254, evm_codes_example_changed_order)
         0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45_u256,
     };
     const auto q2 = ExtPoint{
-        {
-            0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256,
-            0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256,
-        },
-        {
-            0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256,
-            0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256,
-        },
+        Fq2({Fq(0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4_u256),
+            Fq(0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7_u256)}),
+        Fq2({Fq(0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2_u256),
+            Fq(0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc_u256)}),
     };
 
     const std::vector<std::pair<AffinePoint, ExtPoint>> pairs = {{p1, q1}, {p2, q2}};


### PR DESCRIPTION
Use `AffinePoint<ExtFieldElem>` instead of `ExtPoint` (now removed). This consolidates and de-duplicates code.