### PR TITLE
Identify EVM revisions by name rather than by number

### DIFF
--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -922,42 +922,42 @@ enum evmc_revision
      *
      * The one Ethereum launched with.
      */
-    EVMC_FRONTIER = 0,
+    EVMC_FRONTIER,
 
     /**
      * The Homestead revision.
      *
      * https://eips.ethereum.org/EIPS/eip-606
      */
-    EVMC_HOMESTEAD = 1,
+    EVMC_HOMESTEAD,
 
     /**
      * The Tangerine Whistle revision.
      *
      * https://eips.ethereum.org/EIPS/eip-608
      */
-    EVMC_TANGERINE_WHISTLE = 2,
+    EVMC_TANGERINE_WHISTLE,
 
     /**
      * The Spurious Dragon revision.
      *
      * https://eips.ethereum.org/EIPS/eip-607
      */
-    EVMC_SPURIOUS_DRAGON = 3,
+    EVMC_SPURIOUS_DRAGON,
 
     /**
      * The Byzantium revision.
      *
      * https://eips.ethereum.org/EIPS/eip-609
      */
-    EVMC_BYZANTIUM = 4,
+    EVMC_BYZANTIUM,
 
     /**
      * The Constantinople revision.
      *
      * https://eips.ethereum.org/EIPS/eip-1013
      */
-    EVMC_CONSTANTINOPLE = 5,
+    EVMC_CONSTANTINOPLE,
 
     /**
      * The Petersburg revision.
@@ -966,76 +966,76 @@ enum evmc_revision
      *
      * https://eips.ethereum.org/EIPS/eip-1716
      */
-    EVMC_PETERSBURG = 6,
+    EVMC_PETERSBURG,
 
     /**
      * The Istanbul revision.
      *
      * https://eips.ethereum.org/EIPS/eip-1679
      */
-    EVMC_ISTANBUL = 7,
+    EVMC_ISTANBUL,
 
     /**
      * The Berlin revision.
      *
      * https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md
      */
-    EVMC_BERLIN = 8,
+    EVMC_BERLIN,
 
     /**
      * The London revision.
      *
      * https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md
      */
-    EVMC_LONDON = 9,
+    EVMC_LONDON,
 
     /**
      * The Paris revision (aka The Merge).
      *
      * https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md
      */
-    EVMC_PARIS = 10,
+    EVMC_PARIS,
 
     /**
      * The Shanghai revision.
      *
      * https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md
      */
-    EVMC_SHANGHAI = 11,
+    EVMC_SHANGHAI,
 
     /**
      * The Cancun revision.
      *
      * https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md
      */
-    EVMC_CANCUN = 12,
+    EVMC_CANCUN,
 
     /**
      * The Prague / Pectra revision.
      *
      * https://eips.ethereum.org/EIPS/eip-7600
      */
-    EVMC_PRAGUE = 13,
+    EVMC_PRAGUE,
 
     /**
      * The Osaka / Fusaka revision.
      *
      * https://eips.ethereum.org/EIPS/eip-7607
      */
-    EVMC_OSAKA = 14,
+    EVMC_OSAKA,
 
     /**
      * The Amsterdam / Glamsterdam revision.
      *
      * https://eips.ethereum.org/EIPS/eip-7773
      */
-    EVMC_AMSTERDAM = 15,
+    EVMC_AMSTERDAM,
 
     /**
      * The unspecified EVM revision used for EVM implementations to expose
      * experimental features.
      */
-    EVMC_EXPERIMENTAL = 16,
+    EVMC_EXPERIMENTAL,
 
     /** The maximum EVM revision supported. */
     EVMC_MAX_REVISION = EVMC_EXPERIMENTAL,

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -11,6 +11,16 @@ if(TARGET evmone-cli)
         ${PREFIX}/run PROPERTIES PASS_REGULAR_EXPRESSION
         "Result:   success\nGas used: 3\n")
 
+    add_test(NAME ${PREFIX}/run_rev COMMAND evmone-cli run --rev TangerineWhistle 00)
+    set_tests_properties(
+        ${PREFIX}/run_rev PROPERTIES PASS_REGULAR_EXPRESSION
+        "Executing on TangerineWhistle")
+
+    add_test(NAME ${PREFIX}/run_bad_rev COMMAND evmone-cli run --rev NoSuchRev 00)
+    set_tests_properties(
+        ${PREFIX}/run_bad_rev PROPERTIES PASS_REGULAR_EXPRESSION
+        "unknown revision: NoSuchRev")
+
     add_test(NAME ${PREFIX}/version COMMAND evmone-cli --version)
     set_tests_properties(
         ${PREFIX}/version PROPERTIES PASS_REGULAR_EXPRESSION "evmone")

--- a/tools/evmone/main.cpp
+++ b/tools/evmone/main.cpp
@@ -183,7 +183,11 @@ int main(int argc, const char* const* argv) noexcept
         run_cmd.add_option("--gas", gas, "Execution gas limit")
             ->capture_default_str()
             ->check(CLI::Range(0, 1000000000));
-        run_cmd.add_option("--rev", rev, "EVM revision")->capture_default_str();
+        run_cmd
+            .add_option_function<std::string>(
+                "--rev", [&rev](const std::string& name) { rev = evmone::test::to_rev(name); },
+                "EVM revision name")
+            ->default_str(evmc::to_string(rev));
         run_cmd.add_option("--input", input_arg, "Input bytes")->check(HexOrFile);
         run_cmd.add_flag("--create", create,
             "Create new contract out of the code and then execute this contract with the input");


### PR DESCRIPTION
evmone-cli's `run --rev` was bound to the evmc_revision enum, so CLI11 parsed it as the underlying integer (e.g. `--rev 15` for Amsterdam) — an opaque number that also shifts as revisions are inserted. Bind --rev to a string resolved through the existing evmone::test::to_rev() helper, mirroring the t8n `--state.fork` path; the default comes from evmc::to_string() and prints as [Osaka], and an unknown name now fails with "unknown revision: <name>".

Drop the explicit = 0..16 values from the evmc_revision enum so revisions are no longer advertised by number. The enumerators keep their order, leaving the values and ABI unchanged and EVMC_MAX_REVISION / EVMC_LATEST_STABLE_REVISION symbolic.