### PR TITLE
state: Cache repeated and negative account lookups

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -272,6 +272,7 @@ StateDiff State::build_diff(evmc_revision rev) const
 
 Account& State::insert(const address& addr, Account account)
 {
+    m_absent.erase(addr);  // The account exists now.
     const auto r = m_modified.insert({addr, std::move(account)});
     assert(r.second);
     return r.first->second;
@@ -279,16 +280,31 @@ Account& State::insert(const address& addr, Account account)
 
 Account* State::find(const address& addr) noexcept
 {
-    // TODO: Avoid double lookup (find+insert) and not cached initial state lookup for non-existent
-    //   accounts. If we want to cache non-existent account we need a proper flag for it.
+    if (m_last_acc != nullptr && addr == m_last_addr)
+        return m_last_acc;
+
+    Account* acc = nullptr;
     if (const auto it = m_modified.find(addr); it != m_modified.end())
-        return &it->second;
-    if (const auto cacc = m_initial.get_account(addr); cacc)
-        return &insert(addr, {.nonce = cacc->nonce,
-                                 .balance = cacc->balance,
-                                 .code_hash = cacc->code_hash,
-                                 .has_initial_storage = cacc->has_storage});
-    return nullptr;
+        acc = &it->second;
+    else if (!m_absent.contains(addr))
+    {
+        if (const auto cacc = m_initial.get_account(addr); cacc)
+            acc = &insert(addr, {.nonce = cacc->nonce,
+                                    .balance = cacc->balance,
+                                    .code_hash = cacc->code_hash,
+                                    .has_initial_storage = cacc->has_storage});
+        else
+            m_absent.insert(addr);  // Cache the negative lookup.
+    }
+
+    if (acc != nullptr)
+    {
+        // References to unordered_map elements are stable so the cached pointer
+        // remains valid until the element is erased (see rollback()).
+        m_last_addr = addr;
+        m_last_acc = acc;
+    }
+    return acc;
 }
 
 Account& State::get(const address& addr) noexcept
@@ -417,6 +433,8 @@ void State::rollback(size_t checkpoint)
                         //       so we need to delete them here explicitly.
                         //       This should be changed by tuning "erasable" flag
                         //       and clear in all revisions.
+                        if (m_last_acc != nullptr && e.addr == m_last_addr)
+                            m_last_acc = nullptr;  // Invalidate the lookup cache.
                         m_modified.erase(e.addr);
                     }
                 }

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -12,6 +12,7 @@
 #include "state_diff.hpp"
 #include "state_view.hpp"
 #include "transaction.hpp"
+#include <unordered_set>
 #include <variant>
 
 namespace evmone::state
@@ -68,6 +69,16 @@ class State
 
     /// The accounts loaded from the initial state and potentially modified.
     std::unordered_map<address, Account> m_modified;
+
+    /// Addresses known to not exist in m_modified nor in the initial state.
+    /// Avoids repeated initial state queries for non-existent accounts.
+    std::unordered_set<address> m_absent;
+
+    /// Single-entry cache of the last successful account lookup.
+    /// Host callbacks look up the same account repeatedly (e.g. SLOAD/SSTORE
+    /// perform two callbacks per instruction, both hitting the same address).
+    address m_last_addr;
+    Account* m_last_acc = nullptr;
 
     /// The state journal: the list of changes made to the state
     /// with information how to revert them.


### PR DESCRIPTION
This resolves the TODO in `State::find()`.

Host callbacks look up the same account repeatedly: SLOAD/SSTORE perform two Host callbacks per instruction (`access_storage` followed by `get_storage`/`set_storage`), each doing a full hash-map lookup of the same address. This adds a single-entry cache of the last successful lookup so the second callback only compares the address. The cached pointer is stable (`unordered_map` references) and is invalidated on the account erase in `rollback()`.

Lookups of non-existent accounts (e.g. BALANCE/EXTCODESIZE of an empty address, repeated in a loop) previously hit the initial `StateView` on every query — with a real database backend each of those is a repeated trie/DB query. Cache the negative results in a set; `insert()` removes the entry when the account comes into existence.