### PR TITLE
evmc: Remove the capabilities feature

### DIFF
--- a/evmc/include/evmc/evmc.h
+++ b/evmc/include/evmc/evmc.h
@@ -45,7 +45,7 @@ enum
      *
      * @see @ref versioning
      */
-    EVMC_ABI_VERSION = 16
+    EVMC_ABI_VERSION = 17
 };
 
 
@@ -175,9 +175,6 @@ struct evmc_message
      * the evmc_message::recipient.
      * Not required when invoking evmc_execute_fn(), only when invoking evmc_call_fn().
      * Ignored if kind is ::EVMC_CREATE or ::EVMC_CREATE2.
-     *
-     * In case of ::EVMC_CAPABILITY_PRECOMPILES implementation, this fields should be inspected
-     * to identify the requested precompile.
      *
      * Defined as `c` in the Yellow Paper.
      */
@@ -1046,8 +1043,7 @@ enum evmc_revision
  * This function MAY be invoked multiple times for a single VM instance.
  *
  * @param vm         The VM instance. This argument MUST NOT be NULL.
- * @param host       The Host interface. This argument MUST NOT be NULL unless
- *                   the @p vm has the ::EVMC_CAPABILITY_PRECOMPILES capability.
+ * @param host       The Host interface. This argument MUST NOT be NULL.
  * @param context    The opaque pointer to the Host execution context.
  *                   This argument MAY be NULL. The VM MUST pass the same
  *                   pointer to the methods of the @p host interface.
@@ -1065,53 +1061,6 @@ typedef struct evmc_result (*evmc_execute_fn)(struct evmc_vm* vm,
                                               const struct evmc_message* msg,
                                               uint8_t const* code,
                                               size_t code_size);
-
-/**
- * Possible capabilities of a VM.
- */
-enum evmc_capabilities
-{
-    /**
-     * The VM is capable of executing EVM1 bytecode.
-     */
-    EVMC_CAPABILITY_EVM1 = (1u << 0),
-
-    /**
-     * The VM is capable of executing ewasm bytecode.
-     */
-    EVMC_CAPABILITY_EWASM = (1u << 1),
-
-    /**
-     * The VM is capable of executing the precompiled contracts
-     * defined for the range of code addresses.
-     *
-     * The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) specifies
-     * the range 0x000...0000 - 0x000...ffff of addresses
-     * reserved for precompiled and system contracts.
-     *
-     * This capability is **experimental** and MAY be removed without notice.
-     */
-    EVMC_CAPABILITY_PRECOMPILES = (1u << 2)
-};
-
-/**
- * Alias for unsigned integer representing a set of bit flags of EVMC capabilities.
- *
- * @see evmc_capabilities
- */
-typedef uint32_t evmc_capabilities_flagset;
-
-/**
- * Return the supported capabilities of the VM instance.
- *
- * This function MAY be invoked multiple times for a single VM instance,
- * and its value MAY be influenced by calls to evmc_vm::set_option.
- *
- * @param vm  The VM instance.
- * @return    The supported capabilities of the VM. @see evmc_capabilities.
- */
-typedef evmc_capabilities_flagset (*evmc_get_capabilities_fn)(struct evmc_vm* vm);
-
 
 /**
  * The VM instance.
@@ -1157,18 +1106,6 @@ struct evmc_vm
      * This is a mandatory method and MUST NOT be set to NULL.
      */
     evmc_execute_fn execute;
