### PR TITLE
test: Extract shared apply_block from blockchaintest and t8n 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -421,14 +421,14 @@ jobs:
           filter: "-for_amsterdam/*:for_bpo2toamsterdamattime15k/*"
       - collect_coverage_clang:
           flags: eest-develop
-          ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests|utils)
+          ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests)
           binaries: evmone-statetest evmone-blockchaintest
       - run_execution_spec_tests:
           release: v5.4.0
           fixtures_suffix: develop
       - collect_coverage_clang:
           flags: eest-stable
-          ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests|utils)
+          ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests)
           binaries: evmone-statetest evmone-blockchaintest
 
   ethereum-tests:

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -7,6 +7,7 @@
 #include <test/state/errors.hpp>
 #include <test/state/ethash_difficulty.hpp>
 #include <test/state/requests.hpp>
+#include <test/utils/block_transition.hpp>
 #include <test/utils/mpt_hash.hpp>
 #include <test/utils/rlp.hpp>
 #include <test/utils/rlp_encode.hpp>
@@ -22,112 +23,8 @@ constexpr size_t SAFETY_MARGIN = 2 * 1024 * 1024;
 /// The maximum EL block size when RLP encoded (EIP-7934).
 constexpr size_t MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN;
 
-struct RejectedTransaction
-{
-    hash256 hash;
-    size_t index;
-    std::string message;
-};
-
-struct TransitionResult
-{
-    std::vector<state::TransactionReceipt> receipts;
-    std::vector<RejectedTransaction> rejected;
-    std::vector<state::Requests> requests;
-    std::error_code requests_error;
-    int64_t gas_used;
-    state::BloomFilter bloom;
-    int64_t blob_gas_left;
-    TestState block_state;
-};
-
 namespace
 {
-/// Transition the state with a block of transactions.
-///
-/// This assumes block-level validity, but transaction may be invalid.
-///
-/// @param blob_gas_limit  The per-block blob-gas budget set by the protocol maximum.
-TransitionResult apply_block(const TestState& state, evmc::VM& vm, const state::BlockInfo& block,
-    const state::BlockHashes& block_hashes, const std::vector<state::Transaction>& txs,
-    evmc_revision rev, int64_t blob_gas_limit, std::optional<uint64_t> block_reward)
-{
-    TestState block_state(state);
-    system_call_block_start(block_state, block, block_hashes, rev, vm);
-
-    std::vector<state::Log> txs_logs;
-    int64_t block_gas_left = block.gas_limit;
-
-    std::vector<RejectedTransaction> rejected_txs;
-    std::vector<state::TransactionReceipt> receipts;
-
-    int64_t cumulative_gas_used = 0;
-    int64_t block_gas_used = 0;
-    auto blob_gas_left = blob_gas_limit;
-
-    for (size_t i = 0; i < txs.size(); ++i)
-    {
-        const auto& tx = txs[i];
-
-        const auto computed_tx_hash = keccak256(rlp::encode(tx));
-        auto res = test::transition(
-            block_state, block, block_hashes, tx, rev, vm, block_gas_left, blob_gas_left);
-
-        if (holds_alternative<std::error_code>(res))
-        {
-            const auto ec = std::get<std::error_code>(res);
-            rejected_txs.push_back({computed_tx_hash, i, ec.message()});
-        }
-        else
-        {
-            auto& receipt = get<state::TransactionReceipt>(res);
-
-            const auto& tx_logs = receipt.logs;
-
-            txs_logs.insert(txs_logs.end(), tx_logs.begin(), tx_logs.end());
-            cumulative_gas_used += receipt.gas_used;
-            receipt.cumulative_gas_used = cumulative_gas_used;
-            if (rev < EVMC_BYZANTIUM)
-                receipt.post_state = state::mpt_hash(block_state);
-
-            // Block gas accounting, refunds excluded (EIP-7778).
-            const auto block_tx_gas =
-                (rev >= EVMC_AMSTERDAM) ? receipt.gas_used + receipt.gas_refund : receipt.gas_used;
-            block_gas_used += block_tx_gas;
-            block_gas_left -= block_tx_gas;
-            blob_gas_left -= static_cast<int64_t>(tx.blob_gas_used());
-            receipts.emplace_back(std::move(receipt));
-        }
-    }
-
-    std::vector<state::Requests> requests;
-    std::error_code requests_error;
-    if (rev >= EVMC_PRAGUE)
-    {
-        auto opt_deposits = collect_deposit_requests(receipts);
-        if (opt_deposits.has_value())
-            requests.emplace_back(std::move(*opt_deposits));
-        else
-            requests_error = make_error_code(state::INVALID_DEPOSIT_EVENT_LAYOUT);
-    }
-    if (!requests_error)
-    {
-        auto block_end = system_call_block_end(block_state, block, block_hashes, rev, vm);
-        if (const auto* ec = std::get_if<std::error_code>(&block_end))
-            requests_error = *ec;
-        else
-            std::ranges::move(
-                std::get<std::vector<state::Requests>>(block_end), std::back_inserter(requests));
-    }
-
-    finalize(block_state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
-
-    const auto bloom = compute_bloom_filter(receipts);
-
-    return {std::move(receipts), std::move(rejected_txs), std::move(requests), requests_error,
-        block_gas_used, bloom, blob_gas_left, std::move(block_state)};
-}
-
 /// Validates block-level validity unrelated to individual transactions.
 ///
 /// Returns an empty error_code if the block is valid, otherwise the specific validation error.
@@ -333,7 +230,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 const auto& pre_state = parent_data_it->second.post_state;
 
                 auto res = apply_block(pre_state, vm, bi, block_hashes, test_block.transactions,
-                    rev, blob_gas_limit, mining_reward(rev));
+                    rev, blob_gas_limit, {.block_reward = mining_reward(rev)});
 
                 ASSERT_FALSE(res.requests_error);
 
@@ -402,8 +299,9 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 assert(parent_data_it != block_data.end());
                 const auto& pre_state = parent_data_it->second.post_state;
 
-                const auto res = apply_block(pre_state, vm, bi, block_hashes,
-                    test_block.transactions, rev, blob_gas_limit, mining_reward(rev));
+                const auto res =
+                    apply_block(pre_state, vm, bi, block_hashes, test_block.transactions, rev,
+                        blob_gas_limit, {.block_reward = mining_reward(rev)});
                 if (!res.rejected.empty())
                 {
                     // Check if EEST expects transaction-level exception (ignore "legacy" names).

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(
     stdx/utility.hpp
     blob_schedule.hpp
     blob_schedule.cpp
+    block_transition.hpp
+    block_transition.cpp
     blockchaintest.hpp
     blockchaintest_loader.cpp
     bytecode.hpp

--- a/test/utils/block_transition.cpp
+++ b/test/utils/block_transition.cpp
@@ -1,0 +1,121 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2025 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "block_transition.hpp"
+#include <test/state/errors.hpp>
+#include <test/utils/mpt_hash.hpp>
+#include <test/utils/rlp.hpp>
+#include <test/utils/rlp_encode.hpp>
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+
+namespace evmone::test
+{
+namespace
+{
+/// Redirects an ostream's streambuf for the scope's lifetime.
+class StreamRedirect
+{
+    std::ostream& stream_;
+    std::streambuf* prev_;
+
+public:
+    StreamRedirect(std::ostream& stream, std::streambuf* new_buf) noexcept
+      : stream_{stream}, prev_{stream.rdbuf(new_buf)}
+    {}
+
+    StreamRedirect(const StreamRedirect&) = delete;
+    StreamRedirect& operator=(const StreamRedirect&) = delete;
+
+    ~StreamRedirect() { stream_.rdbuf(prev_); }
+};
+}  // namespace
+
+TransitionResult apply_block(const TestState& state, evmc::VM& vm, const state::BlockInfo& block,
+    const state::BlockHashes& block_hashes, const std::vector<state::Transaction>& txs,
+    evmc_revision rev, int64_t blob_gas_limit, const BlockTransitionOptions& opts)
+{
+    const bool trace_enabled = static_cast<bool>(opts.open_trace);
+    if (trace_enabled)
+        vm.set_option("trace", "1");  // This actually appends a new tracer on each set_option().
+
+    TestState block_state(state);
+    if (!opts.skip_system_calls)
+        system_call_block_start(block_state, block, block_hashes, rev, vm);
+
+    std::vector<RejectedTransaction> rejected_txs;
+    std::vector<state::TransactionReceipt> receipts;
+
+    int64_t block_gas_left = block.gas_limit;
+    int64_t cumulative_gas_used = 0;
+    int64_t block_gas_used = 0;
+    auto blob_gas_left = blob_gas_limit;
+
+    for (size_t i = 0; i < txs.size(); ++i)
+    {
+        const auto& tx = txs[i];
+        const auto computed_tx_hash = keccak256(rlp::encode(tx));
+
+        std::optional<StreamRedirect> trace_guard;
+        if (trace_enabled)
+            trace_guard.emplace(std::clog, opts.open_trace(i, computed_tx_hash).rdbuf());
+
+        auto res = transition(
+            block_state, block, block_hashes, tx, rev, vm, block_gas_left, blob_gas_left);
+
+        if (holds_alternative<std::error_code>(res))
+        {
+            const auto ec = std::get<std::error_code>(res);
+            rejected_txs.push_back({computed_tx_hash, i, ec.message()});
+        }
+        else
+        {
+            auto& receipt = get<state::TransactionReceipt>(res);
+
+            cumulative_gas_used += receipt.gas_used;
+            receipt.cumulative_gas_used = cumulative_gas_used;
+            if (rev < EVMC_BYZANTIUM)
+                receipt.post_state = state::mpt_hash(block_state);
+
+            // Block gas accounting, refunds excluded (EIP-7778).
+            const auto block_tx_gas =
+                (rev >= EVMC_AMSTERDAM) ? receipt.gas_used + receipt.gas_refund : receipt.gas_used;
+            block_gas_used += block_tx_gas;
+            block_gas_left -= block_tx_gas;
+            blob_gas_left -= static_cast<int64_t>(tx.blob_gas_used());
+            receipts.emplace_back(std::move(receipt));
+        }
+    }
+
+    std::vector<state::Requests> requests;
+    std::error_code requests_error;
+    if (!opts.skip_system_calls)
+    {
+        if (rev >= EVMC_PRAGUE)
+        {
+            if (auto opt_deposits = collect_deposit_requests(receipts); opt_deposits.has_value())
+                requests.emplace_back(std::move(*opt_deposits));
+            else
+                requests_error = make_error_code(state::INVALID_DEPOSIT_EVENT_LAYOUT);
+        }
+        if (!requests_error)
+        {
+            auto block_end = system_call_block_end(block_state, block, block_hashes, rev, vm);
+            if (const auto* ec = std::get_if<std::error_code>(&block_end))
+                requests_error = *ec;
+            else
+                std::ranges::move(std::get<std::vector<state::Requests>>(block_end),
+                    std::back_inserter(requests));
+        }
+    }
+
+    finalize(block_state, rev, block.coinbase, opts.block_reward, block.ommers, block.withdrawals);
+
+    const auto bloom = compute_bloom_filter(receipts);
+
+    return {std::move(receipts), std::move(rejected_txs), std::move(requests), requests_error,
+        block_gas_used, bloom, blob_gas_left, std::move(block_state)};
+}
+}  // namespace evmone::test

--- a/test/utils/block_transition.hpp
+++ b/test/utils/block_transition.hpp
@@ -1,0 +1,74 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2025 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <test/state/bloom_filter.hpp>
+#include <test/state/requests.hpp>
+#include <test/state/transaction.hpp>
+#include <test/utils/test_state.hpp>
+#include <functional>
+#include <iosfwd>
+#include <optional>
+#include <system_error>
+#include <vector>
+
+namespace evmone::state
+{
+struct BlockInfo;
+}
+
+namespace evmone::test
+{
+/// A transaction rejected during block application.
+struct RejectedTransaction
+{
+    hash256 hash;  ///< keccak256 of the transaction's RLP encoding.
+    size_t index;  ///< Position in the input transaction list.
+    std::string message;
+};
+
+/// Options for apply_block(). Defaults match block-validation (full) behavior.
+struct BlockTransitionOptions
+{
+    /// Mining reward paid to the coinbase on finalization (nullopt = PoS, no reward).
+    std::optional<uint64_t> block_reward;
+
+    /// Skip the block-start/block-end system calls and request collection
+    /// (t8n pre-state-only mode). The transaction loop and finalization still run.
+    bool skip_system_calls = false;
+
+    /// Called once per transaction (just before execution) to obtain a per-tx
+    /// trace sink; std::clog is redirected to the returned stream for the
+    /// duration of that transaction. Unset = tracing disabled.
+    std::function<std::ostream&(size_t tx_index, const hash256& tx_hash)> open_trace;
+};
+
+/// Result of applying a block; see apply_block().
+struct TransitionResult
+{
+    std::vector<state::TransactionReceipt> receipts;  ///< Accepted transactions, in block order.
+    std::vector<RejectedTransaction> rejected;        ///< Rejected transactions, in input order.
+    std::vector<state::Requests> requests;            ///< Collected requests (EIP-7685).
+    std::error_code requests_error;  ///< Set if requests collection failed (block is invalid).
+    int64_t gas_used = 0;       ///< Block gas used; includes refunds for Amsterdam+ (EIP-7778).
+    state::BloomFilter bloom;   ///< Logs bloom over all accepted transactions.
+    int64_t blob_gas_left = 0;  ///< Blob gas remaining out of the budget passed in.
+    TestState block_state;      ///< State after applying the block.
+};
+
+/// Applies a block of transactions to a copy of @p state: block-start system call, the
+/// transactions, request collection, block-end system call, and finalization. The system calls
+/// and request collection are skipped when `opts.skip_system_calls` is set.
+///
+/// Shared block-transition core for the blockchain test runner and the t8n tool. It performs
+/// no validation/assertions and produces no output; callers interpret the returned result.
+/// Block-level validity is assumed, but individual transactions may be rejected.
+///
+/// @param blob_gas_limit  The per-block blob-gas budget set by the protocol maximum.
+[[nodiscard]] TransitionResult apply_block(const TestState& state, evmc::VM& vm,
+    const state::BlockInfo& block, const state::BlockHashes& block_hashes,
+    const std::vector<state::Transaction>& txs, evmc_revision rev, int64_t blob_gas_limit,
+    const BlockTransitionOptions& opts = {});
+}  // namespace evmone::test

--- a/test/utils/t8n.cpp
+++ b/test/utils/t8n.cpp
@@ -4,47 +4,21 @@
 
 #include "t8n.hpp"
 #include <nlohmann/json.hpp>
-#include <test/state/errors.hpp>
 #include <test/state/ethash_difficulty.hpp>
 #include <test/state/requests.hpp>
+#include <test/utils/block_transition.hpp>
 #include <test/utils/mpt_hash.hpp>
 #include <test/utils/rlp.hpp>
 #include <test/utils/rlp_encode.hpp>
 #include <test/utils/statetest.hpp>
 #include <test/utils/utils.hpp>
-#include <algorithm>
 #include <iomanip>
-#include <iostream>
-#include <iterator>
-#include <optional>
 #include <stdexcept>
-#include <system_error>
-#include <vector>
 
 namespace evmone::tooling
 {
 using JSON = nlohmann::json;
 using namespace evmone::test;
-
-namespace
-{
-/// Redirects an ostream's streambuf for the scope's lifetime.
-class StreamRedirect
-{
-    std::ostream& stream_;
-    std::streambuf* prev_;
-
-public:
-    StreamRedirect(std::ostream& stream, std::streambuf* new_buf) noexcept
-      : stream_{stream}, prev_{stream.rdbuf(new_buf)}
-    {}
-
-    StreamRedirect(const StreamRedirect&) = delete;
-    StreamRedirect& operator=(const StreamRedirect&) = delete;
-
-    ~StreamRedirect() { stream_.rdbuf(prev_); }
-};
-}  // namespace
 
 void t8n(evmc::VM& vm, const T8NArgs& args)
 {
@@ -96,139 +70,127 @@ void t8n(evmc::VM& vm, const T8NArgs& args)
     if (rev >= EVMC_LONDON)
         j_result["currentBaseFee"] = hex0x(block.base_fee);
 
-    int64_t cumulative_gas_used = 0;
-    auto blob_gas_left = static_cast<int64_t>(state::max_blob_gas_per_block(blob_params));
+    const auto blob_gas_limit = static_cast<int64_t>(state::max_blob_gas_per_block(blob_params));
+    int64_t gas_used = 0;
+    int64_t blob_gas_left = blob_gas_limit;
     std::vector<state::Transaction> transactions;
     std::vector<state::TransactionReceipt> receipts;
-    int64_t block_gas_left = block.gas_limit;
     std::vector<state::Requests> requests;
+    state::BloomFilter bloom{};
+    TestState post_state;
 
     // Parse and execute transactions
     if (args.txs != nullptr)
     {
         const auto j_txs = JSON::parse(*args.txs);
 
-        const bool trace_enabled = static_cast<bool>(args.open_trace);
-        if (trace_enabled)
-            vm.set_option("trace", "1");  // This actually appends new tracer each set_option().
         if (!args.opcode_count_file.empty())
             vm.set_option("opcode.count", args.opcode_count_file.c_str());
 
-        std::vector<state::Log> txs_logs;
+        j_result["receipts"] = JSON::array();
+        j_result["rejected"] = JSON::array();
 
+        // Parse the transactions, assign the chain ID and validate any provided hash. A non-array
+        // `txs` value yields zero transactions but still produces a full, finalized block result.
+        std::vector<state::Transaction> txs;
         if (j_txs.is_array())
         {
-            j_result["receipts"] = JSON::array();
-            j_result["rejected"] = JSON::array();
-
-            if (!args.pre_state_only)
-                system_call_block_start(state, block, block_hashes, rev, vm);
-
-            for (size_t i = 0; i < j_txs.size(); ++i)
+            txs.reserve(j_txs.size());
+            for (const auto& j_tx : j_txs)
             {
-                auto tx = from_json<state::Transaction>(j_txs[i]);
+                auto tx = from_json<state::Transaction>(j_tx);
                 tx.chain_id = args.chain_id;
 
-                const auto computed_tx_hash = keccak256(rlp::encode(tx));
-                const auto computed_tx_hash_str = hex0x(computed_tx_hash);
-
-                if (j_txs[i].contains("hash"))
+                if (j_tx.contains("hash"))
                 {
+                    const auto computed_tx_hash = keccak256(rlp::encode(tx));
                     const auto loaded_tx_hash_opt =
-                        evmc::from_hex<bytes32>(j_txs[i]["hash"].get<std::string>());
-
+                        evmc::from_hex<bytes32>(j_tx["hash"].get<std::string>());
                     if (!loaded_tx_hash_opt)
                         throw std::logic_error("transaction hash hex is malformed: " +
-                                               j_txs[i]["hash"].get<std::string>());
+                                               j_tx["hash"].get<std::string>());
                     if (*loaded_tx_hash_opt != computed_tx_hash)
                         throw std::logic_error("transaction hash mismatched: computed " +
-                                               computed_tx_hash_str + ", expected " +
+                                               hex0x(computed_tx_hash) + ", expected " +
                                                hex0x(*loaded_tx_hash_opt));
                 }
 
-                std::optional<StreamRedirect> trace_guard;
-                if (trace_enabled)
-                    trace_guard.emplace(std::clog, args.open_trace(i, computed_tx_hash).rdbuf());
-
-                auto res = transition(
-                    state, block, block_hashes, tx, rev, vm, block_gas_left, blob_gas_left);
-
-                if (holds_alternative<std::error_code>(res))
-                {
-                    const auto ec = std::get<std::error_code>(res);
-                    JSON j_rejected_tx;
-                    j_rejected_tx["hash"] = computed_tx_hash_str;
-                    j_rejected_tx["index"] = i;
-                    j_rejected_tx["error"] = ec.message();
-                    j_result["rejected"].push_back(j_rejected_tx);
-                }
-                else
-                {
-                    auto& receipt = get<state::TransactionReceipt>(res);
-
-                    const auto& tx_logs = receipt.logs;
-
-                    txs_logs.insert(txs_logs.end(), tx_logs.begin(), tx_logs.end());
-                    auto& j_receipt = j_result["receipts"][j_result["receipts"].size()];
-
-                    j_receipt["transactionHash"] = computed_tx_hash_str;
-                    j_receipt["gasUsed"] = hex0x(static_cast<uint64_t>(receipt.gas_used));
-                    cumulative_gas_used += receipt.gas_used;
-                    receipt.cumulative_gas_used = cumulative_gas_used;
-                    if (rev < EVMC_BYZANTIUM)
-                        receipt.post_state = state::mpt_hash(state);
-                    j_receipt["cumulativeGasUsed"] = hex0x(cumulative_gas_used);
-
-                    j_receipt["blockHash"] = hex0x(bytes32{});
-                    j_receipt["contractAddress"] = hex0x(address{});
-                    j_receipt["logsBloom"] = hex0x(receipt.logs_bloom_filter);
-                    j_receipt["logs"] = JSON::array();  // FIXME: Add to_json<state:Log>
-                    j_receipt["root"] = "";
-                    j_receipt["status"] = "0x1";
-                    j_receipt["transactionIndex"] = hex0x(i);
-                    blob_gas_left -= static_cast<int64_t>(tx.blob_gas_used());
-                    transactions.emplace_back(std::move(tx));
-                    block_gas_left -= receipt.gas_used;
-                    receipts.emplace_back(std::move(receipt));
-                }
+                txs.emplace_back(std::move(tx));
             }
         }
 
-        if (!args.pre_state_only && rev >= EVMC_PRAGUE)
+        auto res = apply_block(state, vm, block, block_hashes, txs, rev, blob_gas_limit,
+            {.block_reward = args.block_reward,
+                .skip_system_calls = args.pre_state_only,
+                .open_trace = args.open_trace});
+
+        // Build the receipts/rejected JSON lists from the partitioned result. `rejected`
+        // is in input order, so walk it alongside the input transactions; the rest map to
+        // `receipts` in block order.
+        std::vector<state::Log> txs_logs;
+        auto rejected_it = res.rejected.begin();
+        size_t receipt_index = 0;
+        for (size_t i = 0; i < txs.size(); ++i)
         {
-            auto deposits_result = collect_deposit_requests(receipts);
-            if (deposits_result.has_value())
-                requests.emplace_back(std::move(*deposits_result));
+            if (rejected_it != res.rejected.end() && rejected_it->index == i)
+            {
+                JSON j_rejected_tx;
+                j_rejected_tx["hash"] = hex0x(rejected_it->hash);
+                j_rejected_tx["index"] = i;
+                j_rejected_tx["error"] = rejected_it->message;
+                j_result["rejected"].push_back(j_rejected_tx);
+                ++rejected_it;
+            }
             else
-                // Report invalid block in the JSON result when deposit collection fails.
-                j_result["blockException"] =
-                    make_error_code(state::INVALID_DEPOSIT_EVENT_LAYOUT).message();
-            auto requests_result = system_call_block_end(state, block, block_hashes, rev, vm);
-            if (auto* r = std::get_if<std::vector<state::Requests>>(&requests_result))
-                std::ranges::move(*r, std::back_inserter(requests));
-            else
-                // Report invalid block in the JSON result with the specific requests failure
-                // (empty system contract vs. failed system call).
-                j_result["blockException"] = std::get<std::error_code>(requests_result).message();
+            {
+                const auto& receipt = res.receipts[receipt_index++];
+                txs_logs.insert(txs_logs.end(), receipt.logs.begin(), receipt.logs.end());
+
+                auto& j_receipt = j_result["receipts"][j_result["receipts"].size()];
+                j_receipt["transactionHash"] = hex0x(keccak256(rlp::encode(txs[i])));
+                j_receipt["gasUsed"] = hex0x(static_cast<uint64_t>(receipt.gas_used));
+                j_receipt["cumulativeGasUsed"] = hex0x(receipt.cumulative_gas_used);
+                j_receipt["blockHash"] = hex0x(bytes32{});
+                j_receipt["contractAddress"] = hex0x(address{});
+                j_receipt["logsBloom"] = hex0x(receipt.logs_bloom_filter);
+                j_receipt["logs"] = JSON::array();  // FIXME: Add to_json<state:Log>
+                j_receipt["root"] = "";
+                j_receipt["status"] = "0x1";
+                j_receipt["transactionIndex"] = hex0x(i);
+                transactions.emplace_back(std::move(txs[i]));
+            }
         }
 
-        finalize(state, rev, block.coinbase, args.block_reward, block.ommers, block.withdrawals);
+        if (res.requests_error)
+            // Report invalid block in the JSON result when request collection fails.
+            j_result["blockException"] = res.requests_error.message();
+        else
+            requests = std::move(res.requests);
+
+        receipts = std::move(res.receipts);
+        // Block gas used reported as the cumulative transaction gas (refunds excluded),
+        // preserving the prior t8n output.
+        gas_used = receipts.empty() ? 0 : receipts.back().cumulative_gas_used;
+        bloom = res.bloom;
+        blob_gas_left = res.blob_gas_left;
+        post_state = std::move(res.block_state);
 
         j_result["logsHash"] = hex0x(logs_hash(txs_logs));
-        j_result["stateRoot"] = hex0x(state::mpt_hash(state));
+        j_result["stateRoot"] = hex0x(state::mpt_hash(post_state));
     }
+    else
+        post_state = state;
 
-    j_result["logsBloom"] = hex0x(compute_bloom_filter(receipts));
+    j_result["logsBloom"] = hex0x(bloom);
     j_result["receiptsRoot"] = hex0x(state::mpt_hash(receipts));
     if (rev >= EVMC_SHANGHAI)
         j_result["withdrawalsRoot"] = hex0x(state::mpt_hash(block.withdrawals));
 
     j_result["txRoot"] = hex0x(state::mpt_hash(transactions));
-    j_result["gasUsed"] = hex0x(cumulative_gas_used);
+    j_result["gasUsed"] = hex0x(gas_used);
     if (rev >= EVMC_CANCUN)
     {
-        j_result["blobGasUsed"] =
-            hex0x(static_cast<int64_t>(state::max_blob_gas_per_block(blob_params)) - blob_gas_left);
+        j_result["blobGasUsed"] = hex0x(blob_gas_limit - blob_gas_left);
         if (block.excess_blob_gas.has_value())
             j_result["currentExcessBlobGas"] = hex0x(*block.excess_blob_gas);
     }
@@ -251,7 +213,7 @@ void t8n(evmc::VM& vm, const T8NArgs& args)
     if (args.out_result != nullptr)
         *args.out_result << std::setw(2) << j_result;
     if (args.out_alloc != nullptr)
-        *args.out_alloc << std::setw(2) << to_json(TestState{state});
+        *args.out_alloc << std::setw(2) << to_json(TestState{post_state});
     if (args.out_body != nullptr)
         *args.out_body << hex0x(rlp::encode(transactions));
 }


### PR DESCRIPTION
The blockchain test runner and the t8n tool each carried their own block
transition loop. Move the runner's `apply_block` into common
gtest-free `test/utils/block_transition.{hpp,cpp}` used by both.