### PR TITLE
test: Match block requests and transaction exceptions in blockchaintest

### DIFF
--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -33,7 +33,8 @@ struct TransitionResult
 {
     std::vector<state::TransactionReceipt> receipts;
     std::vector<RejectedTransaction> rejected;
-    std::optional<std::vector<state::Requests>> requests;
+    std::vector<state::Requests> requests;
+    std::error_code requests_error;
     int64_t gas_used;
     state::BloomFilter bloom;
     int64_t blob_gas_left;
@@ -99,31 +100,32 @@ TransitionResult apply_block(const TestState& state, evmc::VM& vm, const state::
         }
     }
 
-    auto requests = [&]() -> std::optional<std::vector<state::Requests>> {
-        std::vector<state::Requests> collected;
-
-        if (rev >= EVMC_PRAGUE)
-        {
-            auto opt_deposits = collect_deposit_requests(receipts);
-            if (!opt_deposits.has_value())
-                return std::nullopt;
-            collected.emplace_back(std::move(*opt_deposits));
-        }
-
-        auto requests_result = system_call_block_end(block_state, block, block_hashes, rev, vm);
-        if (!requests_result.has_value())
-            return std::nullopt;
-        std::ranges::move(*requests_result, std::back_inserter(collected));
-
-        return collected;
-    }();
+    std::vector<state::Requests> requests;
+    std::error_code requests_error;
+    if (rev >= EVMC_PRAGUE)
+    {
+        auto opt_deposits = collect_deposit_requests(receipts);
+        if (opt_deposits.has_value())
+            requests.emplace_back(std::move(*opt_deposits));
+        else
+            requests_error = make_error_code(state::INVALID_DEPOSIT_EVENT_LAYOUT);
+    }
+    if (!requests_error)
+    {
+        auto block_end = system_call_block_end(block_state, block, block_hashes, rev, vm);
+        if (const auto* ec = std::get_if<std::error_code>(&block_end))
+            requests_error = *ec;
+        else
+            std::ranges::move(
+                std::get<std::vector<state::Requests>>(block_end), std::back_inserter(requests));
+    }
 
     finalize(block_state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
 
     const auto bloom = compute_bloom_filter(receipts);
 
-    return {std::move(receipts), std::move(rejected_txs), std::move(requests), block_gas_used,
-        bloom, blob_gas_left, std::move(block_state)};
+    return {std::move(receipts), std::move(rejected_txs), std::move(requests), requests_error,
+        block_gas_used, bloom, blob_gas_left, std::move(block_state)};
 }
 
 /// Validates block-level validity unrelated to individual transactions.
@@ -333,7 +335,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 auto res = apply_block(pre_state, vm, bi, block_hashes, test_block.transactions,
                     rev, blob_gas_limit, mining_reward(rev));
 
-                ASSERT_TRUE(res.requests.has_value());
+                ASSERT_FALSE(res.requests_error);
 
                 block_hashes[test_block.expected_block_header.block_number] =
                     test_block.expected_block_header.hash;
