### PR TITLE
evmc: Remove the Constantinople revision

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -449,6 +449,20 @@ jobs:
       - download_execution_tests:
           rev: v17.2
       - run:
+          name: "Drop unsupported Constantinople test cases"
+          working_directory: ~/tests
+          command: |
+            # evmone no longer supports the Constantinople revision (it never
+            # activated on Mainnet and was superseded by Petersburg). Strip the
+            # Constantinople-only cases from the fixtures so the other forks in
+            # each file still run. ConstantinopleFix (== Petersburg) is kept.
+            # Only the directories actually run below are scanned.
+            files=$(grep -rlE '"network"[[:space:]]*:[[:space:]]*"Constantinople"' BlockchainTests/ValidBlocks BlockchainTests/InvalidBlocks LegacyTests/Cancun/BlockchainTests/ValidBlocks LegacyTests/Cancun/BlockchainTests/InvalidBlocks || true)
+            for f in $files; do
+              python3 -c "import json,sys; p=sys.argv[1]; d=json.load(open(p)); json.dump({k:v for k,v in d.items() if v.get('network')!='Constantinople'}, open(p,'w'), indent=1)" "$f"
+              echo "filtered $f"
+            done
+      - run:
           name: "Blockchain tests (ValidBlocks)"
           working_directory: ~/build
           command: >

--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -45,7 +45,7 @@ enum
      *
      * @see @ref versioning
      */
-    EVMC_ABI_VERSION = 13
+    EVMC_ABI_VERSION = 14
 };
 
 
@@ -80,7 +80,7 @@ enum evmc_call_kind
                                 The value param ignored. */
     EVMC_CALLCODE = 2,     /**< Request CALLCODE. */
     EVMC_CREATE = 3,       /**< Request CREATE. */
-    EVMC_CREATE2 = 4,      /**< Request CREATE2. Valid since Constantinople.*/
+    EVMC_CREATE2 = 4,      /**< Request CREATE2. Valid since Petersburg. */
 };
 
 /** The flags for ::evmc_message. */
@@ -951,13 +951,6 @@ enum evmc_revision
      * https://eips.ethereum.org/EIPS/eip-609
      */
     EVMC_BYZANTIUM,
