### PR TITLE
test: Name the shared RLP framing constants

### DIFF
--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(
     precompiles_internal.hpp
     requests.hpp
     requests.cpp
+    rlp_common.hpp
     state.hpp
     state.cpp
     state_diff.hpp

--- a/test/state/rlp_common.hpp
+++ b/test/state/rlp_common.hpp
@@ -1,0 +1,20 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+/// @file
+/// RLP prefix encoding constants (Yellow Paper Appendix B), shared by the encoder and the decoder.
+
+#include <cstddef>
+#include <cstdint>
+
+namespace evmone::rlp
+{
+/// The largest payload encoded in the short form; longer payloads use the long form.
+constexpr size_t SHORT_LENGTH_LIMIT = 55;
+/// Base of a byte-string prefix: a short string is this byte plus its length (0x80..0xb7).
+constexpr uint8_t SHORT_STRING_BASE = 0x80;
+/// Base of a list prefix: a short list is this byte plus its payload length (0xc0..0xf7).
+constexpr uint8_t SHORT_LIST_BASE = 0xc0;
+}  // namespace evmone::rlp

--- a/test/utils/rlp.hpp
+++ b/test/utils/rlp.hpp
@@ -6,7 +6,9 @@
 
 #include <evmc/bytes.hpp>
 #include <intx/intx.hpp>
+#include <test/state/rlp_common.hpp>
 #include <cassert>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -19,26 +21,27 @@ using evmc::bytes_view;
 
 namespace internal
 {
-template <uint8_t ShortBase, uint8_t LongBase>
+template <uint8_t ShortBase>
 inline bytes encode_length(size_t l)
 {
-    static constexpr uint8_t short_cutoff = 55;
-    static_assert(ShortBase + short_cutoff <= 0xff);
+    static_assert(ShortBase + SHORT_LENGTH_LIMIT <= std::numeric_limits<uint8_t>::max(),
+        "long base must fit uint8_t");
+    static constexpr uint8_t LONG_BASE = ShortBase + SHORT_LENGTH_LIMIT;
     assert(l <= 0xffffff);
 
-    if (l <= short_cutoff)
+    if (l <= SHORT_LENGTH_LIMIT)
         return {static_cast<uint8_t>(ShortBase + l)};
     else if (const auto l0 = static_cast<uint8_t>(l); l <= 0xff)
-        return {LongBase + 1, l0};
+        return {LONG_BASE + 1, l0};
     else if (const auto l1 = static_cast<uint8_t>(l >> 8); l <= 0xffff)
-        return {LongBase + 2, l1, l0};
+        return {LONG_BASE + 2, l1, l0};
     else
-        return {LongBase + 3, static_cast<uint8_t>(l >> 16), l1, l0};
+        return {LONG_BASE + 3, static_cast<uint8_t>(l >> 16), l1, l0};
 }
 
 inline bytes wrap_list(const bytes& content)
 {
-    return internal::encode_length<192, 247>(content.size()) + content;
+    return internal::encode_length<SHORT_LIST_BASE>(content.size()) + content;
 }
 
 template <typename InputIterator>
@@ -59,11 +62,10 @@ inline decltype(rlp_encode(std::declval<T>())) encode(const T& v)
 
 inline bytes encode(bytes_view data)
 {
-    static constexpr uint8_t short_base = 128;
-    if (data.size() == 1 && data[0] < short_base)
+    if (data.size() == 1 && data[0] < SHORT_STRING_BASE)
         return {data[0]};
 
-    return internal::encode_length<short_base, 183>(data.size()) += data;  // Op + not available.
+    return internal::encode_length<SHORT_STRING_BASE>(data.size()) += data;  // Op + not available.
 }
 
 inline bytes encode(uint64_t x)


### PR DESCRIPTION
Introduce the RLP prefix bases (0x80 for strings, 0xc0 for lists) and the short-form length limit (Yellow Paper Appendix B) as named constants, replacing the magic numbers in the length encoder. A short item's prefix is base + length, matching the encoder's ShortBase template parameter and the spec's "value 0x80 plus the length" wording; the long-form base (base + SHORT_LENGTH_LIMIT) is derived where used, so only the two short bases need naming. The transaction decoder added next reuses these.

The constants live in test/state/rlp_common.hpp because later we will introduce RLP decoder there.