### PR TITLE
state: Store storage-slot pointers in journal instead of keys

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -62,7 +62,7 @@ evmc_storage_status Host::set_storage(
             status = EVMC_STORAGE_MODIFIED_RESTORED;  // X → Y → X
     }
 
-    m_state.journal_storage_change(addr, key, storage_slot);
+    m_state.journal_storage_change(storage_slot);
     storage_slot.current = value;  // Update current value.
     return status;
 }
@@ -387,7 +387,7 @@ evmc_access_status Host::access_storage(const address& addr, const bytes32& key)
     auto& storage_slot = m_state.get_storage(addr, key);
     if (storage_slot.access_status == EVMC_ACCESS_WARM)
         return EVMC_ACCESS_WARM;  // Nothing changes, skip journaling.
-    m_state.journal_storage_change(addr, key, storage_slot);
+    m_state.journal_storage_change(storage_slot);
     storage_slot.access_status = EVMC_ACCESS_WARM;
     return EVMC_ACCESS_COLD;
 }
@@ -404,7 +404,7 @@ void Host::set_transient_storage(
     const address& addr, const bytes32& key, const bytes32& value) noexcept
 {
     auto& slot = m_state.get(addr).transient_storage[key];
-    m_state.journal_transient_storage_change(addr, key, slot);
+    m_state.journal_transient_storage_change(slot);
     slot = value;
 }
 }  // namespace evmone::state

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -345,16 +345,14 @@ void State::journal_balance_change(const address& addr, const intx::uint256& pre
     m_journal.emplace_back(JournalBalanceChange{{addr}, prev_balance});
 }
 
-void State::journal_storage_change(
-    const address& addr, const bytes32& key, const StorageValue& value)
+void State::journal_storage_change(StorageValue& slot)
 {
-    m_journal.emplace_back(JournalStorageChange{{addr}, key, value.current, value.access_status});
+    m_journal.emplace_back(JournalStorageChange{&slot, slot.current, slot.access_status});
 }
 
-void State::journal_transient_storage_change(
-    const address& addr, const bytes32& key, const bytes32& value)
+void State::journal_transient_storage_change(bytes32& slot)
 {
-    m_journal.emplace_back(JournalTransientStorageChange{{addr}, key, value});
+    m_journal.emplace_back(JournalTransientStorageChange{&slot, slot});
 }
 
 void State::journal_bump_nonce(const address& addr)
@@ -421,14 +419,12 @@ void State::rollback(size_t checkpoint)
                 }
                 else if constexpr (std::is_same_v<T, JournalStorageChange>)
                 {
-                    auto& s = get(e.addr).storage.find(e.key)->second;
-                    s.current = e.prev_value;
-                    s.access_status = e.prev_access_status;
+                    e.slot->current = e.prev_value;
+                    e.slot->access_status = e.prev_access_status;
                 }
                 else if constexpr (std::is_same_v<T, JournalTransientStorageChange>)
                 {
-                    auto& s = get(e.addr).transient_storage.find(e.key)->second;
-                    s = e.prev_value;
+                    *e.slot = e.prev_value;
                 }
                 else if constexpr (std::is_same_v<T, JournalBalanceChange>)
                 {

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -32,16 +32,16 @@ class State
     struct JournalTouched : JournalBase
     {};
 
-    struct JournalStorageChange : JournalBase
+    struct JournalStorageChange
     {
-        bytes32 key;
+        StorageValue* slot = nullptr;  ///< Storage slot in a node-based container (stable refs).
         bytes32 prev_value;
         evmc_access_status prev_access_status;
     };
 
-    struct JournalTransientStorageChange : JournalBase
+    struct JournalTransientStorageChange
     {
-        bytes32 key;
+        bytes32* slot = nullptr;  ///< T-storage slot in a node-based container (stable refs).
         bytes32 prev_value;
     };
 
@@ -113,10 +113,9 @@ public:
 
     void journal_balance_change(const address& addr, const intx::uint256& prev_balance);
 
-    void journal_storage_change(const address& addr, const bytes32& key, const StorageValue& value);
+    void journal_storage_change(StorageValue& slot);
 
-    void journal_transient_storage_change(
-        const address& addr, const bytes32& key, const bytes32& value);
+    void journal_transient_storage_change(bytes32& slot);
 
     void journal_bump_nonce(const address& addr);
 


### PR DESCRIPTION
We currently use a node-base container (std::unordered_map) which
guarantees stability of the pointer/reference to an entry.
Use this to simplify and increase efficiency of the storage/t-storage
journaling. This avoids two map lookups during a revert, but also
makes the entry significantly smaller and cheaper to create.