-
-    /**
-     * The Constantinople revision.
-     *
-     * https://eips.ethereum.org/EIPS/eip-1013
-     */
-    EVMC_CONSTANTINOPLE,
 
     /**
      * The Petersburg revision.

--- a/evmc/include/evmc/helpers.h
+++ b/evmc/include/evmc/helpers.h
@@ -234,8 +234,6 @@ static inline const char* evmc_revision_to_string(enum evmc_revision rev)
         return "SpuriousDragon";
     case EVMC_BYZANTIUM:
         return "Byzantium";
-    case EVMC_CONSTANTINOPLE:
-        return "Constantinople";
     case EVMC_PETERSBURG:
         return "Petersburg";
     case EVMC_ISTANBUL:

--- a/lib/evmone/instructions_storage.cpp
+++ b/lib/evmone/instructions_storage.cpp
@@ -30,7 +30,6 @@ constexpr auto storage_cost_spec = []() noexcept {
         tbl[rev] = {false, 200, 20000, 5000, 15000};
 
     // Net cost schedule.
-    tbl[EVMC_CONSTANTINOPLE] = {true, 200, 20000, 5000, 15000};
     tbl[EVMC_ISTANBUL] = {true, 800, 20000, 5000, 15000};
     tbl[EVMC_BERLIN] = {
         true, instr::warm_storage_read_cost, 20000, 5000 - instr::cold_sload_cost, 15000};

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -129,14 +129,12 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
     table[EVMC_BYZANTIUM][OP_STATICCALL] = 700;
     table[EVMC_BYZANTIUM][OP_REVERT] = 0;
 
-    table[EVMC_CONSTANTINOPLE] = table[EVMC_BYZANTIUM];
-    table[EVMC_CONSTANTINOPLE][OP_SHL] = 3;
-    table[EVMC_CONSTANTINOPLE][OP_SHR] = 3;
-    table[EVMC_CONSTANTINOPLE][OP_SAR] = 3;
-    table[EVMC_CONSTANTINOPLE][OP_EXTCODEHASH] = 400;
-    table[EVMC_CONSTANTINOPLE][OP_CREATE2] = 32000;
-
-    table[EVMC_PETERSBURG] = table[EVMC_CONSTANTINOPLE];
+    table[EVMC_PETERSBURG] = table[EVMC_BYZANTIUM];
+    table[EVMC_PETERSBURG][OP_SHL] = 3;
+    table[EVMC_PETERSBURG][OP_SHR] = 3;
+    table[EVMC_PETERSBURG][OP_SAR] = 3;
+    table[EVMC_PETERSBURG][OP_EXTCODEHASH] = 400;
+    table[EVMC_PETERSBURG][OP_CREATE2] = 32000;
 
     table[EVMC_ISTANBUL] = table[EVMC_PETERSBURG];
     table[EVMC_ISTANBUL][OP_BALANCE] = 700;
@@ -258,9 +256,9 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_XOR] = {"XOR", 0, false, 2, -1, EVMC_FRONTIER};
     table[OP_NOT] = {"NOT", 0, false, 1, 0, EVMC_FRONTIER};
     table[OP_BYTE] = {"BYTE", 0, false, 2, -1, EVMC_FRONTIER};
-    table[OP_SHL] = {"SHL", 0, false, 2, -1, EVMC_CONSTANTINOPLE};
-    table[OP_SHR] = {"SHR", 0, false, 2, -1, EVMC_CONSTANTINOPLE};
-    table[OP_SAR] = {"SAR", 0, false, 2, -1, EVMC_CONSTANTINOPLE};
+    table[OP_SHL] = {"SHL", 0, false, 2, -1, EVMC_PETERSBURG};
+    table[OP_SHR] = {"SHR", 0, false, 2, -1, EVMC_PETERSBURG};
+    table[OP_SAR] = {"SAR", 0, false, 2, -1, EVMC_PETERSBURG};
     table[OP_CLZ] = {"CLZ", 0, false, 1, 0, EVMC_OSAKA};
 
     table[OP_KECCAK256] = {"KECCAK256", 0, false, 2, -1, EVMC_FRONTIER};
@@ -280,7 +278,7 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_EXTCODECOPY] = {"EXTCODECOPY", 0, false, 4, -4, EVMC_FRONTIER};
     table[OP_RETURNDATASIZE] = {"RETURNDATASIZE", 0, false, 0, 1, EVMC_BYZANTIUM};
     table[OP_RETURNDATACOPY] = {"RETURNDATACOPY", 0, false, 3, -3, EVMC_BYZANTIUM};
-    table[OP_EXTCODEHASH] = {"EXTCODEHASH", 0, false, 1, 0, EVMC_CONSTANTINOPLE};
+    table[OP_EXTCODEHASH] = {"EXTCODEHASH", 0, false, 1, 0, EVMC_PETERSBURG};
 
     table[OP_BLOCKHASH] = {"BLOCKHASH", 0, false, 1, 0, EVMC_FRONTIER};
     table[OP_COINBASE] = {"COINBASE", 0, false, 0, 1, EVMC_FRONTIER};
@@ -398,7 +396,7 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_CALLCODE] = {"CALLCODE", 0, false, 7, -6, EVMC_FRONTIER};
     table[OP_RETURN] = {"RETURN", 0, true, 2, -2, EVMC_FRONTIER};
     table[OP_DELEGATECALL] = {"DELEGATECALL", 0, false, 6, -5, EVMC_HOMESTEAD};
-    table[OP_CREATE2] = {"CREATE2", 0, false, 4, -3, EVMC_CONSTANTINOPLE};
+    table[OP_CREATE2] = {"CREATE2", 0, false, 4, -3, EVMC_PETERSBURG};
     table[OP_STATICCALL] = {"STATICCALL", 0, false, 6, -5, EVMC_BYZANTIUM};
     table[OP_REVERT] = {"REVERT", 0, true, 2, -2, EVMC_BYZANTIUM};
     table[OP_INVALID] = {"INVALID", 0, true, 0, 0, EVMC_FRONTIER};

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -129,7 +129,7 @@ std::optional<uint64_t> mining_reward(evmc_revision rev) noexcept
 {
     if (rev < EVMC_BYZANTIUM)
         return 5'000000000'000000000;
-    if (rev < EVMC_CONSTANTINOPLE)
+    if (rev < EVMC_PETERSBURG)
         return 3'000000000'000000000;
     if (rev < EVMC_PARIS)
         return 2'000000000'000000000;

--- a/test/state/ethash_difficulty.cpp
+++ b/test/state/ethash_difficulty.cpp
@@ -18,7 +18,6 @@ int64_t get_bomb_delay(evmc_revision rev) noexcept
         return 0;
     case EVMC_BYZANTIUM:
         return 3'000'000;
-    case EVMC_CONSTANTINOPLE:
     case EVMC_PETERSBURG:
     case EVMC_ISTANBUL:
         return 5'000'000;

--- a/test/unittests/evm_calls_test.cpp
+++ b/test/unittests/evm_calls_test.cpp
@@ -111,7 +111,7 @@ TEST_P(evm, create_gas)
 
 TEST_P(evm, create2)
 {
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     auto& account = host.accounts[msg.recipient];
     account.set_balance(1);
 
@@ -137,7 +137,7 @@ TEST_P(evm, create2)
 
 TEST_P(evm, create2_salt_cost)
 {
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     const auto code = create2().input(0, 0x20);
 
     execute(32021, code);
@@ -155,7 +155,7 @@ TEST_P(evm, create2_salt_cost)
 
 TEST_P(evm, create_balance_too_low)
 {
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     host.accounts[msg.recipient].set_balance(1);
     for (auto op : {OP_CREATE, OP_CREATE2})
     {
@@ -171,7 +171,7 @@ TEST_P(evm, create_failure)
     host.call_result.create_address = 0x00000000000000000000000000000000000000ce_address;
     const auto create_address =
         bytes_view{host.call_result.create_address.bytes, sizeof(host.call_result.create_address)};
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     for (auto op : {OP_CREATE, OP_CREATE2})
     {
         const auto code = push(0) + (3 * OP_DUP1) + op + ret_top();
@@ -267,7 +267,7 @@ TEST_P(evm, call_with_value_depth_limit)
 
 TEST_P(evm, call_depth_limit)
 {
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     msg.depth = 1024;
 
     for (auto op : {OP_CALL, OP_CALLCODE, OP_DELEGATECALL, OP_STATICCALL, OP_CREATE, OP_CREATE2})
@@ -649,7 +649,7 @@ TEST_P(evm, call_value)
 
 TEST_P(evm, create_oog_after)
 {
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     for (auto op : {OP_CREATE, OP_CREATE2})
     {
         auto code = 4 * push(0) + op + OP_SELFDESTRUCT;

--- a/test/unittests/evm_state_test.cpp
+++ b/test/unittests/evm_state_test.cpp
@@ -129,7 +129,7 @@ TEST_P(evm, selfbalance)
     // instruction as a result)
     auto code = bytecode{} + push(1) + OP_SELFBALANCE + mstore(0) + ret(32 - 6, 6);
 
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     execute(code);
     EXPECT_EQ(result.status_code, EVMC_UNDEFINED_INSTRUCTION);
 
@@ -506,7 +506,7 @@ TEST_P(evm, extcodehash)
     execute(code);
     EXPECT_EQ(result.status_code, EVMC_UNDEFINED_INSTRUCTION);
 
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     execute(code);
     EXPECT_EQ(gas_used, 418);
     ASSERT_EQ(result.output_size, 32);

--- a/test/unittests/evm_storage_test.cpp
+++ b/test/unittests/evm_storage_test.cpp
@@ -66,7 +66,7 @@ TEST_P(evm, sstore_cost)
 
     constexpr auto v1 = 0x01_bytes32;
 
-    for (auto r : {EVMC_BYZANTIUM, EVMC_CONSTANTINOPLE, EVMC_PETERSBURG, EVMC_ISTANBUL})
+    for (auto r : {EVMC_BYZANTIUM, EVMC_PETERSBURG, EVMC_ISTANBUL})
     {
         rev = r;
 
@@ -103,8 +103,6 @@ TEST_P(evm, sstore_cost)
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
         if (rev >= EVMC_ISTANBUL)
             EXPECT_EQ(gas_used, 806);
-        else if (rev == EVMC_CONSTANTINOPLE)
-            EXPECT_EQ(gas_used, 206);
         else
             EXPECT_EQ(gas_used, 5006);
         execute(205, sstore(1, 1));
@@ -116,8 +114,6 @@ TEST_P(evm, sstore_cost)
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
         if (rev >= EVMC_ISTANBUL)
             EXPECT_EQ(gas_used, 20812);
-        else if (rev == EVMC_CONSTANTINOPLE)
-            EXPECT_EQ(gas_used, 20212);
         else
             EXPECT_EQ(gas_used, 25012);
 
@@ -128,8 +124,6 @@ TEST_P(evm, sstore_cost)
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
         if (rev >= EVMC_ISTANBUL)
             EXPECT_EQ(gas_used, 806);
-        else if (rev == EVMC_CONSTANTINOPLE)
-            EXPECT_EQ(gas_used, 206);
         else
             EXPECT_EQ(gas_used, 5006);
 
@@ -139,8 +133,6 @@ TEST_P(evm, sstore_cost)
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
         if (rev >= EVMC_ISTANBUL)
             EXPECT_EQ(gas_used, 20812);
-        else if (rev == EVMC_CONSTANTINOPLE)
-            EXPECT_EQ(gas_used, 20212);
         else
             EXPECT_EQ(gas_used, 25012);
 
@@ -151,8 +143,6 @@ TEST_P(evm, sstore_cost)
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
         if (rev >= EVMC_ISTANBUL)
             EXPECT_EQ(gas_used, 5812);
-        else if (rev == EVMC_CONSTANTINOPLE)
-            EXPECT_EQ(gas_used, 5212);
         else
             EXPECT_EQ(gas_used, 10012);
 
@@ -163,8 +153,6 @@ TEST_P(evm, sstore_cost)
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
         if (rev >= EVMC_ISTANBUL)
             EXPECT_EQ(gas_used, 5812);
-        else if (rev == EVMC_CONSTANTINOPLE)
-            EXPECT_EQ(gas_used, 5212);
         else
             EXPECT_EQ(gas_used, 10012);
     }
@@ -255,12 +243,11 @@ TEST_P(evm, sstore_cost_net_gas_metering)
     };
 
     std::array<CostConstants, EVMC_MAX_REVISION + 1> cost_constants{};
-    cost_constants[EVMC_CONSTANTINOPLE] = {200, 20000, 5000, 15000};
     cost_constants[EVMC_ISTANBUL] = {800, 20000, 5000, 15000};
     cost_constants[EVMC_BERLIN] = {100, 20000, 2900, 15000};
     cost_constants[EVMC_LONDON] = {100, 20000, 2900, 4800};
 
-    for (const auto r : {EVMC_CONSTANTINOPLE, EVMC_ISTANBUL, EVMC_BERLIN, EVMC_LONDON})
+    for (const auto r : {EVMC_ISTANBUL, EVMC_BERLIN, EVMC_LONDON})
     {
         rev = r;
         const auto& c = cost_constants.at(static_cast<size_t>(r));
@@ -291,10 +278,6 @@ TEST_P(evm, sstore_below_stipend)
     rev = EVMC_HOMESTEAD;
     execute(2306, code);
     EXPECT_EQ(result.status_code, EVMC_OUT_OF_GAS);
-
-    rev = EVMC_CONSTANTINOPLE;
-    execute(2306, code);
-    EXPECT_EQ(result.status_code, EVMC_SUCCESS);
 
     rev = EVMC_ISTANBUL;
     execute(2306, code);

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -352,7 +352,7 @@ TEST_P(evm, signextend)
 
 TEST_P(evm, signextend_31)
 {
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
 
     execute(bytecode{"61010160000360081c601e0b60005260206000f3"});
     EXPECT_GAS_USED(EVMC_SUCCESS, 38);
@@ -581,7 +581,7 @@ TEST_P(evm, return_empty_buffer_at_high_offset)
 TEST_P(evm, shl)
 {
     const bytecode code = "600560011b6000526001601ff3";
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     execute(code);
     EXPECT_EQ(gas_used, 24);
     EXPECT_EQ(result.status_code, EVMC_SUCCESS);
@@ -592,7 +592,7 @@ TEST_P(evm, shl)
 TEST_P(evm, shr)
 {
     const bytecode code = "600560011c6000526001601ff3";
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     execute(code);
     EXPECT_EQ(gas_used, 24);
     EXPECT_EQ(result.status_code, EVMC_SUCCESS);
@@ -603,7 +603,7 @@ TEST_P(evm, shr)
 TEST_P(evm, sar)
 {
     const bytecode code = "600160000360021d60005260016000f3";
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     execute(code);
     EXPECT_EQ(gas_used, 30);
     EXPECT_EQ(result.status_code, EVMC_SUCCESS);
@@ -614,7 +614,7 @@ TEST_P(evm, sar)
 TEST_P(evm, sar_01)
 {
     const bytecode code = "600060011d60005260016000f3";
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     execute(code);
     EXPECT_EQ(gas_used, 24);
     EXPECT_EQ(result.status_code, EVMC_SUCCESS);
@@ -624,7 +624,7 @@ TEST_P(evm, sar_01)
 
 TEST_P(evm, shift_overflow)
 {
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     for (auto op : {OP_SHL, OP_SHR, OP_SAR})
     {
         execute(not_(0) + 0x100 + op + ret_top());
@@ -694,7 +694,7 @@ TEST_P(evm, staticmode)
 {
     auto code_prefix = 1 + 6 * OP_DUP1;
 
-    rev = EVMC_CONSTANTINOPLE;
+    rev = EVMC_PETERSBURG;
     for (auto op : {OP_SSTORE, OP_LOG0, OP_LOG1, OP_LOG2, OP_LOG3, OP_LOG4, OP_CALL, OP_CREATE,
              OP_CREATE2, OP_SELFDESTRUCT})
     {

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -19,8 +19,6 @@ evmc_revision to_rev(std::string_view s)
         return EVMC_SPURIOUS_DRAGON;
     if (s == "Byzantium")
         return EVMC_BYZANTIUM;
-    if (s == "Constantinople")
-        return EVMC_CONSTANTINOPLE;
     if (s == "Petersburg" || s == "ConstantinopleFix")
         return EVMC_PETERSBURG;
     if (s == "Istanbul")


### PR DESCRIPTION
It never activated on Mainnet (superseded by Petersburg after the EIP-1283 issue) and no live testnet runs it any more. Bump EVMC_ABI_VERSION and retarget its opcodes to Petersburg. Strip the lone Constantinople case from the legacy blockchain-test fixtures in CI.