### PR TITLE
tooling: Restore vm param in t8n()

### DIFF
--- a/test/t8n/CMakeLists.txt
+++ b/test/t8n/CMakeLists.txt
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_executable(evmone-t8n)
-target_link_libraries(evmone-t8n PRIVATE evmone::testutils evmone-buildinfo intx::intx)
+target_link_libraries(evmone-t8n PRIVATE evmone::testutils evmone evmone-buildinfo intx::intx)
 target_sources(evmone-t8n PRIVATE t8n.cpp)

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -4,6 +4,7 @@
 
 #include <evmc/evmc.hpp>
 #include <evmc/hex.hpp>
+#include <evmone/evmone.h>
 #include <evmone/version.h>
 #include <intx/intx.hpp>
 #include <test/utils/t8n.hpp>
@@ -114,7 +115,8 @@ int main(int argc, const char* argv[])
         args.out_alloc = bind_stream(out_alloc, output_path(output_alloc_file));
         args.out_body = bind_stream(out_body, output_path(output_body_file));
 
-        tooling::t8n(args);
+        evmc::VM vm{evmc_create_evmone()};
+        tooling::t8n(vm, args);
     }
     catch (const std::exception& e)
     {

--- a/test/unittests/tooling_t8n_test.cpp
+++ b/test/unittests/tooling_t8n_test.cpp
@@ -2,6 +2,7 @@
 // Copyright 2026 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <evmone/evmone.h>
 #include <gmock/gmock.h>
 #include <test/utils/t8n.hpp>
 #include <sstream>
@@ -56,13 +57,18 @@ constexpr auto TX_JSON = R"([{
 TEST(tooling_t8n, no_inputs_no_outputs)
 {
     // Smoke: t8n() with everything left at defaults must not throw or crash.
+    evmc::VM vm{evmc_create_evmone()};
+
     tooling::T8NArgs args;
     args.rev = EVMC_OSAKA;
-    tooling::t8n(args);
+
+    tooling::t8n(vm, args);
 }
 
 TEST(tooling_t8n, result_written_to_out_streams)
 {
+    evmc::VM vm{evmc_create_evmone()};
+
     tooling::T8NArgs args;
     args.rev = EVMC_OSAKA;
     std::ostringstream out_result;
@@ -70,7 +76,7 @@ TEST(tooling_t8n, result_written_to_out_streams)
     args.out_result = &out_result;
     args.out_alloc = &out_alloc;
 
-    tooling::t8n(args);
+    tooling::t8n(vm, args);
 
     EXPECT_THAT(out_result.str(), HasSubstr("\"gasUsed\""));
     EXPECT_THAT(out_result.str(), HasSubstr("\"txRoot\""));
@@ -81,6 +87,8 @@ TEST(tooling_t8n, result_written_to_out_streams)
 
 TEST(tooling_t8n, open_trace_called_per_tx)
 {
+    evmc::VM vm{evmc_create_evmone()};
+
     std::istringstream env{ENV_JSON};
     std::istringstream alloc{ALLOC_JSON};
     std::istringstream txs{TX_JSON};
@@ -102,7 +110,7 @@ TEST(tooling_t8n, open_trace_called_per_tx)
         return trace_buf;
     };
 
-    tooling::t8n(args);
+    tooling::t8n(vm, args);
 
     ASSERT_EQ(trace_calls.size(), 1U);
     EXPECT_EQ(trace_calls[0].first, 0U);
@@ -113,6 +121,8 @@ TEST(tooling_t8n, open_trace_called_per_tx)
 
 TEST(tooling_t8n, out_body_is_hex_rlp_of_transactions)
 {
+    evmc::VM vm{evmc_create_evmone()};
+
     std::istringstream env{ENV_JSON};
     std::istringstream alloc{ALLOC_JSON};
     std::istringstream txs{TX_JSON};
@@ -130,7 +140,7 @@ TEST(tooling_t8n, out_body_is_hex_rlp_of_transactions)
     args.out_alloc = &out_alloc;
     args.out_body = &out_body;
 
-    tooling::t8n(args);
+    tooling::t8n(vm, args);
 
     // RLP-encoded list of one legacy transaction, hex-prefixed.
     EXPECT_THAT(out_body.str(), StartsWith("0x"));
@@ -139,6 +149,8 @@ TEST(tooling_t8n, out_body_is_hex_rlp_of_transactions)
 
 TEST(tooling_t8n, pre_byzantium_sets_receipt_post_state)
 {
+    evmc::VM vm{evmc_create_evmone()};
+
     // Pre-Byzantium receipts include the post-state root via receipt.post_state.
     // The TX_JSON fixture uses PUSH0 in its init code, so the inner CREATE fails
     // at Homestead, but the outer tx still produces a TransactionReceipt that
@@ -156,7 +168,7 @@ TEST(tooling_t8n, pre_byzantium_sets_receipt_post_state)
     args.txs = &txs;
     args.out_result = &out_result;
 
-    tooling::t8n(args);
+    tooling::t8n(vm, args);
 
     // The "receipts" array is initialized empty on every txs-present run; the
     // distinguishing signal that a receipt was actually produced (i.e., the
@@ -166,6 +178,8 @@ TEST(tooling_t8n, pre_byzantium_sets_receipt_post_state)
 
 TEST(tooling_t8n, mismatched_tx_hash_throws)
 {
+    evmc::VM vm{evmc_create_evmone()};
+
     // TX_JSON's tx with a deliberately wrong "hash" field. t8n() must detect
     // the mismatch against the recomputed hash and throw std::logic_error.
     static constexpr auto TX_WITH_BAD_HASH = R"([{
@@ -194,5 +208,5 @@ TEST(tooling_t8n, mismatched_tx_hash_throws)
     args.env = &env;
     args.txs = &txs;
 
-    EXPECT_THROW(tooling::t8n(args), std::logic_error);
+    EXPECT_THROW(tooling::t8n(vm, args), std::logic_error);
 }

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(evmone::testutils ALIAS evmone.testutils)
 target_link_libraries(
     evmone.testutils
     PUBLIC evmone::state evmc::evmc_cpp nlohmann_json::nlohmann_json
-    PRIVATE evmone evmc::mocked_host
+    PRIVATE evmc::mocked_host
 )
 
 target_sources(

--- a/test/utils/t8n.cpp
+++ b/test/utils/t8n.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "t8n.hpp"
-#include <evmone/evmone.h>
 #include <nlohmann/json.hpp>
 #include <test/state/ethash_difficulty.hpp>
 #include <test/state/requests.hpp>
@@ -46,10 +45,9 @@ public:
 };
 }  // namespace
 
-void t8n(const T8NArgs& args)
+void t8n(evmc::VM& vm, const T8NArgs& args)
 {
     const auto rev = args.rev;
-    evmc::VM vm{evmc_create_evmone()};
 
     const auto blob_params =
         (args.blob_params != nullptr) ?
@@ -111,7 +109,7 @@ void t8n(const T8NArgs& args)
 
         const bool trace_enabled = static_cast<bool>(args.open_trace);
         if (trace_enabled)
-            vm.set_option("trace", "1");
+            vm.set_option("trace", "1");  // This actually appends new tracer each set_option().
         if (!args.opcode_count_file.empty())
             vm.set_option("opcode.count", args.opcode_count_file.c_str());
 

--- a/test/utils/t8n.hpp
+++ b/test/utils/t8n.hpp
@@ -46,7 +46,7 @@ struct T8NArgs
 /// post-state as some JSON outputs. The specifics of the JSON formats and options are dictated
 /// by execution specs, see https://steel.ethereum.foundation/docs/execution-specs.
 ///
-/// The VM is constructed internally because this is a one-off command,
-/// and it needs to modify the VM's config.
-void t8n(const T8NArgs& args);
+/// @param vm    The VM instance. The command may modify/overwrite its config (depends on args).
+/// @param args  The command arguments.
+void t8n(evmc::VM& vm, const T8NArgs& args);
 }  // namespace evmone::tooling


### PR DESCRIPTION
This is useful for later unification of the evmone CLI commands.