### PR TITLE
Implement EIP-7954: "Increase Maximum Contract Size"

### DIFF
--- a/lib/evmone/constants.hpp
+++ b/lib/evmone/constants.hpp
@@ -12,4 +12,11 @@ constexpr auto MAX_CODE_SIZE = 0x6000;
 /// The limit of the size of init codes for contract creation
 /// defined by [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860)
 constexpr auto MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
+
+/// The increased limit of the size of created contract in Amsterdam
+/// defined by [EIP-7954](https://eips.ethereum.org/EIPS/eip-7954)
+constexpr auto MAX_CODE_SIZE_AMSTERDAM = 0x10000;
+
+/// The increased limit of the size of init codes in Amsterdam (EIP-7954).
+constexpr auto MAX_INITCODE_SIZE_AMSTERDAM = 2 * MAX_CODE_SIZE_AMSTERDAM;
 }  // namespace evmone

--- a/lib/evmone/constants.hpp
+++ b/lib/evmone/constants.hpp
@@ -13,6 +13,13 @@ constexpr auto MAX_CODE_SIZE = 0x6000;
 /// defined by [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860).
 constexpr auto MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
 
+/// The increased limit of the size of created contract in Amsterdam
+/// defined by [EIP-7954](https://eips.ethereum.org/EIPS/eip-7954).
+constexpr auto MAX_CODE_SIZE_AMSTERDAM = 0x10000;
+
+/// The increased limit of the size of init codes in Amsterdam (EIP-7954).
+constexpr auto MAX_INITCODE_SIZE_AMSTERDAM = 2 * MAX_CODE_SIZE_AMSTERDAM;
+
 /// The maximum allowed account's nonce value: 2⁶⁴-1.
 /// Transactions and create instructions with nonce equal or above this value are invalid.
 /// Defined by [EIP-2681](https://eips.ethereum.org/EIPS/eip-2681).

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -2,6 +2,7 @@
 // Copyright 2019 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "constants.hpp"
 #include "delegation.hpp"
 #include "instructions.hpp"
 #include <variant>
@@ -215,7 +216,9 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
     const auto init_code_offset = static_cast<size_t>(init_code_offset_u256);
     const auto init_code_size = static_cast<size_t>(init_code_size_u256);
 
-    if (state.rev >= EVMC_SHANGHAI && init_code_size > 0xC000)
+    const size_t max_init_code_size =
+        state.rev >= EVMC_AMSTERDAM ? MAX_INITCODE_SIZE_AMSTERDAM : MAX_INITCODE_SIZE;
+    if (state.rev >= EVMC_SHANGHAI && init_code_size > max_init_code_size)
         return {EVMC_OUT_OF_GAS, gas_left};
 
     const auto init_code_word_cost = 6 * (Op == OP_CREATE2) + 2 * (state.rev >= EVMC_SHANGHAI);

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -217,7 +217,9 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
     const auto init_code_offset = static_cast<size_t>(init_code_offset_u256);
     const auto init_code_size = static_cast<size_t>(init_code_size_u256);
 
-    if (state.rev >= EVMC_SHANGHAI && init_code_size > 0xC000)
+    const size_t max_init_code_size =
+        state.rev >= EVMC_AMSTERDAM ? MAX_INITCODE_SIZE_AMSTERDAM : MAX_INITCODE_SIZE;
+    if (state.rev >= EVMC_SHANGHAI && init_code_size > max_init_code_size)
         return {EVMC_OUT_OF_GAS, gas_left};
 
     const auto init_code_word_cost = 6 * (Op == OP_CREATE2) + 2 * (state.rev >= EVMC_SHANGHAI);

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -312,7 +312,8 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
 
     const bytes_view code{result.output_data, result.output_size};
 
-    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > MAX_CODE_SIZE)
+    const size_t max_code_size = m_rev >= EVMC_AMSTERDAM ? MAX_CODE_SIZE_AMSTERDAM : MAX_CODE_SIZE;
+    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > max_code_size)
         return evmc::Result{EVMC_FAILURE};
 
     // Reject new contract code starting with the 0xEF byte (EIP-3541).

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -227,7 +227,8 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
 
     const bytes_view code{result.output_data, result.output_size};
 
