### PR TITLE
ci: Upgrade codecov orb to 6.0.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  codecov: codecov/codecov@5.4.3
+  codecov: codecov/codecov@6.0.0
   win: circleci/windows@5.0
 
 executors:


### PR DESCRIPTION
The 5.4.3 orb fetched the Codecov PGP public key from Keybase to validate the CLI binary; Keybase is gone, so the "(Codecov) Validate CLI" step failed with "gpg: no valid OpenPGP data found" and broke every coverage-uploading job. Orb 6.0.0 ships wrapper 0.2.9, which embeds the PGP key instead of fetching it. Upload parameters are unchanged (6.0.0 only adds a backward-compatible cli_type, default codecov-cli).