### PR TITLE
Wrap gas counter (gas_left) in a strong Gas type

### DIFF
--- a/lib/evmone/advanced_analysis.hpp
+++ b/lib/evmone/advanced_analysis.hpp
@@ -35,7 +35,7 @@ static_assert(sizeof(BlockInfo) == 8);
 /// The execution state specialized for the Advanced interpreter.
 struct AdvancedExecutionState : ExecutionState
 {
-    int64_t gas_left = 0;
+    Gas gas_left;
 
     /// Pointer to the stack top.
     StackTop stack = stack_space.bottom();
@@ -75,7 +75,7 @@ struct AdvancedExecutionState : ExecutionState
         bytes_view _code) noexcept
     {
         ExecutionState::reset(message, revision, host_interface, host_ctx, _code);
-        gas_left = message.gas;
+        gas_left = Gas{message.gas};
         stack = stack_space.bottom();
         analysis.advanced = nullptr;  // For consistency with previous behavior.
         current_block_cost = 0;

--- a/lib/evmone/advanced_execution.cpp
+++ b/lib/evmone/advanced_execution.cpp
@@ -17,7 +17,9 @@ evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& a
         instr = instr->fn(instr, state);
 
     const auto gas_left =
-        (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
+        (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ?
+            static_cast<int64_t>(state.gas_left) :
+            0;
     const auto gas_refund = (state.status == EVMC_SUCCESS) ? state.gas_refund : 0;
 
     assert(state.output_size != 0 || state.output_offset == 0);

--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -40,7 +40,7 @@ inline evmc_status_code impl(AdvancedExecutionState& state) noexcept
 }
 
 template <Opcode Op,
-    evmc_status_code CoreFn(StackTop, int64_t&, ExecutionState&) noexcept = core::impl<Op>>
+    evmc_status_code CoreFn(StackTop, Gas&, ExecutionState&) noexcept = core::impl<Op>>
 inline evmc_status_code impl(AdvancedExecutionState& state) noexcept
 {
     const auto status = CoreFn(state.stack, state.gas_left, state);
@@ -48,7 +48,7 @@ inline evmc_status_code impl(AdvancedExecutionState& state) noexcept
     return status;
 }
 
-template <Opcode Op, Result CoreFn(StackTop, int64_t, ExecutionState&) noexcept = core::impl<Op>>
+template <Opcode Op, Result CoreFn(StackTop, Gas, ExecutionState&) noexcept = core::impl<Op>>
 inline evmc_status_code impl(AdvancedExecutionState& state) noexcept
 {
     const auto status = CoreFn(state.stack, state.gas_left, state);
@@ -58,7 +58,7 @@ inline evmc_status_code impl(AdvancedExecutionState& state) noexcept
 }
 
 template <Opcode Op,
-    TermResult CoreFn(StackTop, int64_t, ExecutionState&) noexcept = core::impl<Op>>
+    TermResult CoreFn(StackTop, Gas, ExecutionState&) noexcept = core::impl<Op>>
 inline TermResult impl(AdvancedExecutionState& state) noexcept
 {
     // Stack height adjustment may be omitted.
@@ -187,7 +187,7 @@ const Instruction* op_pc(const Instruction* instr, AdvancedExecutionState& state
 const Instruction* op_gas(const Instruction* instr, AdvancedExecutionState& state) noexcept
 {
     const auto correction = state.current_block_cost - instr->arg.number;
-    const auto gas = static_cast<uint64_t>(state.gas_left + correction);
+    const auto gas = static_cast<int64_t>(state.gas_left + correction);
     state.stack.push(gas);
     return ++instr;
 }

--- a/lib/evmone/baseline_execution.cpp
+++ b/lib/evmone/baseline_execution.cpp
@@ -41,7 +41,7 @@ namespace
 /// @return  Status code with information which check has failed
 ///          or EVMC_SUCCESS if everything is fine.
 template <Opcode Op>
-inline evmc_status_code check_requirements(const CostTable& cost_table, int64_t& gas_left,
+inline evmc_status_code check_requirements(const CostTable& cost_table, Gas& gas_left,
     const uint256* stack_top, const uint256* stack_bottom) noexcept
 {
     static_assert(
@@ -100,14 +100,14 @@ struct Position
 /// Helpers for invoking instruction implementations of different signatures.
 /// @{
 [[release_inline]] inline code_iterator invoke(void (*instr_fn)(StackTop) noexcept, Position pos,
-    int64_t& /*gas*/, ExecutionState& /*state*/) noexcept
+    Gas& /*gas*/, ExecutionState& /*state*/) noexcept
 {
     instr_fn(pos.stack_end);
     return pos.code_it + 1;
 }
 
 [[release_inline]] inline code_iterator invoke(
-    Result (*instr_fn)(StackTop, int64_t, ExecutionState&) noexcept, Position pos, int64_t& gas,
+    Result (*instr_fn)(StackTop, Gas, ExecutionState&) noexcept, Position pos, Gas& gas,
     ExecutionState& state) noexcept
 {
     const auto o = instr_fn(pos.stack_end, gas, state);
@@ -121,7 +121,7 @@ struct Position
 }
 
 [[release_inline]] inline code_iterator invoke(void (*instr_fn)(StackTop, ExecutionState&) noexcept,
-    Position pos, int64_t& /*gas*/, ExecutionState& state) noexcept
+    Position pos, Gas& /*gas*/, ExecutionState& state) noexcept
 {
     instr_fn(pos.stack_end, state);
     return pos.code_it + 1;
@@ -129,13 +129,13 @@ struct Position
 
 [[release_inline]] inline code_iterator invoke(
     code_iterator (*instr_fn)(StackTop, ExecutionState&, code_iterator) noexcept, Position pos,
-    int64_t& /*gas*/, ExecutionState& state) noexcept
+    Gas& /*gas*/, ExecutionState& state) noexcept
 {
     return instr_fn(pos.stack_end, state, pos.code_it);
 }
 
 [[release_inline]] inline code_iterator invoke(
-    TermResult (*instr_fn)(StackTop, int64_t, ExecutionState&) noexcept, Position pos, int64_t& gas,
+    TermResult (*instr_fn)(StackTop, Gas, ExecutionState&) noexcept, Position pos, Gas& gas,
     ExecutionState& state) noexcept
 {
     const auto result = instr_fn(pos.stack_end, gas, state);
@@ -147,7 +147,7 @@ struct Position
 /// A helper to invoke the instruction implementation of the given opcode Op.
 template <Opcode Op>
 [[release_inline]] inline Position invoke(const CostTable& cost_table, const uint256* stack_bottom,
-    Position pos, int64_t& gas, ExecutionState& state) noexcept
+    Position pos, Gas& gas, ExecutionState& state) noexcept
 {
     if (const auto status = check_requirements<Op>(cost_table, gas, pos.stack_end, stack_bottom);
         status != EVMC_SUCCESS)
@@ -162,7 +162,7 @@ template <Opcode Op>
 
 
 template <bool TracingEnabled>
-int64_t dispatch(const CostTable& cost_table, ExecutionState& state, int64_t gas,
+Gas dispatch(const CostTable& cost_table, ExecutionState& state, Gas gas,
     const uint8_t* code, Tracer* tracer = nullptr) noexcept
 {
     const auto stack_bottom = state.stack_space.bottom();
@@ -179,7 +179,7 @@ int64_t dispatch(const CostTable& cost_table, ExecutionState& state, int64_t gas
             if (offset < state.original_code.size())  // Skip STOP from code padding.
             {
                 tracer->notify_instruction_start(
-                    offset, position.stack_end - 1, stack_height, gas, state);
+                    offset, position.stack_end - 1, stack_height, static_cast<int64_t>(gas), state);
             }
         }
 
@@ -214,8 +214,8 @@ int64_t dispatch(const CostTable& cost_table, ExecutionState& state, int64_t gas
 }
 
 #if EVMONE_CGOTO_SUPPORTED
-int64_t dispatch_cgoto(
-    const CostTable& cost_table, ExecutionState& state, int64_t gas, const uint8_t* code) noexcept
+Gas dispatch_cgoto(
+    const CostTable& cost_table, ExecutionState& state, Gas gas, const uint8_t* code) noexcept
 {
 #pragma GCC diagnostic ignored "-Wpedantic"
 
@@ -267,7 +267,7 @@ evmc_result execute(VM& vm, const evmc_host_interface& host, evmc_host_context* 
 {
     const auto code = analysis.code();
     const auto code_begin = code.data();
-    auto gas = msg.gas;
+    auto gas = Gas{msg.gas};
 
     auto& state = vm.get_execution_state(static_cast<size_t>(msg.depth));
     state.reset(msg, rev, host, ctx, code);
@@ -292,7 +292,9 @@ evmc_result execute(VM& vm, const evmc_host_interface& host, evmc_host_context* 
             gas = dispatch<false>(cost_table, state, gas, code_begin);
     }
 
-    const auto gas_left = (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? gas : 0;
+    const int64_t gas_left =
+        (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? static_cast<int64_t>(gas) :
+                                                                        0;
     const auto gas_refund = (state.status == EVMC_SUCCESS) ? state.gas_refund : 0;
 
     assert(state.output_size != 0 || state.output_offset == 0);

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -5,6 +5,7 @@
 
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
+#include <compare>
 #include <exception>
 #include <memory>
 #include <string>
@@ -24,6 +25,45 @@ class CodeAnalysis;
 using evmc::bytes;
 using evmc::bytes_view;
 using intx::uint256;
+
+
+/// Strong type wrapper for the EVM gas counter.
+///
+/// Wraps int64_t to prevent accidental mixing of gas with other integers.
+/// Conversions to/from int64_t are explicit, so gas only crosses into the raw
+/// int64_t world (EVMC messages/results, the stack, tracing) at deliberate
+/// static_cast points. The gas-domain arithmetic operators accept raw int64_t
+/// cost operands so instruction implementations are unchanged.
+class Gas
+{
+    int64_t m_value = 0;
+
+public:
+    Gas() = default;
+    explicit constexpr Gas(int64_t value) noexcept : m_value{value} {}
+    explicit constexpr operator int64_t() const noexcept { return m_value; }
+
+    constexpr Gas& operator-=(int64_t cost) noexcept
+    {
+        m_value -= cost;
+        return *this;
+    }
+    constexpr Gas& operator+=(int64_t amount) noexcept
+    {
+        m_value += amount;
+        return *this;
+    }
+
+    friend constexpr Gas operator-(Gas a, Gas b) noexcept { return Gas{a.m_value - b.m_value}; }
+    friend constexpr Gas operator+(Gas a, int64_t b) noexcept { return Gas{a.m_value + b}; }
+    friend constexpr Gas operator/(Gas a, int64_t b) noexcept { return Gas{a.m_value / b}; }
+
+    friend constexpr std::strong_ordering operator<=>(Gas a, int64_t b) noexcept
+    {
+        return a.m_value <=> b;
+    }
+    friend constexpr bool operator==(Gas a, int64_t b) noexcept { return a.m_value == b; }
+};
 
 
 /// Provides memory for EVM stack.

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -48,7 +48,7 @@ public:
 struct Result
 {
     evmc_status_code status;
-    int64_t gas_left;
+    Gas gas_left;
 };
 
 /// Instruction result indicating that execution terminates unconditionally.
@@ -121,8 +121,8 @@ constexpr int64_t copy_cost(uint64_t size_in_bytes) noexcept
 /// - making mload()/mstore()/mstore8() too costly to inline.
 ///
 /// TODO: This function should be moved to Memory class.
-[[gnu::noinline]] inline int64_t grow_memory(
-    int64_t gas_left, Memory& memory, uint64_t new_size) noexcept
+[[gnu::noinline]] inline Gas grow_memory(
+    Gas gas_left, Memory& memory, uint64_t new_size) noexcept
 {
     // This implementation recomputes memory.size(). This value is already known to the caller
     // and can be passed as a parameter, but this makes no difference to the performance.
@@ -141,7 +141,7 @@ constexpr int64_t copy_cost(uint64_t size_in_bytes) noexcept
 
 /// Check memory requirements of a reasonable size.
 inline bool check_memory(
-    int64_t& gas_left, Memory& memory, const uint256& offset, uint64_t size) noexcept
+    Gas& gas_left, Memory& memory, const uint256& offset, uint64_t size) noexcept
 {
     // TODO: This should be done in intx.
     // There is "branchless" variant of this using | instead of ||, but benchmarks difference
@@ -162,7 +162,7 @@ inline bool check_memory(
 
 /// Check memory requirements for "copy" instructions.
 inline bool check_memory(
-    int64_t& gas_left, Memory& memory, const uint256& offset, const uint256& size) noexcept
+    Gas& gas_left, Memory& memory, const uint256& offset, const uint256& size) noexcept
 {
     if (size == 0)  // Copy of size 0 is always valid (even if offset is huge).
         return true;
@@ -193,7 +193,7 @@ inline constexpr auto jumpdest = noop;
 
 template <evmc_status_code Status>
 inline TermResult stop_impl(
-    StackTop /*stack*/, int64_t gas_left, ExecutionState& /*state*/) noexcept
+    StackTop /*stack*/, Gas gas_left, ExecutionState& /*state*/) noexcept
 {
     return {Status, gas_left};
 }
@@ -255,7 +255,7 @@ inline void mulmod(StackTop stack) noexcept
     m = m != 0 ? intx::mulmod(x, y, m) : 0;
 }
 
-inline Result exp(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result exp(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& base = stack.pop();
     auto& exponent = stack.top();
@@ -400,7 +400,7 @@ inline void clz(StackTop stack) noexcept
     stack.top() = clz(stack.top());
 }
 
-inline Result keccak256(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result keccak256(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& index = stack.pop();
     auto& size = stack.top();
@@ -426,7 +426,7 @@ inline void address(StackTop stack, ExecutionState& state) noexcept
     stack.push(intx::be::load<uint256>(state.msg->recipient));
 }
 
-inline Result balance(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result balance(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     auto& x = stack.top();
     const auto addr = intx::be::trunc<evmc::address>(x);
@@ -480,7 +480,7 @@ inline void calldatasize(StackTop stack, ExecutionState& state) noexcept
     stack.push(state.msg->input_size);
 }
 
-inline Result calldatacopy(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result calldatacopy(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& mem_index = stack.pop();
     const auto& input_index = stack.pop();
@@ -512,7 +512,7 @@ inline void codesize(StackTop stack, ExecutionState& state) noexcept
     stack.push(state.original_code.size());
 }
 
-inline Result codecopy(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result codecopy(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     // TODO: Similar to calldatacopy().
 
@@ -573,7 +573,7 @@ inline void slotnum(StackTop stack, ExecutionState& state) noexcept
     stack.push(state.get_tx_context().block_slot_number);
 }
 
-inline Result extcodesize(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result extcodesize(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     auto& x = stack.top();
     const auto addr = intx::be::trunc<evmc::address>(x);
@@ -588,7 +588,7 @@ inline Result extcodesize(StackTop stack, int64_t gas_left, ExecutionState& stat
     return {EVMC_SUCCESS, gas_left};
 }
 
-inline Result extcodecopy(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result extcodecopy(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto addr = intx::be::trunc<evmc::address>(stack.pop());
     const auto& mem_index = stack.pop();
@@ -626,7 +626,7 @@ inline void returndatasize(StackTop stack, ExecutionState& state) noexcept
     stack.push(state.return_data.size());
 }
 
-inline Result returndatacopy(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result returndatacopy(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& mem_index = stack.pop();
     const auto& input_index = stack.pop();
@@ -654,7 +654,7 @@ inline Result returndatacopy(StackTop stack, int64_t gas_left, ExecutionState& s
     return {EVMC_SUCCESS, gas_left};
 }
 
-inline Result extcodehash(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result extcodehash(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     auto& x = stack.top();
     const auto addr = intx::be::trunc<evmc::address>(x);
@@ -720,7 +720,7 @@ inline void selfbalance(StackTop stack, ExecutionState& state) noexcept
     stack.push(intx::be::load<uint256>(state.host.get_balance(state.msg->recipient)));
 }
 
-inline Result mload(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result mload(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     auto& index = stack.top();
 
@@ -731,7 +731,7 @@ inline Result mload(StackTop stack, int64_t gas_left, ExecutionState& state) noe
     return {EVMC_SUCCESS, gas_left};
 }
 
-inline Result mstore(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result mstore(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& index = stack.pop();
     const auto& value = stack.pop();
@@ -743,7 +743,7 @@ inline Result mstore(StackTop stack, int64_t gas_left, ExecutionState& state) no
     return {EVMC_SUCCESS, gas_left};
 }
 
-inline Result mstore8(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result mstore8(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& index = stack.pop();
     const auto& value = stack.pop();
@@ -755,9 +755,9 @@ inline Result mstore8(StackTop stack, int64_t gas_left, ExecutionState& state) n
     return {EVMC_SUCCESS, gas_left};
 }
 
-Result sload(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+Result sload(StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 
-Result sstore(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+Result sstore(StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 
 /// Internal jump implementation for JUMP/JUMPI instructions.
 inline code_iterator jump_impl(ExecutionState& state, const uint256& dst) noexcept
@@ -797,9 +797,9 @@ inline void msize(StackTop stack, ExecutionState& state) noexcept
     stack.push(state.memory.size());
 }
 
-inline Result gas(StackTop stack, int64_t gas_left, ExecutionState& /*state*/) noexcept
+inline Result gas(StackTop stack, Gas gas_left, ExecutionState& /*state*/) noexcept
 {
-    stack.push(gas_left);
+    stack.push(static_cast<int64_t>(gas_left));
     return {EVMC_SUCCESS, gas_left};
 }
 
@@ -811,10 +811,10 @@ inline void tload(StackTop stack, ExecutionState& state) noexcept
     x = intx::be::load<uint256>(value);
 }
 
-inline Result tstore(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result tstore(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     if (state.in_static_mode())
-        return {EVMC_STATIC_MODE_VIOLATION, 0};
+        return {EVMC_STATIC_MODE_VIOLATION, Gas{0}};
 
     const auto key = intx::be::store<evmc::bytes32>(stack.pop());
     const auto value = intx::be::store<evmc::bytes32>(stack.pop());
@@ -975,7 +975,7 @@ inline code_iterator exchange(StackTop stack, ExecutionState& state, code_iterat
     return pos + 2;
 }
 
-inline Result mcopy(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result mcopy(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& dst_u256 = stack.pop();
     const auto& src_u256 = stack.pop();
@@ -998,12 +998,12 @@ inline Result mcopy(StackTop stack, int64_t gas_left, ExecutionState& state) noe
 }
 
 template <size_t NumTopics>
-inline Result log(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline Result log(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     static_assert(NumTopics <= 4);
 
     if (state.in_static_mode())
-        return {EVMC_STATIC_MODE_VIOLATION, 0};
+        return {EVMC_STATIC_MODE_VIOLATION, Gas{0}};
 
     const auto& offset = stack.pop();
     const auto& size = stack.pop();
@@ -1032,19 +1032,19 @@ inline Result log(StackTop stack, int64_t gas_left, ExecutionState& state) noexc
 
 
 template <Opcode Op>
-Result call_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+Result call_impl(StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 inline constexpr auto call = call_impl<OP_CALL>;
 inline constexpr auto callcode = call_impl<OP_CALLCODE>;
 inline constexpr auto delegatecall = call_impl<OP_DELEGATECALL>;
 inline constexpr auto staticcall = call_impl<OP_STATICCALL>;
 
 template <Opcode Op>
-Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+Result create_impl(StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 inline constexpr auto create = create_impl<OP_CREATE>;
 inline constexpr auto create2 = create_impl<OP_CREATE2>;
 
 template <evmc_status_code StatusCode>
-inline TermResult return_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline TermResult return_impl(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     const auto& offset = stack[0];
     const auto& size = stack[1];
@@ -1060,7 +1060,7 @@ inline TermResult return_impl(StackTop stack, int64_t gas_left, ExecutionState& 
 inline constexpr auto return_ = return_impl<EVMC_SUCCESS>;
 inline constexpr auto revert = return_impl<EVMC_REVERT>;
 
-inline TermResult selfdestruct(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline TermResult selfdestruct(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     if (state.in_static_mode())
         return {EVMC_STATIC_MODE_VIOLATION, gas_left};

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -18,7 +18,7 @@ namespace
 /// Returns EIP-7702 delegate address if addr is delegated, or addr itself otherwise.
 /// Applies gas charge for accessing delegate account and may fail with out of gas.
 inline std::variant<evmc::address, Result> get_target_address(
-    const evmc::address& addr, int64_t& gas_left, ExecutionState& state) noexcept
+    const evmc::address& addr, Gas& gas_left, ExecutionState& state) noexcept
 {
     if (state.rev < EVMC_PRAGUE)
         return addr;
@@ -62,7 +62,7 @@ consteval evmc_call_kind to_call_kind(Opcode op) noexcept
 }
 
 template <Opcode Op>
-Result call_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+Result call_impl(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     static_assert(
         Op == OP_CALL || Op == OP_CALLCODE || Op == OP_DELEGATECALL || Op == OP_STATICCALL);
@@ -147,12 +147,12 @@ Result call_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexce
 
     if constexpr (Op == OP_STATICCALL)
     {
-        msg.gas = std::min(msg.gas, gas_left - gas_left / 64);
+        msg.gas = std::min(msg.gas, static_cast<int64_t>(gas_left - gas_left / 64));
     }
     else
     {
         if (state.rev >= EVMC_TANGERINE_WHISTLE)  // Always true for STATICCALL.
-            msg.gas = std::min(msg.gas, gas_left - gas_left / 64);
+            msg.gas = std::min(msg.gas, static_cast<int64_t>(gas_left - gas_left / 64));
         else if (msg.gas > gas_left)
             return {EVMC_OUT_OF_GAS, gas_left};
     }
@@ -185,16 +185,16 @@ Result call_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexce
 }
 
 template Result call_impl<OP_CALL>(
-    StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+    StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 template Result call_impl<OP_STATICCALL>(
-    StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+    StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 template Result call_impl<OP_DELEGATECALL>(
-    StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+    StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 template Result call_impl<OP_CALLCODE>(
-    StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+    StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 
 template <Opcode Op>
-Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+Result create_impl(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     static_assert(Op == OP_CREATE || Op == OP_CREATE2);
 
@@ -231,7 +231,7 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
         return {EVMC_SUCCESS, gas_left};  // "Light" failure.
 
     evmc_message msg{.kind = to_call_kind(Op)};
-    msg.gas = gas_left;
+    msg.gas = static_cast<int64_t>(gas_left);
     if (state.rev >= EVMC_TANGERINE_WHISTLE)
         msg.gas = msg.gas - msg.gas / 64;
 
@@ -258,7 +258,7 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
 }
 
 template Result create_impl<OP_CREATE>(
-    StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+    StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 template Result create_impl<OP_CREATE2>(
-    StackTop stack, int64_t gas_left, ExecutionState& state) noexcept;
+    StackTop stack, Gas gas_left, ExecutionState& state) noexcept;
 }  // namespace evmone::instr::core

--- a/lib/evmone/instructions_storage.cpp
+++ b/lib/evmone/instructions_storage.cpp
@@ -95,7 +95,7 @@ constexpr auto sstore_costs = []() noexcept {
 }();
 }  // namespace
 
-Result sload(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+Result sload(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     auto& x = stack.top();
     const auto key = intx::be::store<evmc::bytes32>(x);
@@ -116,7 +116,7 @@ Result sload(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
     return {EVMC_SUCCESS, gas_left};
 }
 
-Result sstore(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+Result sstore(StackTop stack, Gas gas_left, ExecutionState& state) noexcept
 {
     if (state.in_static_mode())
         return {EVMC_STATIC_MODE_VIOLATION, gas_left};

--- a/test/unittests/execution_state_test.cpp
+++ b/test/unittests/execution_state_test.cpp
@@ -74,7 +74,7 @@ TEST(execution_state, reset_advanced)
     const evmone::advanced::AdvancedCodeAnalysis analysis;
 
     evmone::advanced::AdvancedExecutionState st;
-    st.gas_left = 1;
+    st.gas_left = evmone::Gas{1};
     st.gas_refund = 2;
     st.stack.push(6u);
     st.memory.grow(64);


### PR DESCRIPTION
gas_left is a bare int64_t threaded through the whole interpreter, so it can be silently confused with unrelated integers (stack values, memory sizes, EVMC's own int64 gas fields). Wrap it in evmone::Gas: conversions to/from int64_t are explicit, so gas only crosses into raw int64_t at the EVMC boundary (message.gas, evmc::Result.gas_left, the GAS opcode push, tracing) through deliberate static_cast. The gas-domain operators (-=, +=, binary -, +, /, <=>) accept raw int64_t cost operands, so instruction bodies are unchanged and the change stays mechanical: Result::gas_left, check_requirements, every core impl, grow_memory/check_memory, dispatch[_cgoto] and
AdvancedExecutionState::gas_left.

Generated code is not identical to the int64_t version (measured on the clang assertions build, x86-64):

- baseline_execution.cpp.o gains 127 static instructions. The gas check (gas_left -= cost) < 0 lowers to `subq; jl` (signed-less, reusing the subtraction's flags) instead of `subq; js` (sign bit) -- same instruction count; in cmov contexts the spaceship form even drops a testq (`subq; cmovge` vs `testq; cmovns`).

- Hot path is zero-cost. Deterministic instruction counts (google benchmark --benchmark_perf_counters=INSTRUCTIONS) over single-opcode loops running millions of iterations stay within +0.003%: ADD +0.003%, MUL +0.001%, SUB/LT/GT/ISZERO/NOT/SIGNEXTEND/JUMPDEST +0.002..0.007%.

- A fixed ~255 extra instructions per execute() call remain (setup and teardown inlining churn from the boundary casts and the Gas dispatch return value): +0.003% on normal workloads, up to +0.9% only on trivially short executions (synth/loop_v1: 27544 vs 27289 instructions).

1115/1115 unit tests pass (baseline, advanced, cgoto).