### PR TITLE
Move the create address computation to lib/evmone

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(evmone
     baseline_instruction_table.cpp
     baseline_instruction_table.hpp
     constants.hpp
+    create_address.cpp
+    create_address.hpp
     delegation.cpp
     delegation.hpp
     instructions.hpp

--- a/lib/evmone/create_address.cpp
+++ b/lib/evmone/create_address.cpp
@@ -1,0 +1,62 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "create_address.hpp"
+#include <evmone_precompiles/keccak.hpp>
+#include <intx/intx.hpp>
+#include <algorithm>
+#include <bit>
+
+namespace evmone
+{
+address compute_create_address(const address& sender, uint64_t sender_nonce) noexcept
+{
+    static constexpr auto RLP_STR_BASE = 0x80;
+    static constexpr auto RLP_LIST_BASE = 0xc0;
+    static constexpr auto ADDRESS_SIZE = sizeof(sender);
+    static constexpr std::ptrdiff_t MAX_NONCE_SIZE = sizeof(sender_nonce);
+
+    uint8_t buffer[ADDRESS_SIZE + MAX_NONCE_SIZE + 3];  // 3 for RLP prefix bytes.
+    auto p = &buffer[1];                                // Skip RLP list prefix for now.
+    *p++ = RLP_STR_BASE + ADDRESS_SIZE;                 // Set RLP string prefix for address.
+    p = std::copy_n(sender.bytes, ADDRESS_SIZE, p);
+
+    if (sender_nonce < RLP_STR_BASE)  // Short integer encoding including 0 as empty string (0x80).
+    {
+        *p++ = sender_nonce != 0 ? static_cast<uint8_t>(sender_nonce) : RLP_STR_BASE;
+    }
+    else  // Prefixed integer encoding.
+    {
+        const auto num_nonzero_bytes = (std::bit_width(sender_nonce) + 7) / 8;
+        *p++ = static_cast<uint8_t>(RLP_STR_BASE + num_nonzero_bytes);
+        intx::be::unsafe::store(p, sender_nonce);
+        p = std::shift_left(p, p + MAX_NONCE_SIZE, MAX_NONCE_SIZE - num_nonzero_bytes);
+    }
+
+    const auto total_size = static_cast<size_t>(p - buffer);
+    buffer[0] = static_cast<uint8_t>(RLP_LIST_BASE + (total_size - 1));  // Set the RLP list prefix.
+
+    const auto base_hash = ethash::keccak256(buffer, total_size);
+    address addr;
+    std::copy_n(&base_hash.bytes[sizeof(base_hash) - ADDRESS_SIZE], ADDRESS_SIZE, addr.bytes);
+    return addr;
+}
+
+address compute_create2_address(
+    const address& sender, const bytes32& salt, bytes_view init_code) noexcept
+{
+    const auto init_code_hash = ethash::keccak256(init_code.data(), init_code.size());
+    uint8_t buffer[1 + sizeof(sender) + sizeof(salt) + sizeof(init_code_hash)];
+    static_assert(std::size(buffer) == 85);
+    auto it = std::begin(buffer);
+    *it++ = 0xff;
+    it = std::copy_n(sender.bytes, sizeof(sender), it);
+    it = std::copy_n(salt.bytes, sizeof(salt), it);
+    std::copy_n(init_code_hash.bytes, sizeof(init_code_hash), it);
+    const auto base_hash = ethash::keccak256(buffer, std::size(buffer));
+    address addr;
+    std::copy_n(&base_hash.bytes[sizeof(base_hash) - sizeof(addr)], sizeof(addr), addr.bytes);
+    return addr;
+}
+}  // namespace evmone

--- a/lib/evmone/create_address.hpp
+++ b/lib/evmone/create_address.hpp
@@ -1,0 +1,38 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <evmc/utils.h>
+
+namespace evmone
+{
+using evmc::address;
+using evmc::bytes32;
+using evmc::bytes_view;
+
+/// Computes the address of the to-be-created contract with the CREATE scheme.
+///
+/// Computes the new account address for the contract creation context of the CREATE instruction
+/// or a create transaction, as keccak256(rlp([sender, sender_nonce]))[12:].
+/// This is defined by 𝐀𝐃𝐃𝐑 in Yellow Paper, 7. Contract Creation, (88-90), the case for ζ = ∅.
+///
+/// @param sender        The address of the message sender. YP: 𝑠.
+/// @param sender_nonce  The sender's nonce before the increase. YP: 𝑛.
+/// @return              The address computed with the CREATE scheme.
+[[nodiscard]] EVMC_EXPORT address compute_create_address(
+    const address& sender, uint64_t sender_nonce) noexcept;
+
+/// Computes the address of the to-be-created contract with the CREATE2 scheme.
+///
+/// Computes the new account address for the contract creation context of the CREATE2 instruction,
+/// as keccak256(0xff ++ sender ++ salt ++ keccak256(init_code))[12:] per EIP-1014.
+///
+/// @param sender        The address of the message sender.
+/// @param salt          The salt.
+/// @param init_code     The init_code to hash (initcode or initcontainer).
+/// @return              The address computed with the CREATE2 scheme.
+[[nodiscard]] EVMC_EXPORT address compute_create2_address(
+    const address& sender, const bytes32& salt, bytes_view init_code) noexcept;
+}  // namespace evmone

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -176,56 +176,6 @@ bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcep
     return false;
 }
 
