### PR TITLE
ci: Upgrade execution-specs to tests@v20.0.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -140,26 +140,27 @@ commands:
         type: string
       fixtures_suffix:
         type: string
-        default: stable
+        default: ""
     steps:
       - run:
           name: "Download execution-spec-tests: <<parameters.release>>"
           working_directory: ~/spec-tests
           command: |
             find . -delete
-            curl -L --retry 3 -C - --output-dir /tmp -O https://github.com/<<parameters.repo>>/releases/download/<<parameters.release>>/fixtures_<<parameters.fixtures_suffix>>.tar.gz
-            tar -xzf /tmp/fixtures_<<parameters.fixtures_suffix>>.tar.gz
+            curl -L --retry 3 -C - --output-dir /tmp -O https://github.com/<<parameters.repo>>/releases/download/<<parameters.release>>/fixtures<<parameters.fixtures_suffix>>.tar.gz
+            tar -xzf /tmp/fixtures<<parameters.fixtures_suffix>>.tar.gz
             ls -l
 
   run_execution_spec_tests:
     parameters:
       repo:
         type: string
-        default: ethereum/execution-spec-tests
+        default: ethereum/execution-specs
       release:
         type: string
       fixtures_suffix:
         type: string
+        default: ""
       filter:
         type: string
         default: "*"
@@ -422,17 +423,15 @@ jobs:
     steps:
       - build
       - run_execution_spec_tests:
-          repo: ethereum/execution-specs
-          release: tests-glamsterdam-devnet@v6.1.0
-          fixtures_suffix: glamsterdam-devnet
+          release: tests-glamsterdam-devnet@v6.1.1
+          fixtures_suffix: _glamsterdam-devnet
           filter: "-for_amsterdam/*:for_bpo2toamsterdamattime15k/*"
       - collect_coverage_clang:
           flags: eest-develop
           ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests)
           binaries: evmone-statetest evmone-blockchaintest
       - run_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: develop
+          release: tests@v20.0.0
       - collect_coverage_clang:
           flags: eest-stable
           ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests)
@@ -477,8 +476,7 @@ jobs:
     steps:
       - build
       - download_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: stable
+          release: tests@v20.0.0
       - run:
           name: "Execution spec tests (state_tests)"
           working_directory: ~/build
@@ -498,8 +496,7 @@ jobs:
           command: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev
       - build
       - download_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: stable
+          release: tests@v20.0.0
       - run:
           name: "Execution spec tests (state_tests)"
           working_directory: ~/build
@@ -554,8 +551,7 @@ jobs:
       - build
       - test
       - run_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: develop
+          release: tests@v20.0.0
 
   clang-tidy:
     executor: linux-clang-selfhosted

--- a/circle.yml
+++ b/circle.yml
@@ -135,31 +135,33 @@ commands:
     parameters:
       repo:
         type: string
-        default: ethereum/execution-spec-tests
+        default: ethereum/execution-specs
       release:
         type: string
       fixtures_suffix:
         type: string
-        default: stable
+        default: ""
     steps:
       - run:
-          name: "Download execution-spec-tests: <<parameters.release>>"
+          name: "Download test fixtures: <<parameters.repo>> <<parameters.release>>"
           working_directory: ~/spec-tests
           command: |
             find . -delete
-            curl -L --retry 3 -C - --output-dir /tmp -O https://github.com/<<parameters.repo>>/releases/download/<<parameters.release>>/fixtures_<<parameters.fixtures_suffix>>.tar.gz
-            tar -xzf /tmp/fixtures_<<parameters.fixtures_suffix>>.tar.gz
+            rm -f /tmp/fixtures<<parameters.fixtures_suffix>>.tar.gz
+            curl -L --fail --retry 3 -C - --output-dir /tmp -O https://github.com/<<parameters.repo>>/releases/download/<<parameters.release>>/fixtures<<parameters.fixtures_suffix>>.tar.gz
+            tar -xzf /tmp/fixtures<<parameters.fixtures_suffix>>.tar.gz
             ls -l
 
   run_execution_spec_tests:
     parameters:
       repo:
         type: string
-        default: ethereum/execution-spec-tests
+        default: ethereum/execution-specs
       release:
         type: string
       fixtures_suffix:
         type: string
+        default: ""
       filter:
         type: string
         default: "*"
@@ -422,17 +424,15 @@ jobs:
     steps:
       - build
       - run_execution_spec_tests:
-          repo: ethereum/execution-specs
-          release: tests-glamsterdam-devnet@v6.1.0
-          fixtures_suffix: glamsterdam-devnet
+          release: tests-glamsterdam-devnet@v6.1.1
+          fixtures_suffix: _glamsterdam-devnet
           filter: "-for_amsterdam/*:for_bpo2toamsterdamattime15k/*"
       - collect_coverage_clang:
           flags: eest-develop
           ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests)
           binaries: evmone-statetest evmone-blockchaintest
       - run_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: develop
+          release: tests@v20.0.1
       - collect_coverage_clang:
           flags: eest-stable
           ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|unittests)
@@ -491,8 +491,7 @@ jobs:
     steps:
       - build
       - download_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: stable
+          release: tests@v20.0.1
       - run:
           name: "Execution spec tests (state_tests)"
           working_directory: ~/build
@@ -512,8 +511,7 @@ jobs:
           command: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev
       - build
       - download_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: stable
+          release: tests@v20.0.1
       - run:
           name: "Execution spec tests (state_tests)"
           working_directory: ~/build
@@ -568,8 +566,7 @@ jobs:
       - build
       - test
       - run_execution_spec_tests:
-          release: v5.4.0
-          fixtures_suffix: develop
+          release: tests@v20.0.1
 
   clang-tidy:
     executor: linux-clang-selfhosted


### PR DESCRIPTION
Move the fixture source from the archived ethereum/execution-spec-tests releases to ethereum/execution-specs, where the tarball is named `fixtures<suffix>.tar.gz`, so the suffix carries its own separator and defaults to none; the glamsterdam-devnet pin follows to v6.1.1. The transactions in these fixtures are taken from their encodings, whose signatures the state test runner now verifies, so the bad_v_r_s and invalid_chain_id cases they add are rejected as they should be.