### PR TITLE
Implement EIP-7708: "ETH transfers emit a log"

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -4,6 +4,7 @@
 
 #include "host.hpp"
 #include "precompiles.hpp"
+#include "system_contracts.hpp"
 #include <evmone/constants.hpp>
 
 namespace evmone::state
@@ -142,6 +143,9 @@ bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcep
         acc.balance = 0;
         beneficiary_acc.balance += balance;  // Keep balance if acc is the beneficiary.
 
+        if (m_rev >= EVMC_AMSTERDAM && balance != 0 && addr != beneficiary)
+            emit_transfer_log(m_logs, addr, beneficiary, balance);
+
         // Return "selfdestruct not registered".
         // In practice this affects only refunds before Cancun.
         return false;
@@ -154,6 +158,9 @@ bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcep
         beneficiary_acc.balance += balance;
         acc.balance = 0;  // Zero balance if acc is the beneficiary (before EIP-8246)
     }
+
+    if (m_rev >= EVMC_AMSTERDAM && balance != 0 && addr != beneficiary)
+        emit_transfer_log(m_logs, addr, beneficiary, balance);
 
     // Mark the destruction if not done already.
     if (!acc.destructed)
@@ -286,6 +293,10 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     sender_acc.balance -= value;
     new_acc->balance += value;  // The new account may be prefunded.
 
+    // Emit transfer log (EIP-7708), CREATE address is always different from sender.
+    if (m_rev >= EVMC_AMSTERDAM && value != 0)
+        emit_transfer_log(m_logs, msg.sender, msg.recipient, value);
+
     auto create_msg = msg;
     create_msg.input_data = nullptr;
     create_msg.input_size = 0;
@@ -360,6 +371,9 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
             m_state.journal_balance_change(msg.recipient, dst_acc.balance);
             m_state.get(msg.sender).balance -= value;
             dst_acc.balance += value;
+
+            if (m_rev >= EVMC_AMSTERDAM && address{msg.sender} != msg.recipient)
+                emit_transfer_log(m_logs, msg.sender, msg.recipient, value);
         }
     }
 

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -143,7 +143,7 @@ bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcep
         acc.balance = 0;
         beneficiary_acc.balance += balance;  // Keep balance if acc is the beneficiary.
 
-        if (m_rev >= EVMC_AMSTERDAM && balance != 0 && addr != beneficiary)
+        if (m_rev >= EVMC_AMSTERDAM)
             emit_transfer_log(m_logs, addr, beneficiary, balance);
 
         // Return "selfdestruct not registered".
@@ -159,7 +159,7 @@ bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcep
         acc.balance = 0;  // Zero balance if acc is the beneficiary (before EIP-8246)
     }
 
-    if (m_rev >= EVMC_AMSTERDAM && balance != 0 && addr != beneficiary)
+    if (m_rev >= EVMC_AMSTERDAM)
         emit_transfer_log(m_logs, addr, beneficiary, balance);
 
     // Mark the destruction if not done already.
@@ -293,8 +293,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     sender_acc.balance -= value;
     new_acc->balance += value;  // The new account may be prefunded.
 
-    // Emit transfer log (EIP-7708), CREATE address is always different from sender.
-    if (m_rev >= EVMC_AMSTERDAM && value != 0)
+    if (m_rev >= EVMC_AMSTERDAM)
         emit_transfer_log(m_logs, msg.sender, msg.recipient, value);
 
     auto create_msg = msg;
@@ -372,7 +371,7 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
             m_state.get(msg.sender).balance -= value;
             dst_acc.balance += value;
 
-            if (m_rev >= EVMC_AMSTERDAM && address{msg.sender} != msg.recipient)
+            if (m_rev >= EVMC_AMSTERDAM)
                 emit_transfer_log(m_logs, msg.sender, msg.recipient, value);
         }
     }

