### PR TITLE
crypto: Fix incorrect docstrings in BN254 and KZG pairing helpers

### DIFF
--- a/lib/evmone_precompiles/kzg.cpp
+++ b/lib/evmone_precompiles/kzg.cpp
@@ -56,7 +56,8 @@ blst_p1_affine add_or_double(const blst_p1_affine& p, const blst_p1& q) noexcept
 bool pairings_verify(const blst_p1_affine& a1, const blst_p1_affine& b1) noexcept
 {
     blst_fp12 left;
-    // Uses precomputed Miller loop lines for the G2 generator.
+    // Runs the Miller loop against the G2 generator (no precomputed lines).
+    // TODO: Precompute lines for G2_GEN and use blst_miller_loop_lines() like the [s]₂ side.
     blst_aggregated_in_g1(&left, &a1);
     // Uses precomputed Miller loop lines for KZG_SETUP_G2_1 ([s]₂).
     blst_fp12 right;

--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -11,7 +11,7 @@ namespace evmmax::bn254
 namespace
 {
 /// Multiplies `fr` (Fq12) values by sparse `v` (Fq12) value of the form
-/// [[t[0] * y, 0, 0],[t[1] * x, t[0], 0]] where `v` coefficients are from Fq2
+/// [[t[0] * y, 0, 0],[t[1] * x, t[2], 0]] where `v` coefficients are from Fq2
 constexpr void multiply_by_lin_func_value(
     Fq12& fr, std::array<Fq2, 3> t, const Fq& x, const Fq& y) noexcept
 {


### PR DESCRIPTION
- pairing.cpp: the sparse Fq12 line value matrix had [1][1] = t[0], but the body of multiply_by_lin_func_value uses t[2]. Symbolic expansion (treating v = t[0]·y + t[1]·x·w + t[2]·v·w) confirms t[2] is correct.

- kzg.cpp: blst_aggregated_in_g1 was claimed to use precomputed Miller-loop lines for the G2 generator. It does not: it calls miller_loop_n(ret, &BLS12_381_G2, sig, 1) on the fly. Reword the comment and add a TODO to precompute G2_GEN lines, matching the existing [s]₂ path.