### PR TITLE
evmc: Bump ABI version to 13

### DIFF
--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -39,12 +39,13 @@ enum
     /**
      * The EVMC ABI version number of the interface declared in this file.
      *
-     * The EVMC ABI version always equals the major version number of the EVMC project.
+     * The ABI version is incremented on every incompatible change of the EVMC API or ABI
+     * (up to EVMC 12 it equaled the major version number of the standalone EVMC project).
      * The Host SHOULD check if the ABI versions match when dynamically loading VMs.
      *
      * @see @ref versioning
      */
-    EVMC_ABI_VERSION = 12
+    EVMC_ABI_VERSION = 13
 };
 
 


### PR DESCRIPTION
The ABI changed incompatibly since EVMC 12 (evmone 0.21.0) while the version number stayed at 12, so a host built against ABI-12 headers would load the new VM cleanly and then read structs at wrong offsets:

- evmc_tx_context layout changed: the TXCREATE initcodes fields were removed (#1514) and block_slot_number was added for EIP-7843 (#1517).
- evmc_result lost the reserved optional-data storage (#1529).
- EVMC_EOFCREATE was removed from evmc_call_kind, freeing value 5 for future reuse (#1515).
- The EVMC_AMSTERDAM revision was added (#1508).

This is the first ABI bump since EVMC was merged into evmone, so the version no longer tracks the standalone EVMC project's major version; the doc comment is updated accordingly.