--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -11,7 +11,7 @@ namespace evmone::state
 {
 namespace
 {
-/// EIP-7708: keccak256("Transfer(address,address,uint256)")
+/// The ETH transfer log topic (EIP-7708): keccak256("Transfer(address,address,uint256)")
 constexpr auto TRANSFER_EVENT_TOPIC =
     0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef_bytes32;
 

--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -11,6 +11,19 @@ namespace evmone::state
 {
 namespace
 {
+/// EIP-7708: keccak256("Transfer(address,address,uint256)")
+constexpr auto TRANSFER_EVENT_TOPIC =
+    0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef_bytes32;
+
+/// Convert an address to a 32-byte value, left-padded with zeros.
+/// TODO: Deduplicate with to_bytes32 in test/utils/utils.hpp.
+bytes32 to_bytes32(const address& addr) noexcept
+{
+    bytes32 res{};
+    std::copy_n(addr.bytes, sizeof(addr), &res.bytes[sizeof(res) - sizeof(addr)]);
+    return res;
+}
+
 /// Information about a registered "storage" system contract. They are executed at the block start
 /// to store additional information in the State.
 struct StorageSystemContract
@@ -128,5 +141,12 @@ std::variant<RequestsResult, std::error_code> system_call_block_end(const StateV
         requests.emplace_back(request_type, bytes_view{res.output_data, res.output_size});
     }
     return RequestsResult{state.build_diff(rev), requests};
+}
+
+void emit_transfer_log(
+    std::vector<Log>& logs, const address& sender, const address& recipient, const uint256& amount)
+{
+    logs.push_back({SYSTEM_ADDRESS, bytes{intx::be::store<uint256be>(amount)},
+        {TRANSFER_EVENT_TOPIC, to_bytes32(sender), to_bytes32(recipient)}});
 }
 }  // namespace evmone::state

--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -11,10 +11,6 @@ namespace evmone::state
 {
 namespace
 {
-/// The ETH transfer log topic (EIP-7708): keccak256("Transfer(address,address,uint256)")
-constexpr auto TRANSFER_EVENT_TOPIC =
-    0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef_bytes32;
-
 /// Convert an address to a 32-byte value, left-padded with zeros.
 /// TODO: Deduplicate with to_bytes32 in test/utils/utils.hpp.
 bytes32 to_bytes32(const address& addr) noexcept
@@ -146,6 +142,16 @@ std::variant<RequestsResult, std::error_code> system_call_block_end(const StateV
 void emit_transfer_log(
     std::vector<Log>& logs, const address& sender, const address& recipient, const uint256& amount)
 {
+    /// The ETH transfer log topic (EIP-7708): keccak256("Transfer(address,address,uint256)")
+    constexpr auto TRANSFER_EVENT_TOPIC =
+        0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef_bytes32;
+
+    if (amount == 0)  // No log for 0 value transfers.
+        return;
+
+    if (sender == recipient)  // No log for self transfers (balance unchanged).
+        return;
+
     logs.push_back({SYSTEM_ADDRESS, bytes{intx::be::store<uint256be>(amount)},
         {TRANSFER_EVENT_TOPIC, to_bytes32(sender), to_bytes32(recipient)}});
 }

--- a/test/state/system_contracts.hpp
+++ b/test/state/system_contracts.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "requests.hpp"
+#include "transaction.hpp"
 #include <evmc/evmc.hpp>
 #include <system_error>
 #include <variant>
@@ -56,4 +57,8 @@ struct RequestsResult
 [[nodiscard]] std::variant<RequestsResult, std::error_code> system_call_block_end(
     const StateView& state_view, const BlockInfo& block, const BlockHashes& block_hashes,
     evmc_revision rev, evmc::VM& vm);
+
+/// Emit an ETH transfer log (LOG3) from SYSTEM_ADDRESS for a value transfer (EIP-7708).
+void emit_transfer_log(
+    std::vector<Log>& logs, const address& sender, const address& recipient, const uint256& amount);
 }  // namespace evmone::state

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "state_transition.hpp"
+#include <test/state/system_contracts.hpp>
 #include <test/utils/mpt_hash.hpp>
 #include <test/utils/statetest.hpp>
+#include <test/utils/utils.hpp>
 #include <filesystem>
 #include <fstream>
 
@@ -171,5 +173,15 @@ void state_transition::export_state_test(
 {
     const auto j = to_state_test(export_test_name, block, tx, pre, rev, res, post);
     std::ofstream{export_file_path} << std::setw(2) << j;
+}
+
+Log state_transition::transfer_log(
+    const address& sender, const address& recipient, const intx::uint256& amount)
+{
+    static constexpr std::string_view EVENT = "Transfer(address,address,uint256)";
+    static const auto topic =
+        keccak256({reinterpret_cast<const uint8_t*>(EVENT.data()), EVENT.size()});
+    return {SYSTEM_ADDRESS, bytes{intx::be::store<uint256be>(amount)},
+        {topic, to_bytes32(sender), to_bytes32(recipient)}};
 }
 }  // namespace evmone::test

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -103,6 +103,11 @@ protected:
     /// The test runner.
     void TearDown() override;
 
+    /// Build the expected EIP-7708 Transfer log: {SYSTEM_ADDRESS, amount (32-byte big-endian),
+    /// topics = [Transfer event topic, sender, recipient]}.
+    static Log transfer_log(
+        const address& sender, const address& recipient, const intx::uint256& amount);
+
     /// Exports the test in the JSON State Test format to ExportableFixture::export_out.
     void export_state_test(
         const std::variant<TransactionReceipt, std::error_code>& res, const TestState& post);

--- a/test/unittests/state_transition_selfdestruct_test.cpp
+++ b/test/unittests/state_transition_selfdestruct_test.cpp
@@ -259,7 +259,7 @@ TEST_F(state_transition, massdestruct_cancun)
 
 TEST_F(state_transition, eip7708_transfer_log_selfdestruct_existing)
 {
-    // A pre-existing contract self-destructing to a distinct beneficiary emits a ETH transfer log
+    // A pre-existing contract self-destructing to a distinct beneficiary emits an ETH transfer log
     // for the moved balance (EIP-7708).
     rev = EVMC_AMSTERDAM;
     static constexpr auto Beneficiary = 0xbe_address;
@@ -273,7 +273,7 @@ TEST_F(state_transition, eip7708_transfer_log_selfdestruct_existing)
 
 TEST_F(state_transition, eip7708_transfer_log_create_tx_then_selfdestruct)
 {
-    // A CREATE-transaction endowment emits a ETH trasfer log, then the same-tx-created account
+    // A CREATE-transaction endowment emits an ETH transfer log, then the same-tx-created account
     // self-destructing in its initcode emits a second ETH transfer log (EIP-7708).
     rev = EVMC_AMSTERDAM;
     static constexpr auto Beneficiary = 0xbe_address;

--- a/test/unittests/state_transition_selfdestruct_test.cpp
+++ b/test/unittests/state_transition_selfdestruct_test.cpp
@@ -256,3 +256,33 @@ TEST_F(state_transition, massdestruct_cancun)
 
     expect.post[SINK].balance = N;
 }
+
+TEST_F(state_transition, eip7708_transfer_log_selfdestruct_existing)
+{
+    // A pre-existing contract self-destructing to a distinct beneficiary emits a ETH transfer log
+    // for the moved balance (EIP-7708).
+    rev = EVMC_AMSTERDAM;
+    static constexpr auto Beneficiary = 0xbe_address;
+    tx.to = To;
+    pre[To] = {.balance = 0x99, .code = selfdestruct(Beneficiary)};
+
+    expect.post[To] = {};  // EIP-6780: survives, balance moved out.
+    expect.post[Beneficiary].balance = 0x99;
+    expect.logs = {transfer_log(To, Beneficiary, 0x99)};
+}
+
+TEST_F(state_transition, eip7708_transfer_log_create_tx_then_selfdestruct)
+{
+    // A CREATE-transaction endowment emits a ETH trasfer log, then the same-tx-created account
+    // self-destructing in its initcode emits a second ETH transfer log (EIP-7708).
+    rev = EVMC_AMSTERDAM;
+    static constexpr auto Beneficiary = 0xbe_address;
+    tx.value = 0x99;
+    tx.data = selfdestruct(Beneficiary);
+    pre[Sender].balance += 0x99;
+    const auto created = compute_create_address(Sender, tx.nonce);
+
+    expect.post[created].exists = false;
+    expect.post[Beneficiary].balance = 0x99;
+    expect.logs = {transfer_log(Sender, created, 0x99), transfer_log(created, Beneficiary, 0x99)};
+}

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -280,3 +280,15 @@ TEST_F(state_transition, tx_emits_log)
     expect.post[To] = {};  // the contract survives (has code).
     expect.logs = {Log{To, bytes{0xaa, 0xbb, 0xcc, 0xdd}, {TOPIC}}};
 }
+
+TEST_F(state_transition, eip7708_transfer_log_tx_value)
+{
+    // Top level transaction with value emits log (EIP-7708).
+    rev = EVMC_AMSTERDAM;
+    tx.to = To;
+    tx.value = 0x12345;
+    pre[Sender].balance += 0x12345;
+
+    expect.post[To].balance = 0x12345;
+    expect.logs = {transfer_log(Sender, To, 0x12345)};
+}


### PR DESCRIPTION
In all cases where ETH transfer happens in EVM emit LOG3 "Transfer" matching smart contract ABI. These cases are:
- CALL with value,
- CREATE with endowment,
- SELFDESTRUCT sending all to beneficiary. The log is omitted when the transfer value is zero or the recipient is the sender.