-
-    /**
-     * A method returning capabilities supported by the VM instance.
-     *
-     * The value returned MAY change when different options are set via the set_option() method.
-     *
-     * A Client SHOULD only rely on the value returned if it has queried it after
-     * it has called the set_option().
-     *
-     * This is a mandatory method and MUST NOT be set to NULL.
-     */
-    evmc_get_capabilities_fn get_capabilities;
 
     /**
      * Optional pointer to function modifying VM's options.

--- a/evmc/include/evmc/evmc.hpp
+++ b/evmc/include/evmc/evmc.hpp
@@ -687,18 +687,6 @@ public:
     /// @copydoc evmc_vm::version
     char const* version() const noexcept { return m_instance->version; }
 
-    /// Checks if the VM has the given capability.
-    bool has_capability(evmc_capabilities capability) const noexcept
-    {
-        return (get_capabilities() & static_cast<evmc_capabilities_flagset>(capability)) != 0;
-    }
-
-    /// @copydoc evmc_vm::get_capabilities
-    evmc_capabilities_flagset get_capabilities() const noexcept
-    {
-        return m_instance->get_capabilities(m_instance);
-    }
-
     /// @copydoc evmc_set_option()
     evmc_set_option_result set_option(const char name[], const char value[]) noexcept
     {
@@ -724,23 +712,6 @@ public:
                    size_t code_size) noexcept
     {
         return execute(Host::get_interface(), host.to_context(), rev, msg, code, code_size);
-    }
-
-    /// Executes code without the Host context.
-    ///
-    /// The same as
-    /// execute(const evmc_host_interface&, evmc_host_context*, evmc_revision,
-    ///         const evmc_message&, const uint8_t*, size_t),
-    /// but without providing the Host context and interface.
-    /// This method is for experimental precompiles support where execution is
-    /// guaranteed not to require any Host access.
-    Result execute(evmc_revision rev,
-                   const evmc_message& msg,
-                   const uint8_t* code,
-                   size_t code_size) noexcept
-    {
-        return Result{
-            m_instance->execute(m_instance, nullptr, nullptr, rev, &msg, code, code_size)};
     }
 
     /// Returns the pointer to C EVMC struct representing the VM.

--- a/evmc/include/evmc/helpers.h
+++ b/evmc/include/evmc/helpers.h
@@ -51,16 +51,6 @@ static inline const char* evmc_vm_version(struct evmc_vm* vm)
 }
 
 /**
- * Checks if the VM has the given capability.
- *
- * @see evmc_get_capabilities_fn
- */
-static inline bool evmc_vm_has_capability(struct evmc_vm* vm, enum evmc_capabilities capability)
-{
-    return (vm->get_capabilities(vm) & (evmc_capabilities_flagset)capability) != 0;
-}
-
-/**
  * Destroys the VM instance.
  *
  * @see evmc_destroy_fn

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -22,11 +22,6 @@ void destroy(evmc_vm* vm) noexcept
     delete static_cast<VM*>(vm);
 }
 
-constexpr evmc_capabilities_flagset get_capabilities(evmc_vm* /*vm*/) noexcept
-{
-    return EVMC_CAPABILITY_EVM1;
-}
-
 evmc_set_option_result set_option(evmc_vm* c_vm, char const* c_name, char const* c_value) noexcept
 {
     const auto name = (c_name != nullptr) ? std::string_view{c_name} : std::string_view{};
@@ -78,7 +73,6 @@ VM::VM() noexcept
         PROJECT_VERSION,
         evmone::destroy,
         evmone::baseline::execute,
-        evmone::get_capabilities,
         evmone::set_option,
     }
 {

--- a/test/unittests/evmone_test.cpp
+++ b/test/unittests/evmone_test.cpp
@@ -15,13 +15,6 @@ TEST(evmone, info)
     EXPECT_TRUE(vm.is_abi_compatible());
 }
 
-TEST(evmone, capabilities)
-{
-    auto vm = evmc_create_evmone();
-    EXPECT_EQ(vm->get_capabilities(vm), evmc_capabilities_flagset{EVMC_CAPABILITY_EVM1});
-    vm->destroy(vm);
-}
-
 TEST(evmone, set_option_invalid)
 {
     auto vm = evmc_create_evmone();


### PR DESCRIPTION
The EVMC capabilities are not really used: eWasm is gone, precompiles-only didn't take off. As we have EVMC in-house now, drop capabilities feature. Also bump EVMC_ABI_VERSION to 17.