-address compute_create_address(const address& sender, uint64_t sender_nonce) noexcept
-{
-    static constexpr auto RLP_STR_BASE = 0x80;
-    static constexpr auto RLP_LIST_BASE = 0xc0;
-    static constexpr auto ADDRESS_SIZE = sizeof(sender);
-    static constexpr std::ptrdiff_t MAX_NONCE_SIZE = sizeof(sender_nonce);
-
-    uint8_t buffer[ADDRESS_SIZE + MAX_NONCE_SIZE + 3];  // 3 for RLP prefix bytes.
-    auto p = &buffer[1];                                // Skip RLP list prefix for now.
-    *p++ = RLP_STR_BASE + ADDRESS_SIZE;                 // Set RLP string prefix for address.
-    p = std::copy_n(sender.bytes, ADDRESS_SIZE, p);
-
-    if (sender_nonce < RLP_STR_BASE)  // Short integer encoding including 0 as empty string (0x80).
-    {
-        *p++ = sender_nonce != 0 ? static_cast<uint8_t>(sender_nonce) : RLP_STR_BASE;
-    }
-    else  // Prefixed integer encoding.
-    {
-        const auto num_nonzero_bytes = (std::bit_width(sender_nonce) + 7) / 8;
-        *p++ = static_cast<uint8_t>(RLP_STR_BASE + num_nonzero_bytes);
-        intx::be::unsafe::store(p, sender_nonce);
-        p = std::shift_left(p, p + MAX_NONCE_SIZE, MAX_NONCE_SIZE - num_nonzero_bytes);
-    }
-
-    const auto total_size = static_cast<size_t>(p - buffer);
-    buffer[0] = static_cast<uint8_t>(RLP_LIST_BASE + (total_size - 1));  // Set the RLP list prefix.
-
-    const auto base_hash = keccak256({buffer, total_size});
-    address addr;
-    std::copy_n(&base_hash.bytes[sizeof(base_hash) - ADDRESS_SIZE], ADDRESS_SIZE, addr.bytes);
-    return addr;
-}
-
-address compute_create2_address(
-    const address& sender, const bytes32& salt, bytes_view init_code) noexcept
-{
-    const auto init_code_hash = keccak256(init_code);
-    uint8_t buffer[1 + sizeof(sender) + sizeof(salt) + sizeof(init_code_hash)];
-    static_assert(std::size(buffer) == 85);
-    auto it = std::begin(buffer);
-    *it++ = 0xff;
-    it = std::copy_n(sender.bytes, sizeof(sender), it);
-    it = std::copy_n(salt.bytes, sizeof(salt), it);
-    std::copy_n(init_code_hash.bytes, sizeof(init_code_hash), it);
-    const auto base_hash = keccak256({buffer, std::size(buffer)});
-    address addr;
-    std::copy_n(&base_hash.bytes[sizeof(base_hash) - sizeof(addr)], sizeof(addr), addr.bytes);
-    return addr;
-}
-
 std::optional<evmc_message> Host::prepare_message(evmc_message msg) noexcept
 {
     if (msg.depth == 0 || msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -6,33 +6,12 @@
 
 #include "state.hpp"
 #include "state_view.hpp"
+#include <evmone/create_address.hpp>
 #include <optional>
 
 namespace evmone::state
 {
 using evmc::uint256be;
-
-/// Computes the address of to-be-created contract with the CREATE scheme.
-///
-/// Computes the new account address for the contract creation context of the CREATE instruction
-/// or a create transaction.
-/// This is defined by 𝐀𝐃𝐃𝐑 in Yellow Paper, 7. Contract Creation, (88-90), the case for ζ = ∅.
-///
-/// @param sender        The address of the message sender. YP: 𝑠.
-/// @param sender_nonce  The sender's nonce before the increase. YP: 𝑛.
-/// @return              The address computed with the CREATE scheme.
-[[nodiscard]] address compute_create_address(const address& sender, uint64_t sender_nonce) noexcept;
-
-/// Computes the address of to-be-created contract with the CREATE2 scheme.
-///
-/// Computes the new account address for the contract creation context of the CREATE2 instruction.
-///
-/// @param sender        The address of the message sender.
-/// @param salt          The salt.
-/// @param init_code     The init_code to hash (initcode or initcontainer).
-/// @return              The address computed with the scheme.
-[[nodiscard]] address compute_create2_address(
-    const address& sender, const bytes32& salt, bytes_view init_code) noexcept;
 
 class Host : public evmc::Host
 {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
     baseline_analysis_test.cpp
     blockchaintest_loader_test.cpp
     bytecode_test.cpp
+    create_address_test.cpp
     evm_fixture.cpp
     evm_fixture.hpp
     evm_test.cpp
@@ -57,7 +58,6 @@ target_sources(
     state_difficulty_test.cpp
     state_mpt_hash_test.cpp
     state_mpt_test.cpp
-    state_new_account_address_test.cpp
     state_precompiles_test.cpp
     state_rlp_test.cpp
     state_system_call_test.cpp

--- a/test/unittests/create_address_test.cpp
+++ b/test/unittests/create_address_test.cpp
@@ -2,16 +2,16 @@
 // Copyright 2023 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <evmone/create_address.hpp>
 #include <gtest/gtest.h>
-#include <test/state/host.hpp>
 #include <test/utils/rlp.hpp>
 
 using namespace evmc;
 using namespace evmc::literals;
 
-TEST(state_new_account_address, create_examples)
+TEST(create_address, create_examples)
 {
-    static constexpr auto addr = evmone::state::compute_create_address;
+    static constexpr auto addr = evmone::compute_create_address;
 
     static constexpr auto S0 = 0x00_address;
     EXPECT_EQ(addr(S0, 0), 0xbd770416a3345f91e4b34576cb804a576fa48eb1_address);
@@ -34,10 +34,10 @@ TEST(state_new_account_address, create_examples)
     EXPECT_EQ(beacon_roots2, 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address);
 }
 
-TEST(state_new_account_address, create_nonces)
+TEST(create_address, create_nonces)
 {
     // Explore nonce values from all ranges giving RLP encoding schemes.
-    static constexpr auto addr = evmone::state::compute_create_address;
+    static constexpr auto addr = evmone::compute_create_address;
 
     struct TestCase
     {
@@ -81,7 +81,7 @@ TEST(state_new_account_address, create_nonces)
     }
 }
 
-TEST(state_new_account_address, create_rlp)
+TEST(create_address, create_rlp)
 {
     // Compute the RLP payload for keccak256 hash producing the final CREATE address.
     // This test is to visualize what RLP inputs are reaching the final keccak256 hash.
@@ -118,9 +118,9 @@ TEST(state_new_account_address, create_rlp)
     EXPECT_EQ(rlp(S, 0xffffffffffffffff).length() / 2, 31u);
 }
 
-TEST(state_new_account_address, create2)
+TEST(create_address, create2)
 {
-    static constexpr auto addr = evmone::state::compute_create2_address;
+    static constexpr auto addr = evmone::compute_create2_address;
     static constexpr address SENDERS[] = {
         0x00_address, 0x01_address, 0x8000000000000000000000000000000000000000_address};
     static constexpr auto z0 = 0x00_bytes32;


### PR DESCRIPTION
compute_create_address() and compute_create2_address() are defined in the testing host (test/state/host.{hpp,cpp}) although they are not Host-specific, and the VM itself will need them once it computes the create address instead of the Host (#1589).

Move them to the new TU lib/evmone/create_address.{hpp,cpp} in the evmone namespace. The implementations are unchanged except the keccak256() host-utils wrapper being replaced by the direct ethash::keccak256() call. The functions are marked EVMC_EXPORT so the testing code can still reach them across the libevmone shared-library boundary.