### PR TITLE
Extract shared frame-exit result construction

### DIFF
--- a/lib/evmone/advanced_execution.cpp
+++ b/lib/evmone/advanced_execution.cpp
@@ -16,13 +16,7 @@ evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& a
     while (instr != nullptr)
         instr = instr->fn(instr, state);
 
-    const auto gas_left =
-        (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
-    const auto gas_refund = (state.status == EVMC_SUCCESS) ? state.gas_refund : 0;
-
-    assert(state.output_size != 0 || state.output_offset == 0);
-    return evmc::make_result(state.status, gas_left, gas_refund,
-        state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);
+    return make_execution_result(state, state.gas_left);
 }
 
 evmc_result execute(evmc_vm* /*unused*/, const evmc_host_interface* host, evmc_host_context* ctx,

--- a/lib/evmone/baseline_execution.cpp
+++ b/lib/evmone/baseline_execution.cpp
@@ -292,12 +292,7 @@ evmc_result execute(VM& vm, const evmc_host_interface& host, evmc_host_context* 
             gas = dispatch<false>(cost_table, state, gas, code_begin);
     }
 
-    const auto gas_left = (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? gas : 0;
-    const auto gas_refund = (state.status == EVMC_SUCCESS) ? state.gas_refund : 0;
-
-    assert(state.output_size != 0 || state.output_offset == 0);
-    const auto result = evmc::make_result(state.status, gas_left, gas_refund,
-        state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);
+    const auto result = make_execution_result(state, gas);
 
     if (INTX_UNLIKELY(tracer != nullptr))
         tracer->notify_execution_end(result);

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -5,6 +5,7 @@
 
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
+#include <cassert>
 #include <exception>
 #include <memory>
 #include <string>
@@ -193,4 +194,21 @@ public:
         return m_tx;
     }
 };
+
+/// Builds the execution result for a finished frame from its final @p state and @p gas_left.
+///
+/// Applies the frame-exit rules shared by the baseline and advanced interpreters: an exceptional
+/// halt consumes all gas (only a success or revert keeps it), the gas refund counts only on
+/// success, and the output is the memory range recorded in the state.
+inline evmc_result make_execution_result(ExecutionState& state, int64_t gas_left) noexcept
+{
+    // An exceptional halt consumes all gas; only a success or revert keeps gas_left.
+    if (state.status != EVMC_SUCCESS && state.status != EVMC_REVERT)
+        gas_left = 0;
+    const auto gas_refund = (state.status == EVMC_SUCCESS) ? state.gas_refund : 0;
+
+    assert(state.output_size != 0 || state.output_offset == 0);
+    return evmc::make_result(state.status, gas_left, gas_refund,
+        state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);
+}
 }  // namespace evmone


### PR DESCRIPTION
Use shared procedure for frame exit in Baseline and Advanced.