@@ -373,7 +375,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                     state::mpt_hash(res.receipts), test_block.expected_block_header.receipts_root);
                 if (rev >= EVMC_PRAGUE)
                 {
-                    EXPECT_EQ(calculate_requests_hash(*res.requests),
+                    EXPECT_EQ(calculate_requests_hash(res.requests),
                         test_block.expected_block_header.requests_hash);
                 }
                 EXPECT_EQ(res.gas_used, test_block.expected_block_header.gas_used);
@@ -402,10 +404,29 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
 
                 const auto res = apply_block(pre_state, vm, bi, block_hashes,
                     test_block.transactions, rev, blob_gas_limit, mining_reward(rev));
-                if (!res.requests.has_value())
-                    continue;
                 if (!res.rejected.empty())
+                {
+                    // Check if EEST expects transaction-level exception (ignore "legacy" names).
+                    if (test_block.expected_exception.find("Exception.") != std::string::npos)
+                    {
+                        EXPECT_TRUE(
+                            test_block.expected_exception.starts_with("TransactionException."))
+                            << "Transaction-level invalidity mismatch: got "
+                            << res.rejected.front().message << ", expected "
+                            << test_block.expected_exception;
+                    }
                     continue;
+                }
+                if (res.requests_error)
+                {
+                    // Requests collection failure; verify the reason matches (same
+                    // `BlockException.*` substring match as the block validation errors above).
+                    EXPECT_NE(test_block.expected_exception.find(res.requests_error.message()),
+                        std::string::npos)
+                        << "Block invalidity reason mismatch: got " << res.requests_error.message()
+                        << ", expected " << test_block.expected_exception;
+                    continue;
+                }
                 if (blob_gas_limit - res.blob_gas_left !=
                     static_cast<int64_t>(bi.blob_gas_used.value_or(0)))
                     continue;
@@ -421,7 +442,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                     continue;
                 if (state::mpt_hash(res.receipts) != test_block.expected_block_header.receipts_root)
                     continue;
-                if (rev >= EVMC_PRAGUE && calculate_requests_hash(*res.requests) !=
+                if (rev >= EVMC_PRAGUE && calculate_requests_hash(res.requests) !=
                                               test_block.expected_block_header.requests_hash)
                     continue;
                 if (res.gas_used != test_block.expected_block_header.gas_used)

--- a/test/state/errors.hpp
+++ b/test/state/errors.hpp
@@ -42,6 +42,11 @@ enum ErrorCode : int  // NOLINT(*-use-enum-class)
     INVALID_BLOCK_TIMESTAMP_OLDER_THAN_PARENT,
     INVALID_BLOCK_PARENT,
     INVALID_BLOCK_NUMBER,
+
+    // Block requests collection (EIP-7685).
+    INVALID_DEPOSIT_EVENT_LAYOUT,
+    SYSTEM_CONTRACT_EMPTY,
+    SYSTEM_CONTRACT_CALL_FAILED,
 };
 
 /// Obtains a reference to the static error category object for evmone errors.
@@ -113,6 +118,12 @@ inline const std::error_category& evmone_category() noexcept
                 return "BlockException.INVALID_BLOCK_PARENT";
             case INVALID_BLOCK_NUMBER:
                 return "BlockException.INVALID_BLOCK_NUMBER";
+            case INVALID_DEPOSIT_EVENT_LAYOUT:
+                return "BlockException.INVALID_DEPOSIT_EVENT_LAYOUT";
+            case SYSTEM_CONTRACT_EMPTY:
+                return "BlockException.SYSTEM_CONTRACT_EMPTY";
+            case SYSTEM_CONTRACT_CALL_FAILED:
+                return "BlockException.SYSTEM_CONTRACT_CALL_FAILED";
             default:
                 assert(false);
                 return "Wrong error code";

--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "system_contracts.hpp"
+#include "errors.hpp"
 #include "host.hpp"
 #include "state_view.hpp"
 
@@ -106,7 +107,7 @@ StateDiff system_call_block_start(const StateView& state_view, const BlockInfo& 
     return state.build_diff(rev);
 }
 
-std::optional<RequestsResult> system_call_block_end(const StateView& state_view,
+std::variant<RequestsResult, std::error_code> system_call_block_end(const StateView& state_view,
     const BlockInfo& block, const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
 {
     State state{state_view};
@@ -119,11 +120,11 @@ std::optional<RequestsResult> system_call_block_end(const StateView& state_view,
         // Fail if the target account doesn't exist. This is by EIP-7002 and EIP-7251 spec.
         const auto code = state_view.get_account_code(addr);
         if (code.empty())
-            return std::nullopt;
+            return make_error_code(SYSTEM_CONTRACT_EMPTY);
 
         const auto res = execute_system_call(state, block, block_hashes, rev, vm, addr, code, {});
         if (res.status_code != EVMC_SUCCESS)
-            return std::nullopt;
+            return make_error_code(SYSTEM_CONTRACT_CALL_FAILED);
         requests.emplace_back(request_type, bytes_view{res.output_data, res.output_size});
     }
     return RequestsResult{state.build_diff(rev), requests};

--- a/test/state/system_contracts.hpp
+++ b/test/state/system_contracts.hpp
@@ -5,6 +5,8 @@
 
 #include "requests.hpp"
 #include <evmc/evmc.hpp>
+#include <system_error>
+#include <variant>
 
 namespace evmone::state
 {
@@ -49,7 +51,9 @@ struct RequestsResult
 ///
 /// Executes code of pre-defined accounts via pseudo-transaction from the system sender (0xff...fe).
 /// The sender's nonce is not increased.
-/// @return The collected requests and state diff or std::nullopt if the execution has failed.
-[[nodiscard]] std::optional<RequestsResult> system_call_block_end(const StateView& state_view,
-    const BlockInfo& block, const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
+/// @return The collected requests and state diff, or the error code identifying why the block
+///         requests collection failed.
+[[nodiscard]] std::variant<RequestsResult, std::error_code> system_call_block_end(
+    const StateView& state_view, const BlockInfo& block, const BlockHashes& block_hashes,
+    evmc_revision rev, evmc::VM& vm);
 }  // namespace evmone::state

--- a/test/unittests/state_system_call_test.cpp
+++ b/test/unittests/state_system_call_test.cpp
@@ -81,8 +81,8 @@ TEST_F(state_system_call, withdrawal)
     state[CONSOLIDATION_REQUEST_ADDRESS].code = bytecode{OP_STOP};
 
     const auto r = system_call_block_end(state, block, block_hashes, EVMC_PRAGUE, vm);
-    ASSERT_TRUE(r.has_value());
-    const auto& requests = *r;
+    ASSERT_TRUE(std::holds_alternative<std::vector<Requests>>(r));
+    const auto& requests = std::get<std::vector<Requests>>(r);
 
     EXPECT_FALSE(state.contains(SYSTEM_ADDRESS));
     const auto& c = state.at(WITHDRAWAL_REQUEST_ADDRESS);
@@ -109,8 +109,8 @@ TEST_F(state_system_call, consolidation)
     state[WITHDRAWAL_REQUEST_ADDRESS].code = bytecode{OP_STOP};
 
     const auto r = system_call_block_end(state, block, block_hashes, EVMC_PRAGUE, vm);
-    ASSERT_TRUE(r.has_value());
-    const auto& requests = *r;
+    ASSERT_TRUE(std::holds_alternative<std::vector<Requests>>(r));
+    const auto& requests = std::get<std::vector<Requests>>(r);
 
     EXPECT_FALSE(state.contains(SYSTEM_ADDRESS));
     const auto& c = state.at(CONSOLIDATION_REQUEST_ADDRESS);

--- a/test/utils/t8n.cpp
+++ b/test/utils/t8n.cpp
@@ -4,6 +4,7 @@
 
 #include "t8n.hpp"
 #include <nlohmann/json.hpp>
+#include <test/state/errors.hpp>
 #include <test/state/ethash_difficulty.hpp>
 #include <test/state/requests.hpp>
 #include <test/utils/mpt_hash.hpp>
@@ -200,13 +201,15 @@ void t8n(evmc::VM& vm, const T8NArgs& args)
                 requests.emplace_back(std::move(*deposits_result));
             else
                 // Report invalid block in the JSON result when deposit collection fails.
-                j_result["blockException"] = "invalid deposit event layout";
+                j_result["blockException"] =
+                    make_error_code(state::INVALID_DEPOSIT_EVENT_LAYOUT).message();
             auto requests_result = system_call_block_end(state, block, block_hashes, rev, vm);
-            if (requests_result.has_value())
-                std::ranges::move(*requests_result, std::back_inserter(requests));
+            if (auto* r = std::get_if<std::vector<state::Requests>>(&requests_result))
+                std::ranges::move(*r, std::back_inserter(requests));
             else
-                // Report invalid block in the JSON result when requests fail.
-                j_result["blockException"] = "system contract empty or failed";
+                // Report invalid block in the JSON result with the specific requests failure
+                // (empty system contract vs. failed system call).
+                j_result["blockException"] = std::get<std::error_code>(requests_result).message();
         }
 
         finalize(state, rev, block.coinbase, args.block_reward, block.ommers, block.withdrawals);

--- a/test/utils/test_state.cpp
+++ b/test/utils/test_state.cpp
@@ -101,14 +101,15 @@ void system_call_block_start(TestState& state, const state::BlockInfo& block,
     state.apply(diff);
 }
 
-std::optional<std::vector<state::Requests>> system_call_block_end(TestState& state,
+std::variant<std::vector<state::Requests>, std::error_code> system_call_block_end(TestState& state,
     const state::BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev,
     evmc::VM& vm)
 {
     auto result = state::system_call_block_end(state, block, block_hashes, rev, vm);
-    if (!result.has_value())
-        return std::nullopt;
-    state.apply(result->state_diff);
-    return std::move(result->requests);
+    if (const auto* error = std::get_if<std::error_code>(&result))
+        return *error;
+    auto& requests_result = std::get<state::RequestsResult>(result);
+    state.apply(requests_result.state_diff);
+    return std::move(requests_result.requests);
 }
 }  // namespace evmone::test

--- a/test/utils/test_state.hpp
+++ b/test/utils/test_state.hpp
@@ -84,7 +84,8 @@ void system_call_block_start(TestState& state, const state::BlockInfo& block,
     const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
 
 /// Wrapping of state::system_call_block_end() which operates on TestState.
-std::optional<std::vector<state::Requests>> system_call_block_end(TestState& state,
+/// Returns the collected requests, or the error code if the collection failed.
+std::variant<std::vector<state::Requests>, std::error_code> system_call_block_end(TestState& state,
     const state::BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev,
     evmc::VM& vm);
 }  // namespace test


### PR DESCRIPTION
The invalid-block branch silently accepted any transition failure without checking it against the fixture's `expectException`. Verify those reasons:

- Requests collection failures map to distinct exceptions (`INVALID_DEPOSIT_EVENT_LAYOUT`, `SYSTEM_CONTRACT_EMPTY`, `SYSTEM_CONTRACT_CALL_FAILED`); `system_call_block_end` now returns the specific error code, which t8n also reports.
- A rejected transaction is required to match a `TransactionException.*` fixture (it stops block processing immediately).
