### PR TITLE
state: Don't journal warm storage accesses

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -62,9 +62,7 @@ evmc_storage_status Host::set_storage(
             status = EVMC_STORAGE_MODIFIED_RESTORED;  // X → Y → X
     }
 
-    // In Berlin this is handled in access_storage().
-    if (m_rev < EVMC_BERLIN)
-        m_state.journal_storage_change(addr, key, storage_slot);
+    m_state.journal_storage_change(addr, key, storage_slot);
     storage_slot.current = value;  // Update current value.
     return status;
 }
@@ -471,8 +469,11 @@ evmc_access_status Host::access_account(const address& addr) noexcept
 evmc_access_status Host::access_storage(const address& addr, const bytes32& key) noexcept
 {
     auto& storage_slot = m_state.get_storage(addr, key);
+    if (storage_slot.access_status == EVMC_ACCESS_WARM)
+        return EVMC_ACCESS_WARM;  // Nothing changes, skip journaling.
     m_state.journal_storage_change(addr, key, storage_slot);
-    return std::exchange(storage_slot.access_status, EVMC_ACCESS_WARM);
+    storage_slot.access_status = EVMC_ACCESS_WARM;
+    return EVMC_ACCESS_COLD;
 }
 
 


### PR DESCRIPTION
`access_storage()` journaled every storage access, including warm ones where nothing changes. Warm SLOADs are among the most frequent operations and each appended a ~90-byte journal entry, growing the journal by a large number of no-op entries per storage-heavy transaction, all replayed on rollback.

Journal in `access_storage()` only when the slot status actually changes (cold access) and journal the value change in `set_storage()` instead (previously pre-Berlin only).

**Equivalence argument**: every journal entry still snapshots the slot state `(current, access_status)` immediately before a change — any value change goes through `set_storage()` (now always journaled) and any status change goes through `access_storage()` (journaled exactly when it changes) — so replaying the journal in reverse restores the exact previous state for any interleaving. E.g. cold SSTORE now produces two entries: rollback restores `(V, WARM)` then `(V, COLD)`, same final state as the single `(V, COLD)` entry before.

Journal entries per operation:

| op | before | after |
|---|---|---|
| warm SLOAD | 1 | 0 |
| warm SSTORE | 1 | 1 |
| cold SLOAD | 1 | 1 |
| cold SSTORE | 1 | 2 (cold access is capped by the 2100 gas cost) |