### PR TITLE
Compute the create address in the VM

### DIFF
--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -45,7 +45,7 @@ enum
      *
      * @see @ref versioning
      */
-    EVMC_ABI_VERSION = 15
+    EVMC_ABI_VERSION = 16
 };
 
 
@@ -128,6 +128,7 @@ struct evmc_message
      * message value evmc_message::value is going to be transferred.
      * For ::EVMC_CALLCODE or ::EVMC_DELEGATECALL, this may be different from
      * the evmc_message::code_address.
+     * For ::EVMC_CREATE and ::EVMC_CREATE2 this is the address of the account to be created.
      *
      * Defined as `r` in the Yellow Paper.
      */
@@ -166,14 +167,6 @@ struct evmc_message
      * Defined as `v` or `v~` in the Yellow Paper.
      */
     evmc_uint256be value;
-
-    /**
-     * The optional value used in new contract address construction.
-     *
-     * Needed only for a Host to calculate created address when kind is ::EVMC_CREATE2.
-     * Ignored in evmc_execute_fn().
-     */
-    evmc_bytes32 create2_salt;
 
     /**
      * The address of the code to be executed.
@@ -465,16 +458,6 @@ struct evmc_result
      * function to the result itself allows VM composition.
      */
     evmc_release_result_fn release;
-
-    /**
-     * The address of the possibly created contract.
-     *
-     * The create address may be provided even though the contract creation has failed
-     * (evmc_result::status_code is not ::EVMC_SUCCESS). This is useful in situations
-     * when the address is observable, e.g. access to it remains warm.
-     * In all other cases the address MUST be null bytes.
-     */
-    evmc_address create_address;
 };
 
 

--- a/evmc/include/evmc/evmc.hpp
+++ b/evmc/include/evmc/evmc.hpp
@@ -328,7 +328,6 @@ constexpr auto make_result = evmc_make_result;
 class Result : private evmc_result
 {
 public:
-    using evmc_result::create_address;
     using evmc_result::gas_left;
     using evmc_result::gas_refund;
     using evmc_result::output_data;
@@ -363,21 +362,6 @@ public:
                     int64_t _gas_refund = 0) noexcept
       : evmc_result{make_result(_status_code, _gas_left, _gas_refund, nullptr, 0)}
     {}
-
-    /// Creates the result of contract creation.
-    ///
-    /// @param _status_code     The status code.
-    /// @param _gas_left        The amount of gas left.
-    /// @param _gas_refund      The amount of refunded gas.
-    /// @param _create_address  The address of the possibly created account.
-    explicit Result(evmc_status_code _status_code,
-                    int64_t _gas_left,
-                    int64_t _gas_refund,
-                    const evmc_address& _create_address) noexcept
-      : evmc_result{make_result(_status_code, _gas_left, _gas_refund, nullptr, 0)}
-    {
-        create_address = _create_address;
-    }
 
     /// Converting constructor from raw evmc_result.
     ///

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -2,6 +2,8 @@
 // Copyright 2019 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "constants.hpp"
+#include "create_address.hpp"
 #include "delegation.hpp"
 #include "instructions.hpp"
 #include <variant>
@@ -204,7 +206,7 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
     const auto endowment = stack.pop();
     const auto init_code_offset_u256 = stack.pop();
     const auto init_code_size_u256 = stack.pop();
-    const auto salt = (Op == OP_CREATE2) ? stack.pop() : uint256{};
+    const auto salt = (Op == OP_CREATE2) ? intx::be::store<bytes32>(stack.pop()) : bytes32{};
 
     stack.push(0);  // Assume failure.
     state.return_data.clear();
@@ -230,20 +232,32 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
         intx::be::load<uint256>(state.host.get_balance(state.msg->recipient)) < endowment)
         return {EVMC_SUCCESS, gas_left};  // "Light" failure.
 
+    const auto& sender = state.msg->recipient;
+    const auto sender_nonce = state.host.get_nonce(sender);  // Pre-bump sender nonce.
+
+    // Creation fails when the sender's nonce is at maximum (EIP-2681).
+    if (sender_nonce == MAX_NONCE)
+        return {EVMC_SUCCESS, gas_left};  // "Light" failure.
+
+    const auto init_code =
+        bytes_view{init_code_size > 0 ? &state.memory[init_code_offset] : nullptr, init_code_size};
+
     evmc_message msg{.kind = to_call_kind(Op)};