-    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > MAX_CODE_SIZE)
+    const size_t max_code_size = m_rev >= EVMC_AMSTERDAM ? MAX_CODE_SIZE_AMSTERDAM : MAX_CODE_SIZE;
+    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > max_code_size)
         return evmc::Result{EVMC_FAILURE};
 
     // Reject new contract code starting with the 0xEF byte (EIP-3541).

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -535,8 +535,10 @@ std::variant<TransactionProperties, std::error_code> validate_transaction(
     if (sender_acc.nonce > tx.nonce)
         return make_error_code(NONCE_TOO_LOW);
 
-    // initcode size is limited by EIP-3860.
-    if (rev >= EVMC_SHANGHAI && !tx.to.has_value() && tx.data.size() > MAX_INITCODE_SIZE)
+    // Initcode size is limited by EIP-3860, raised for Amsterdam by EIP-7954.
+    const size_t max_initcode_size =
+        rev >= EVMC_AMSTERDAM ? MAX_INITCODE_SIZE_AMSTERDAM : MAX_INITCODE_SIZE;
+    if (rev >= EVMC_SHANGHAI && !tx.to.has_value() && tx.data.size() > max_initcode_size)
         return make_error_code(INIT_CODE_SIZE_LIMIT_EXCEEDED);
 
     // Compute and check if sender has enough balance for the theoretical maximum transaction cost.

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -524,8 +524,10 @@ std::variant<TransactionProperties, std::error_code> validate_transaction(
     if (sender_acc.nonce > tx.nonce)
         return make_error_code(NONCE_TOO_LOW);
 
-    // initcode size is limited by EIP-3860.
-    if (rev >= EVMC_SHANGHAI && !tx.to.has_value() && tx.data.size() > MAX_INITCODE_SIZE)
+    // Initcode size is limited by EIP-3860, raised for Amsterdam by EIP-7954.
+    const size_t max_initcode_size =
+        rev >= EVMC_AMSTERDAM ? MAX_INITCODE_SIZE_AMSTERDAM : MAX_INITCODE_SIZE;
+    if (rev >= EVMC_SHANGHAI && !tx.to.has_value() && tx.data.size() > max_initcode_size)
         return make_error_code(INITCODE_SIZE_EXCEEDED);
 
     // Compute and check if sender has enough balance for the theoretical maximum transaction cost.

--- a/test/unittests/state_transition_create_test.cpp
+++ b/test/unittests/state_transition_create_test.cpp
@@ -362,3 +362,30 @@ TEST_F(state_transition, created_code_hash)
     expect.post[created].code = runtime_code;
     expect.post[To].storage[0x00_bytes32] = keccak256(runtime_code);
 }
+
+TEST_F(state_transition, eip7954_create_tx_at_max_code_size)
+{
+    // Amsterdam raises the deployed code size limit from 0x6000 to 0x10000 (EIP-7954).
+    // A create transaction deploying code of exactly the new limit succeeds.
+    rev = EVMC_AMSTERDAM;
+    static constexpr auto code_size = 0x10000;  // MAX_CODE_SIZE_AMSTERDAM.
+    tx.gas_limit = 16'000'000;                  // Covers the ~13.1M code-deposit gas (200/byte).
+    block.gas_limit = tx.gas_limit;
+    pre[Sender].balance = tx.gas_limit * tx.max_gas_price;
+    tx.data = ret(0, code_size);  // Init code returns `code_size` zero bytes as the deployed code.
+
+    const auto create_address = compute_create_address(Sender, pre[Sender].nonce);
+    expect.post[create_address].code = bytes(code_size, 0x00);
+}
+
+TEST_F(state_transition, eip7954_create_tx_above_max_code_size)
+{
+    // Code one byte above the new 0x10000 limit is still rejected on Amsterdam (EIP-7954).
+    rev = EVMC_AMSTERDAM;
+    static constexpr auto code_size = 0x10000 + 1;
+    tx.data = ret(0, code_size);  // Init code returns code one byte over the limit.
+
+    const auto create_address = compute_create_address(Sender, pre[Sender].nonce);
+    expect.status = EVMC_FAILURE;
+    expect.post[create_address].exists = false;
+}

--- a/test/unittests/state_transition_create_test.cpp
+++ b/test/unittests/state_transition_create_test.cpp
@@ -424,3 +424,33 @@ TEST_F(state_transition, create2_rollback_preserves_access_list_slot_warmth)
     expect.post[created].storage[0x01_bytes32] = 0x01_bytes32;
     expect.gas_used = 109405;  // Cooling the slot would add the 2100 cold surcharge.
 }
+
+TEST_F(state_transition, eip7954_create_tx_at_max_code_size)
+{
+    // Amsterdam raises the deployed code size limit from 0x6000 to 0x10000 (EIP-7954).
+    // A create transaction deploying code of exactly the new limit succeeds.
+    rev = EVMC_AMSTERDAM;
+    static constexpr auto code_size = 0x10000;  // MAX_CODE_SIZE_AMSTERDAM.
+    tx.gas_limit = 16'000'000;                  // Covers the ~13.1M code-deposit gas (200/byte).
+    block.gas_limit = tx.gas_limit;
+    pre[Sender].balance = tx.gas_limit * tx.max_gas_price;
+    tx.data = ret(0, code_size);  // Init code returns `code_size` zero bytes as the deployed code.
+
+    const auto create_address = compute_create_address(Sender, pre[Sender].nonce);
+    expect.post[create_address].code = bytes(code_size, 0x00);
+}
+
+TEST_F(state_transition, eip7954_create_tx_above_max_code_size)
+{
+    // Code one byte above the new 0x10000 limit is still rejected on Amsterdam (EIP-7954).
+    rev = EVMC_AMSTERDAM;
+    static constexpr auto code_size = 0x10000 + 1;
+    tx.gas_limit = 16'000'000;  // Enough to deposit the code, so only the limit can reject it.
+    block.gas_limit = tx.gas_limit;
+    pre[Sender].balance = tx.gas_limit * tx.max_gas_price;
+    tx.data = ret(0, code_size);  // Init code returns code one byte over the limit.
+
+    const auto create_address = compute_create_address(Sender, pre[Sender].nonce);
+    expect.status = EVMC_FAILURE;
+    expect.post[create_address].exists = false;
+}


### PR DESCRIPTION
Amsterdam raises the deployed contract code limit from 0x6000 (EIP-170) to 0x10000, and the init code limit from 0xC000 to 0x20000 (EIP-3860 keeps the init code limit at twice the code limit).