### PR TITLE
evmc: Add get_nonce() to the host interface

### DIFF
--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -45,7 +45,7 @@ enum
      *
      * @see @ref versioning
      */
-    EVMC_ABI_VERSION = 14
+    EVMC_ABI_VERSION = 15
 };
 
 
@@ -670,6 +670,18 @@ typedef evmc_uint256be (*evmc_get_balance_fn)(struct evmc_host_context* context,
                                               const evmc_address* address);
 
 /**
+ * Get nonce callback function.
+ *
+ * This callback function is used by a VM to query the nonce of the given account in the state.
+ *
+ * @param context  The pointer to the Host execution context.
+ * @param address  The address of the account.
+ * @return         The nonce of the given account or 0 if the account does not exist.
+ */
+typedef uint64_t (*evmc_get_nonce_fn)(struct evmc_host_context* context,
+                                      const evmc_address* address);
+
+/**
  * Get code size callback function.
  *
  * This callback function is used by a VM to get the size of the code stored
@@ -832,6 +844,9 @@ struct evmc_host_interface
 
     /** Get balance callback function. */
     evmc_get_balance_fn get_balance;
+
+    /** Get nonce callback function. */
+    evmc_get_nonce_fn get_nonce;
 
     /** Get code size callback function. */
     evmc_get_code_size_fn get_code_size;

--- a/evmc/include/evmc/evmc.hpp
+++ b/evmc/include/evmc/evmc.hpp
@@ -454,6 +454,9 @@ public:
     /// @copydoc evmc_host_interface::get_balance
     virtual uint256be get_balance(const address& addr) const noexcept = 0;
 
+    /// @copydoc evmc_host_interface::get_nonce
+    virtual uint64_t get_nonce(const address& addr) const noexcept = 0;
+
     /// @copydoc evmc_host_interface::get_code_size
     virtual size_t get_code_size(const address& addr) const noexcept = 0;
 
@@ -541,6 +544,11 @@ public:
     uint256be get_balance(const address& address) const noexcept final
     {
         return host->get_balance(context, &address);
+    }
+
+    uint64_t get_nonce(const address& address) const noexcept final
+    {
+        return host->get_nonce(context, &address);
     }
 
     size_t get_code_size(const address& address) const noexcept final
@@ -799,6 +807,11 @@ inline evmc_uint256be get_balance(evmc_host_context* h, const evmc_address* addr
     return Host::from_context(h)->get_balance(*addr);
 }
 
+inline uint64_t get_nonce(evmc_host_context* h, const evmc_address* addr) noexcept
+{
+    return Host::from_context(h)->get_nonce(*addr);
+}
+
 inline size_t get_code_size(evmc_host_context* h, const evmc_address* addr) noexcept
 {
     return Host::from_context(h)->get_code_size(*addr);
@@ -886,6 +899,7 @@ inline const evmc_host_interface& Host::get_interface() noexcept
         ::evmc::internal::get_storage,
         ::evmc::internal::set_storage,
         ::evmc::internal::get_balance,
+        ::evmc::internal::get_nonce,
         ::evmc::internal::get_code_size,
         ::evmc::internal::get_code_hash,
         ::evmc::internal::copy_code,

--- a/evmc/include/evmc/mocked_host.hpp
+++ b/evmc/include/evmc/mocked_host.hpp
@@ -324,6 +324,17 @@ public:
         return it->second.balance;
     }
 
+    /// Get the account's nonce (EVMC Host method).
+    uint64_t get_nonce(const address& addr) const noexcept override
+    {
+        record_account_access(addr);
+        const auto it = accounts.find(addr);
+        if (it == accounts.end())
+            return 0;
+
+        return static_cast<uint64_t>(it->second.nonce);
+    }
+
     /// Get the account's code size (EVMC host method).
     size_t get_code_size(const address& addr) const noexcept override
     {

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -75,6 +75,12 @@ uint256be Host::get_balance(const address& addr) const noexcept
     return (acc != nullptr) ? intx::be::store<uint256be>(acc->balance) : uint256be{};
 }
 
+uint64_t Host::get_nonce(const address& addr) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    return (acc != nullptr) ? acc->nonce : 0;
+}
+
 namespace
 {
 /// Check if an existing account is the "create collision"

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -71,6 +71,8 @@ private:
 
     [[nodiscard]] uint256be get_balance(const address& addr) const noexcept override;
 
+    [[nodiscard]] uint64_t get_nonce(const address& addr) const noexcept override;
+
     [[nodiscard]] size_t get_code_size(const address& addr) const noexcept override;
 
     [[nodiscard]] bytes32 get_code_hash(const address& addr) const noexcept override;


### PR DESCRIPTION
Upcoming work computes the CREATE address in the VM, making the creating
frame the first VM-side consumer of the sender's nonce. A message field
cannot carry it - a reentrant frame creating from the same account bumps
the nonce mid-frame - so it is a live query like get_balance.

Bump EVMC_ABI_VERSION to 15.