+    msg.recipient = (Op == OP_CREATE) ? compute_create_address(sender, sender_nonce) :
+                                        compute_create2_address(sender, salt, init_code);
+
+    // Access to the new address is warmed and never reverted (EIP-2929).
+    if (state.rev >= EVMC_BERLIN)
+        state.host.access_account(msg.recipient);
+
     msg.gas = gas_left;
     if (state.rev >= EVMC_TANGERINE_WHISTLE)
-        msg.gas = msg.gas - msg.gas / 64;
+        msg.gas -= msg.gas / 64;
 
-    if (init_code_size > 0)
-    {
-        // init_code_offset may be garbage if init_code_size == 0.
-        msg.input_data = &state.memory[init_code_offset];
-        msg.input_size = init_code_size;
-    }
-    msg.sender = state.msg->recipient;
+    msg.input_data = init_code.data();
+    msg.input_size = init_code.size();
+    msg.sender = sender;
     msg.depth = state.msg->depth + 1;
-    msg.create2_salt = intx::be::store<evmc::bytes32>(salt);
     msg.value = intx::be::store<evmc::uint256be>(endowment);
 
     const auto result = state.host.call(msg);
@@ -252,7 +266,7 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
 
     state.return_data.assign(result.output_data, result.output_size);
     if (result.status_code == EVMC_SUCCESS)
-        stack.top() = intx::be::load<uint256>(result.create_address);
+        stack.top() = intx::be::load<uint256>(msg.recipient);
 
     return {EVMC_SUCCESS, gas_left};
 }

--- a/test/fuzzer/fuzzer.cpp
+++ b/test/fuzzer/fuzzer.cpp
@@ -80,14 +80,6 @@ public:
         else
             result.gas_left = msg.gas / (gas_left_factor + 3);
 
-        if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
-        {
-            // Use the output to fill the create address.
-            // We still keep the output to check if VM is going to ignore it.
-            std::memcpy(result.create_address.bytes, result.output_data,
-                std::min(sizeof(result.create_address), result.output_size));
-        }
-
         return result;
     }
 };
@@ -202,7 +194,7 @@ fuzz_input populate_input(const uint8_t* data, size_t data_size) noexcept
     const auto destination_8bits = data[6];
     const auto sender_8bits = data[7];
     const auto value_8bits = data[8];
-    const auto create2_salt_8bits = data[9];
+    // data[9] unused (was the create2_salt, dropped from evmc_message).
 
     const auto tx_gas_price_8bits = data[10];
     const auto tx_origin_8bits = data[11];
@@ -247,9 +239,6 @@ fuzz_input populate_input(const uint8_t* data, size_t data_size) noexcept
     in.msg.input_size = input_size_16bits;
     in.msg.input_data = data;
     in.msg.value = generate_interesting_value(value_8bits);
-
-    // Should be ignored by VMs.
-    in.msg.create2_salt = generate_interesting_value(create2_salt_8bits);
 
     data += in.msg.input_size;
     data_size -= in.msg.input_size;
@@ -359,7 +348,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t data_size) noe
                 ASSERT_EQ(bytes_view(m1.input_data, m1.input_size),
                     bytes_view(m2.input_data, m2.input_size));
                 ASSERT_EQ(evmc::uint256be{m1.value}, evmc::uint256be{m2.value});
