### PR TITLE
ci: Switch the EEST devnet fixtures to glamsterdam-devnet

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -153,6 +153,9 @@ commands:
 
   run_execution_spec_tests:
     parameters:
+      repo:
+        type: string
+        default: ethereum/execution-spec-tests
       release:
         type: string
       fixtures_suffix:
@@ -162,6 +165,7 @@ commands:
         default: "*"
     steps:
       - download_execution_spec_tests:
+          repo: <<parameters.repo>>
           release: <<parameters.release>>
           fixtures_suffix: <<parameters.fixtures_suffix>>
       - run:
@@ -418,8 +422,9 @@ jobs:
     steps:
       - build
       - run_execution_spec_tests:
-          release: bal@v5.6.1
-          fixtures_suffix: bal
+          repo: ethereum/execution-specs
+          release: tests-glamsterdam-devnet@v6.1.0
+          fixtures_suffix: glamsterdam-devnet
           filter: "-for_amsterdam/*:for_bpo2toamsterdamattime15k/*"
       - collect_coverage_clang:
           flags: eest-develop


### PR DESCRIPTION
The bal@v5.6.1 fixtures are superseded by the glamsterdam-devnet release, which is published in ethereum/execution-specs instead of ethereum/execution-spec-tests. Point the existing run at tests-glamsterdam-devnet@v6.1.0 and add a repo parameter to run_execution_spec_tests to select the source repository.

for_amsterdam/* and for_bpo2toamsterdamattime15k/* stay filtered out (Amsterdam is not implemented yet); the rest pass on master: 8069 state and 8518 blockchain tests.