### PR TITLE
state: Avoid redundant lookups and allocations

### DIFF
--- a/test/state/bloom_filter.cpp
+++ b/test/state/bloom_filter.cpp
@@ -13,7 +13,7 @@ namespace
 /// Adds an entry to the bloom filter.
 /// based on
 /// https://ethereum.github.io/execution-specs/autoapi/ethereum/shanghai/bloom/index.html#add-to-bloom
-inline void add_to(BloomFilter& bf, const bytes_view& entry)
+inline void add_to(BloomFilter& bf, bytes_view entry)
 {
     const auto hash = keccak256(entry);
 

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -364,11 +364,13 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
 
             // Transfer value: sender → recipient.
             // The sender's balance is already checked therefore the sender account must exist.
+            // References to accounts are stable, inserting the recipient doesn't affect them.
             const auto value = intx::be::load<intx::uint256>(msg.value);
-            assert(m_state.get(msg.sender).balance >= value);
-            m_state.journal_balance_change(msg.sender, m_state.get(msg.sender).balance);
+            auto& sender_acc = m_state.get(msg.sender);
+            assert(sender_acc.balance >= value);
+            m_state.journal_balance_change(msg.sender, sender_acc.balance);
             m_state.journal_balance_change(msg.recipient, dst_acc.balance);
-            m_state.get(msg.sender).balance -= value;
+            sender_acc.balance -= value;
             dst_acc.balance += value;
 
             if (m_rev >= EVMC_AMSTERDAM)
@@ -402,15 +404,20 @@ evmc::Result Host::call(const evmc_message& orig_msg) noexcept
     if (result.status_code != EVMC_SUCCESS)
     {
         static constexpr auto addr_03 = 0x03_address;
-        auto* const acc_03 = m_state.find(addr_03);
-        const auto is_03_touched = acc_03 != nullptr && acc_03->erase_if_empty;
+        // The 0x03 quirk applies only from Spurious Dragon, don't look the account up earlier.
+        bool is_03_touched = false;
+        if (m_rev >= EVMC_SPURIOUS_DRAGON)
+        {
+            const auto* const acc_03 = m_state.find(addr_03);
+            is_03_touched = acc_03 != nullptr && acc_03->erase_if_empty;
+        }
 
         // Revert.
         m_state.rollback(state_checkpoint);
         m_logs.resize(logs_checkpoint);
 
         // The 0x03 quirk: the touch on this address is never reverted.
-        if (is_03_touched && m_rev >= EVMC_SPURIOUS_DRAGON)
+        if (is_03_touched)
             m_state.touch(addr_03);
     }
     return result;
@@ -458,9 +465,13 @@ evmc_access_status Host::access_account(const address& addr) noexcept
     if (m_rev < EVMC_BERLIN)
         return EVMC_ACCESS_COLD;  // Ignore before Berlin.
 
+    // Precompiles are always warm (EIP-2929); don't create state entries for them.
+    if (is_precompile(m_rev, addr))
+        return EVMC_ACCESS_WARM;
+
     auto& acc = m_state.get_or_insert(addr, {.erase_if_empty = true});
 
-    if (acc.access_status == EVMC_ACCESS_WARM || is_precompile(m_rev, addr))
+    if (acc.access_status == EVMC_ACCESS_WARM)
         return EVMC_ACCESS_WARM;
 
     m_state.journal_access_account(addr);

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -185,12 +185,15 @@ int64_t process_authorization_list(
         // 8. Set the code of authority to be 0xef0100 || address. This is a delegation designation.
         else
         {
-            auto new_code = bytes(DELEGATION_MAGIC) + bytes(auth.addr);
+            uint8_t designation[std::size(DELEGATION_MAGIC) + sizeof(auth.addr)];
+            const auto it = std::ranges::copy(DELEGATION_MAGIC, designation).out;
+            std::ranges::copy(auth.addr.bytes, it);
+            const bytes_view new_code{designation, std::size(designation)};
             if (authority.code != new_code)
             {
                 // We are doing this only if the code is different to make the state diff precise.
                 authority.code_changed = true;
-                authority.code = std::move(new_code);
+                authority.code = new_code;
                 authority.code_hash = keccak256(authority.code);
             }
         }
@@ -226,6 +229,7 @@ evmc_message build_message(const Transaction& tx, int64_t execution_gas_limit) n
 StateDiff State::build_diff(evmc_revision rev) const
 {
     StateDiff diff;
+    diff.modified_accounts.reserve(m_modified.size());
     for (const auto& [addr, m] : m_modified)
     {
         if (m.destructed)
@@ -333,7 +337,9 @@ StorageValue& State::get_storage(const address& addr, const bytes32& key)
     // TODO: Avoid account lookup by giving the reference to the account's storage to Host.
     auto& acc = get(addr);
     const auto [it, missing] = acc.storage.try_emplace(key);
-    if (missing)
+    // Query the initial state only if the account may have storage there;
+    // otherwise the initial value is guaranteed to be zero (the default).
+    if (missing && acc.has_initial_storage)
     {
         const auto initial_value = m_initial.get_storage(addr, key);
         it->second = {initial_value, initial_value};
@@ -633,6 +639,12 @@ TransactionReceipt transition(const StateView& state_view, const BlockInfo& bloc
     for (const auto& [a, storage_keys] : tx.access_list)
     {
         host.access_account(a);
+        if (storage_keys.empty())
+            continue;
+        // The access list may name a precompile together with storage keys. access_account()
+        // doesn't create state entries for precompiles, but warming the storage keys requires
+        // the account to exist in the state.
+        state.get_or_insert(a, {.erase_if_empty = true});
         for (const auto& key : storage_keys)
             state.get_storage(a, key).access_status = EVMC_ACCESS_WARM;
     }

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -246,6 +246,16 @@ TEST_F(state_transition, access_list_cost_osaka_unchanged)
     expect.gas_used = 25300;
 }
 
+TEST_F(state_transition, access_list_precompile_with_storage_keys)
+{
+    // An access list may name a precompile together with storage keys (EIP-2930).
+    rev = EVMC_OSAKA;
+    tx.to = To;
+    tx.access_list = {{0x01_address, {0x01_bytes32}}};
+    // intrinsic = 21000 + 2400 + 1900 = 25300
+    expect.gas_used = 25300;
+}
+
 TEST_F(state_transition, access_list_floor_amsterdam)
 {
     // EIP-7981: access-list bytes count toward the floor.


### PR DESCRIPTION
A collection of small optimizations on the state transition hot paths:

- Skip the initial state storage query for accounts without initial storage (e.g. newly created contracts): the value is guaranteed to be zero. A constructor storing N slots previously made N pointless `StateView::get_storage()` queries.
- Bind the sender account reference once in `execute_message()` instead of three `get()` lookups per value-transferring call (references to `unordered_map` elements are stable, inserting the recipient doesn't invalidate them).
- Look up the 0x03 quirk account on the revert path only for revisions where the quirk applies (Spurious Dragon and later).
- Return early from `access_account()` for precompiles: they are always warm (EIP-2929) and no state entry is needed for them. Note a small observable difference: untouched precompile addresses no longer appear in the state diff as no-op modified/deleted entries (the resulting post-state is identical).
- Build the EIP-7702 delegation designation in a stack buffer instead of concatenating temporary heap allocations per authorization.
- Reserve `StateDiff::modified_accounts`, pass `bytes_view` by value.