-                ASSERT_EQ(evmc::bytes32{m1.create2_salt}, evmc::bytes32{m2.create2_salt});
             }
 
             ASSERT(std::equal(ref_host.recorded_logs.begin(), ref_host.recorded_logs.end(),

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -176,50 +176,10 @@ bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcep
     return false;
 }
 
-std::optional<evmc_message> Host::prepare_message(evmc_message msg) noexcept
-{
-    if (msg.depth == 0 || msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
-    {
-        auto& sender_acc = m_state.get(msg.sender);
-
-        // EIP-2681 (already checked for depth 0 during transaction validation).
-        if (sender_acc.nonce == MAX_NONCE)
-            return {};  // Light early exception.
-
-        if (msg.depth != 0)
-        {
-            m_state.journal_bump_nonce(msg.sender);
-            ++sender_acc.nonce;  // Bump sender nonce.
-        }
-
-        if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
-        {
-            // Compute and set the address of the account being created.
-            assert(msg.recipient == address{});
-            assert(msg.code_address == address{});
-            // Nonce was already incremented, but creation calculation needs non-incremented value
-            assert(sender_acc.nonce != 0);
-            const auto creation_sender_nonce = sender_acc.nonce - 1;
-            if (msg.kind == EVMC_CREATE)
-                msg.recipient = compute_create_address(msg.sender, creation_sender_nonce);
-            else
-            {
-                assert(msg.kind == EVMC_CREATE2);
-                msg.recipient = compute_create2_address(
-                    msg.sender, msg.create2_salt, {msg.input_data, msg.input_size});
-            }
-
-            // By EIP-2929, the access to new created address is never reverted.
-            access_account(msg.recipient);
-        }
-    }
-
-    return msg;
-}
-
 evmc::Result Host::create(const evmc_message& msg) noexcept
 {
     assert(msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2);
+    assert(msg.recipient != address{});  // Must be computed already.
 
     auto* new_acc = m_state.find(msg.recipient);
     const bool new_acc_exists = new_acc != nullptr;
@@ -254,10 +214,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     const bytes_view initcode{msg.input_data, msg.input_size};
     auto result = m_vm.execute(*this, m_rev, create_msg, initcode.data(), initcode.size());
     if (result.status_code != EVMC_SUCCESS)
-    {
-        result.create_address = msg.recipient;
         return result;
-    }
 
     auto gas_left = result.gas_left;
     assert(gas_left >= 0);
@@ -277,7 +234,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     if (gas_left < 0)
     {
         return (m_rev == EVMC_FRONTIER) ?
-                   evmc::Result{EVMC_SUCCESS, result.gas_left, result.gas_refund, msg.recipient} :
+                   evmc::Result{EVMC_SUCCESS, result.gas_left, result.gas_refund} :
                    evmc::Result{EVMC_FAILURE};
     }
 
@@ -288,7 +245,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
         new_acc->code_changed = true;
     }
 
-    return evmc::Result{result.status_code, gas_left, result.gas_refund, msg.recipient};
+    return evmc::Result{result.status_code, gas_left, result.gas_refund};
 }
 
 evmc::Result Host::execute_message(const evmc_message& msg) noexcept
@@ -340,16 +297,21 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
     return m_vm.execute(*this, m_rev, msg, code.data(), code.size());
 }
 
