### PR TITLE
tracing: Keep copy of output path in InstructionCounter

### DIFF
--- a/lib/evmone/tracing.cpp
+++ b/lib/evmone/tracing.cpp
@@ -70,7 +70,7 @@ class InstructionCounter : public Tracer
 {
     std::stack<bytes_view> m_codes;
     std::array<unsigned, 256> m_counters{};
-    std::string_view m_out_file_path;
+    std::string m_out_file_path;
 
     void on_execution_start(
         evmc_revision /*rev*/, const evmc_message& /*msg*/, bytes_view code) noexcept override
@@ -94,7 +94,7 @@ public:
 
     ~InstructionCounter() noexcept override
     {
-        std::ofstream out{std::string{m_out_file_path}};
+        std::ofstream out{m_out_file_path};
         out << "{\n";
         bool first = true;
         for (size_t i = 0; i < std::size(m_counters); ++i)


### PR DESCRIPTION
Previously used string_view for output path causes lifetime issues for users: the tracer outputs to file during destruction.