### PR TITLE
state: Merge account-flag journal entries into one

### DIFF
--- a/test/state/account.hpp
+++ b/test/state/account.hpp
@@ -74,9 +74,15 @@ struct Account
     bool erase_if_empty = false;
 
     /// The account has been created in the current transaction.
+    ///
+    /// FIXME: Not reverted on CREATE rollback; a leaked value suppresses the
+    /// EIP-161 touch-delete of the now-empty account (state-root divergence).
     bool just_created = false;
 
-    // This account's code has been modified.
+    /// This account's code has been modified.
+    ///
+    /// FIXME: Not reverted on CREATE rollback; a leaked value adds a
+    /// false-positive code entry to the state diff.
     bool code_changed = false;
 
     /// If the account has non-empty initial storage (when accessing the cold account).

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -169,7 +169,7 @@ bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcep
     // Mark the destruction if not done already.
     if (!acc.destructed)
     {
-        m_state.journal_destruct(addr);
+        m_state.journal_account_flags(addr, acc);
         acc.destructed = true;
         return true;
     }
@@ -377,7 +377,7 @@ evmc_access_status Host::access_account(const address& addr) noexcept
     if (acc.access_status == EVMC_ACCESS_WARM || is_precompile(m_rev, addr))
         return EVMC_ACCESS_WARM;
 
-    m_state.journal_access_account(addr);
+    m_state.journal_account_flags(addr, acc);
     acc.access_status = EVMC_ACCESS_WARM;
     return EVMC_ACCESS_COLD;
 }

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -321,8 +321,8 @@ Account& State::touch(const address& addr)
     auto& acc = get_or_insert(addr, {.erase_if_empty = true});
     if (!acc.erase_if_empty && acc.is_empty())
     {
+        journal_account_flags(addr, acc);
         acc.erase_if_empty = true;
-        m_journal.emplace_back(JournalTouched{addr});
     }
     return acc;
 }
@@ -365,14 +365,10 @@ void State::journal_create(const address& addr, bool existed)
     m_journal.emplace_back(JournalCreate{{addr}, existed});
 }
 
-void State::journal_destruct(const address& addr)
+void State::journal_account_flags(const address& addr, const Account& acc)
 {
-    m_journal.emplace_back(JournalDestruct{addr});
-}
-
-void State::journal_access_account(const address& addr)
-{
-    m_journal.emplace_back(JournalAccessAccount{addr});
+    m_journal.emplace_back(
+        JournalAccountFlags{{addr}, acc.access_status, acc.destructed, acc.erase_if_empty});
 }
 
 void State::rollback(size_t checkpoint)
@@ -386,17 +382,12 @@ void State::rollback(size_t checkpoint)
                 {
                     get(e.addr).nonce -= 1;
                 }
-                else if constexpr (std::is_same_v<T, JournalTouched>)
+                else if constexpr (std::is_same_v<T, JournalAccountFlags>)
                 {
-                    get(e.addr).erase_if_empty = false;
-                }
-                else if constexpr (std::is_same_v<T, JournalDestruct>)
-                {
-                    get(e.addr).destructed = false;
-                }
-                else if constexpr (std::is_same_v<T, JournalAccessAccount>)
-                {
-                    get(e.addr).access_status = EVMC_ACCESS_COLD;
+                    auto& a = get(e.addr);
+                    a.access_status = e.access_status;
+                    a.destructed = e.destructed;
+                    a.erase_if_empty = e.erase_if_empty;
                 }
                 else if constexpr (std::is_same_v<T, JournalCreate>)
                 {

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -29,8 +29,12 @@ class State
         intx::uint256 prev_balance;
     };
 
-    struct JournalTouched : JournalBase
-    {};
+    struct JournalAccountFlags : JournalBase
+    {
+        evmc_access_status access_status;
+        bool destructed;
+        bool erase_if_empty;
+    };
 
     struct JournalStorageChange
     {
@@ -53,15 +57,8 @@ class State
         bool existed;
     };
 
-    struct JournalDestruct : JournalBase
-    {};
-
-    struct JournalAccessAccount : JournalBase
-    {};
-
-    using JournalEntry =
-        std::variant<JournalBalanceChange, JournalTouched, JournalStorageChange, JournalNonceBump,
-            JournalCreate, JournalTransientStorageChange, JournalDestruct, JournalAccessAccount>;
+    using JournalEntry = std::variant<JournalBalanceChange, JournalAccountFlags,
+        JournalStorageChange, JournalNonceBump, JournalCreate, JournalTransientStorageChange>;
 
     /// The read-only view of the initial (cold) state.
     const StateView& m_initial;
@@ -121,9 +118,7 @@ public:
 
     void journal_create(const address& addr, bool existed);
 
-    void journal_destruct(const address& addr);
-
-    void journal_access_account(const address& addr);
+    void journal_account_flags(const address& addr, const Account& acc);
 
     /// @}
 };


### PR DESCRIPTION
Three journal shapes each hand-reverted one account flag: JournalTouched (erase_if_empty), JournalDestruct (destructed), and JournalAccessAccount (access_status). Each carried only an address and, on rollback, reset its one flag to a hardcoded default -- three near-duplicate single-field alternatives in the JournalEntry variant.

Replace them with one JournalAccountFlags entry: a snapshot of an account's {erase_if_empty, destructed, access_status} taken by journal_account_flags() before one of them changes (touch / selfdestruct / access), which rollback restores wholesale. This is an exact LIFO undo log -- entries above this one are reverted first, so restoring a flag this entry did not change is a no-op (it already holds its as-of-this-entry value), and the changed flag's snapshot value equals the old per-entry constant: touch journals only when erase_if_empty is false, selfdestruct only when destructed is false, access only when access_status is COLD. JournalCreate is untouched. Variant: 8 -> 6 alternatives.