-evmc::Result Host::call(const evmc_message& orig_msg) noexcept
+evmc::Result Host::call(const evmc_message& msg) noexcept
 {
-    const auto msg = prepare_message(orig_msg);
-    if (!msg.has_value())
-        return evmc::Result{EVMC_FAILURE, orig_msg.gas};  // Light exception.
+    if (msg.depth != 0 && (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2))
+    {
+        // Bump the creator's nonce (already done for depth 0). Not reverted if creation fails.
+        auto& sender_acc = m_state.get(msg.sender);
+        assert(sender_acc.nonce != MAX_NONCE);
+        m_state.journal_bump_nonce(msg.sender);
+        ++sender_acc.nonce;
+    }
 
     const auto logs_checkpoint = m_logs.size();
     const auto state_checkpoint = m_state.checkpoint();
 
-    auto result = execute_message(*msg);
+    auto result = execute_message(msg);
 
     if (result.status_code != EVMC_SUCCESS)
     {

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -7,7 +7,6 @@
 #include "state.hpp"
 #include "state_view.hpp"
 #include <evmone/create_address.hpp>
-#include <optional>
 
 namespace evmone::state
 {
@@ -75,14 +74,6 @@ public:
 
 private:
     evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept override;
-
-    /// Prepares message for execution.
-    ///
-    /// This contains mostly checks and logic related to the sender
-    /// which may finally be moved to EVM.
-    /// Any state modification is not reverted.
-    /// @return Modified message or std::nullopt in case of EVM exception.
-    std::optional<evmc_message> prepare_message(evmc_message msg) noexcept;
 
     evmc::Result execute_message(const evmc_message& msg) noexcept;
 };

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -203,7 +203,7 @@ int64_t process_authorization_list(
 
 evmc_message build_message(const Transaction& tx, int64_t execution_gas_limit) noexcept
 {
-    const auto recipient = tx.to.has_value() ? *tx.to : evmc::address{};
+    const auto recipient = tx.to.has_value() ? *tx.to : compute_create_address(tx.sender, tx.nonce);
 
     return {
         .kind = tx.to.has_value() ? EVMC_CALL : EVMC_CREATE,
@@ -215,7 +215,6 @@ evmc_message build_message(const Transaction& tx, int64_t execution_gas_limit) n
         .input_data = tx.data.data(),
         .input_size = tx.data.size(),
         .value = intx::be::store<evmc::uint256be>(tx.value),
-        .create2_salt = {},
         .code_address = recipient,
         .code = nullptr,
         .code_size = 0,
@@ -627,9 +626,10 @@ TransactionReceipt transition(const StateView& state_view, const BlockInfo& bloc
 
     Host host{rev, vm, state, block, block_hashes, tx};
 
-    sender_acc.access_status = EVMC_ACCESS_WARM;  // Tx sender is always warm.
-    if (tx.to.has_value())
-        host.access_account(*tx.to);
+    auto message = build_message(tx, tx_props.execution_gas_limit);
+
+    sender_acc.access_status = EVMC_ACCESS_WARM;  // Sender is always warm.
+    host.access_account(message.recipient);  // Recipient (incl. create address) is always warm.
     for (const auto& [a, storage_keys] : tx.access_list)
     {
         host.access_account(a);
@@ -642,7 +642,6 @@ TransactionReceipt transition(const StateView& state_view, const BlockInfo& bloc
     if (rev >= EVMC_SHANGHAI)
         host.access_account(block.coinbase);
 
-    auto message = build_message(tx, tx_props.execution_gas_limit);
     if (tx.to.has_value())
     {
         if (const auto delegate = get_delegate_address(host, *tx.to))

--- a/test/unittests/evm_calls_test.cpp
+++ b/test/unittests/evm_calls_test.cpp
@@ -5,6 +5,7 @@
 /// This file contains EVM unit tests that perform any kind of calls.
 
 #include "evm_fixture.hpp"
+#include <evmone/create_address.hpp>
 
 using namespace evmc::literals;
 using namespace evmone::test;
@@ -76,14 +77,13 @@ TEST_P(evm, create)
     auto call_output = bytes{0xa, 0xb, 0xc};
     host.call_result.output_data = call_output.data();
     host.call_result.output_size = call_output.size();
-    host.call_result.create_address = 0xcc010203040506070809010203040506070809ce_address;
     host.call_result.gas_left = 200000;
     execute(300000, sstore(1, create().value(1).input(0, 0x20)));
 
     EXPECT_GAS_USED(EVMC_SUCCESS, 115816);
 
-    EXPECT_EQ(account.storage[0x01_bytes32].current,
-        0x000000000000000000000000cc010203040506070809010203040506070809ce_bytes32);
+    const auto expected_addr = evmone::compute_create_address(msg.recipient, 0);
+    EXPECT_EQ(account.storage[0x01_bytes32].current, to_bytes32(expected_addr));
 
     ASSERT_EQ(host.recorded_calls.size(), 1);
     const auto& call_msg = host.recorded_calls.back();
@@ -91,7 +91,6 @@ TEST_P(evm, create)
     EXPECT_EQ(call_msg.gas, 263801);
     EXPECT_EQ(call_msg.value, 0x01_bytes32);
     EXPECT_EQ(call_msg.input_size, 0x20);
-    EXPECT_EQ(call_msg.create2_salt, 0x00_bytes32);
 }
 
 TEST_P(evm, create_gas)
@@ -118,7 +117,6 @@ TEST_P(evm, create2)
     const bytes call_output{0xa, 0xb, 0xc};
     host.call_result.output_data = call_output.data();
     host.call_result.output_size = call_output.size();
-    host.call_result.create_address = 0xc2010203040506070809010203040506070809ce_address;
     host.call_result.gas_left = 200000;
     execute(300000, sstore(1, create2().value(1).input(0, 0x41).salt(0x5a)));
     EXPECT_GAS_USED(EVMC_SUCCESS, 115817);
@@ -129,10 +127,13 @@ TEST_P(evm, create2)
     EXPECT_EQ(call_msg.gas, 263775);
     EXPECT_EQ(call_msg.value, 0x01_bytes32);
     EXPECT_EQ(call_msg.input_size, 0x41);
-    EXPECT_EQ(call_msg.create2_salt, 0x5a_bytes32);
 
-    EXPECT_EQ(account.storage[0x01_bytes32].current,
-        0x000000000000000000000000c2010203040506070809010203040506070809ce_bytes32);
+    // The VM computes the created address itself: CREATE2 with salt 0x5a over
+    // the 0x41-byte all-zero initcode read from the empty memory.
+    const auto initcode = bytes(0x41, 0);
+    const auto expected_addr =
+        evmone::compute_create2_address(msg.recipient, 0x5a_bytes32, initcode);
+    EXPECT_EQ(account.storage[0x01_bytes32].current, to_bytes32(expected_addr));
 }
 
 TEST_P(evm, create2_salt_cost)
@@ -168,12 +169,13 @@ TEST_P(evm, create_balance_too_low)
 
 TEST_P(evm, create_failure)
 {
-    host.call_result.create_address = 0x00000000000000000000000000000000000000ce_address;
-    const auto create_address =
-        bytes_view{host.call_result.create_address.bytes, sizeof(host.call_result.create_address)};
     rev = EVMC_PETERSBURG;
     for (auto op : {OP_CREATE, OP_CREATE2})
     {
+        const auto computed_addr = op == OP_CREATE ?
+                                       evmone::compute_create_address(msg.recipient, 0) :
+                                       evmone::compute_create2_address(msg.recipient, {}, {});
+        const auto create_address = bytes_view{computed_addr.bytes, sizeof(computed_addr)};
         const auto code = push(0) + (3 * OP_DUP1) + op + ret_top();
 
         host.call_result.status_code = EVMC_SUCCESS;
@@ -797,7 +799,10 @@ TEST_P(evm, call_gas_refund_aggregation_different_calls)
 TEST_P(evm, call_gas_refund_aggregation_same_calls)
 {
     rev = EVMC_LONDON;
-    host.accounts[msg.recipient].set_balance(2);
+    // The first CREATE pushes its address, which the second CREATE then pops as its value argument,
+    // the balance must cover it.
+    host.accounts[msg.recipient].balance =
+        intx::be::store<evmc::uint256be>(intx::uint256{1} << 200);
     host.call_result.status_code = EVMC_SUCCESS;
     host.call_result.gas_refund = 1;
 

--- a/test/unittests/evm_eip3860_initcode_test.cpp
+++ b/test/unittests/evm_eip3860_initcode_test.cpp
@@ -14,7 +14,6 @@ inline constexpr size_t initcode_size_limit = 0xc000;
 
 TEST_P(evm, create_initcode_limit)
 {
-    host.call_result.create_address = 0x02_address;
     for (const auto& c : {create().input(0, calldataload(0)) + ret_top(),
              create2().input(0, calldataload(0)) + ret_top()})
     {
@@ -30,7 +29,9 @@ TEST_P(evm, create_initcode_limit)
                 }
                 else
                 {
-                    EXPECT_OUTPUT_INT(2);
+                    EXPECT_STATUS(EVMC_SUCCESS);
+                    ASSERT_EQ(result.output_size, 32);
+                    EXPECT_NE(intx::be::unsafe::load<intx::uint256>(result.output_data), 0);
                 }
             }
         }

--- a/test/unittests/evm_other_test.cpp
+++ b/test/unittests/evm_other_test.cpp
@@ -85,9 +85,10 @@ TEST_P(evm, evmone_block_gas_cost_overflow_create)
 
     execute(gas_max - 1, code);
     EXPECT_STATUS(EVMC_OUT_OF_GAS);
-    if (!host.recorded_calls.empty())  // turbo
+    if (!host.recorded_calls.empty())  // Advanced.
     {
-        EXPECT_EQ(host.recorded_calls.size(), 3);  // baseline
+        // Baseline: The first CREATE pushes its address, the next fails the memory check.
+        EXPECT_EQ(host.recorded_calls.size(), 1);
     }
 }
 

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -311,7 +311,6 @@ TEST_F(tracing, trace_create_instruction)
     const auto code = push(10) + push(0) + push(0) + OP_CREATE + ret_top();
 
     const auto result_data = "0x60016000526001601ff3"_hex;
-    host.call_result.create_address = 0x1122334455667788991011223344556677889910_address;
     host.call_result.output_data = result_data.data();
     host.call_result.output_size = result_data.size();
 
@@ -320,8 +319,8 @@ TEST_F(tracing, trace_create_instruction)
 {"pc":2,"op":96,"gas":"0xf423d","gasCost":"0x3","memSize":0,"stack":["0xa"],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":4,"op":96,"gas":"0xf423a","gasCost":"0x3","memSize":0,"stack":["0xa","0x0"],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":6,"op":240,"gas":"0xf4237","gasCost":"0x7d00","memSize":0,"stack":["0xa","0x0","0x0"],"depth":1,"refund":0,"opName":"CREATE"}
-{"pc":7,"op":96,"gas":"0x3b14","gasCost":"0x3","memSize":32,"stack":["0x1122334455667788991011223344556677889910"],"returnData":"0x60016000526001601ff3","depth":1,"refund":0,"opName":"PUSH1"}
-{"pc":9,"op":82,"gas":"0x3b11","gasCost":"0x3","memSize":32,"stack":["0x1122334455667788991011223344556677889910","0x0"],"returnData":"0x60016000526001601ff3","depth":1,"refund":0,"opName":"MSTORE"}
+{"pc":7,"op":96,"gas":"0x3b14","gasCost":"0x3","memSize":32,"stack":["0xbd770416a3345f91e4b34576cb804a576fa48eb1"],"returnData":"0x60016000526001601ff3","depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":9,"op":82,"gas":"0x3b11","gasCost":"0x3","memSize":32,"stack":["0xbd770416a3345f91e4b34576cb804a576fa48eb1","0x0"],"returnData":"0x60016000526001601ff3","depth":1,"refund":0,"opName":"MSTORE"}
 {"pc":10,"op":96,"gas":"0x3b0e","gasCost":"0x3","memSize":32,"stack":[],"returnData":"0x60016000526001601ff3","depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":12,"op":96,"gas":"0x3b0b","gasCost":"0x3","memSize":32,"stack":["0x20"],"returnData":"0x60016000526001601ff3","depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":14,"op":243,"gas":"0x3b08","gasCost":"0x0","memSize":32,"stack":["0x20","0x0"],"returnData":"0x60016000526001601ff3","depth":1,"refund":0,"opName":"RETURN"}


### PR DESCRIPTION
The create address was computed host-side (Host::prepare_message), one
EVMC crossing too late: msg.recipient traveled down empty and was
filled midway, the EIP-2681 nonce-overflow light-fail lived in the host
while the depth and balance light-fails lived in the VM, the EIP-2929
warming happened host-side where EELS does it in the creating frame,
and the parent could learn what it created only from
evmc_result.create_address.

Compute the address in create_impl instead: read the sender's nonce via
get_nonce (unifying the EIP-2681 light-fail with depth/balance), derive
the CREATE/CREATE2 address, warm it in the creating frame, 
and pass it down in msg.recipient - the same
VM-resolved-message pattern as code_address for EIP-7702 delegations.
This leaves evmc_result.create_address and evmc_message.create2_salt
without readers: drop both and bump EVMC_ABI_VERSION to 16.

Host::prepare_message dissolves. The creator-nonce bump stays in
Host::call before the state checkpoint: per the Yellow Paper it
survives a failed creation. At depth 0, build_message computes the
deployment address from tx.nonce.