### PR TITLE
test: Change spelling to "TangerineWhistle" and "SpuriousDragon"

### DIFF
--- a/evmc/include/evmc/helpers.h
+++ b/evmc/include/evmc/helpers.h
@@ -229,9 +229,9 @@ static inline const char* evmc_revision_to_string(enum evmc_revision rev)
     case EVMC_HOMESTEAD:
         return "Homestead";
     case EVMC_TANGERINE_WHISTLE:
-        return "Tangerine Whistle";
+        return "TangerineWhistle";
     case EVMC_SPURIOUS_DRAGON:
-        return "Spurious Dragon";
+        return "SpuriousDragon";
     case EVMC_BYZANTIUM:
         return "Byzantium";
     case EVMC_CONSTANTINOPLE:

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -13,9 +13,9 @@ evmc_revision to_rev(std::string_view s)
         return EVMC_FRONTIER;
     if (s == "Homestead")
         return EVMC_HOMESTEAD;
-    if (s == "Tangerine Whistle" || s == "EIP150")
+    if (s == "TangerineWhistle" || s == "EIP150")
         return EVMC_TANGERINE_WHISTLE;
-    if (s == "Spurious Dragon" || s == "EIP158")
+    if (s == "SpuriousDragon" || s == "EIP158")
         return EVMC_SPURIOUS_DRAGON;
     if (s == "Byzantium")
         return EVMC_BYZANTIUM;


### PR DESCRIPTION
Spell fork names without space to match execution-specs:
- "Tangerine Whistle" → "TangerineWhistle",
- "Spurious Dragon" → "SpuriousDragon".

This allows us to execute new test suite for these forks in next release of tests in execution-specs. Also handy for `evmone t8n`.

We decided not to support old spelling as this fork name is old and not very user-facing.