### PR TITLE
state: Limit the 0x03 touch-quirk lookup to [Spurious Dragon, Paris)

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -315,17 +315,22 @@ evmc::Result Host::call(const evmc_message& msg) noexcept
 
     if (result.status_code != EVMC_SUCCESS)
     {
-        static constexpr auto addr_03 = 0x03_address;
-        auto* const acc_03 = m_state.find(addr_03);
-        const auto is_03_touched = acc_03 != nullptr && acc_03->erase_if_empty;
+        // The 0x03 (RIPEMD-160) touch quirk: a touch on this address is
+        // never reverted. It only matters when the account is empty, so gate it by rev range.
+        static constexpr auto ADDR_03 = 0x03_address;
+        bool is_03_touched = false;
+        if (m_rev < EVMC_PARIS && m_rev >= EVMC_SPURIOUS_DRAGON) [[unlikely]]
+        {
+            const auto* const acc_03 = m_state.find(ADDR_03);
+            is_03_touched = acc_03 != nullptr && acc_03->erase_if_empty;
+        }
 
         // Revert.
         m_state.rollback(state_checkpoint);
         m_logs.resize(logs_checkpoint);
 
-        // The 0x03 quirk: the touch on this address is never reverted.
-        if (is_03_touched && m_rev >= EVMC_SPURIOUS_DRAGON)
-            m_state.touch(addr_03);
+        if (is_03_touched) [[unlikely]]
+            m_state.touch(ADDR_03);
     }
     return result;
 }

--- a/test/unittests/state_transition_touch_test.cpp
+++ b/test/unittests/state_transition_touch_test.cpp
@@ -225,3 +225,32 @@ TEST_F(state_transition, touch_revert_selfdestruct_to_nonexistient_tw)
     expect.post[DESTRUCTOR].exists = true;
     expect.post[BENEFICIARY].exists = false;
 }
+
+TEST_F(state_transition, touch_revert_ripemd_frontier)
+{
+    // Before Spurious Dragon the 0x03 quirk is off: the failed call's touch of 0x03 is reverted and
+    // 0x03 does not linger. Guards the >= EVMC_SPURIOUS_DRAGON lower bound.
+    rev = EVMC_FRONTIER;
+    block.base_fee = 0;
+    tx.type = Transaction::Type::legacy;
+    tx.to = To;
+    pre[*tx.to] = {.code = call(0x03_address)};  // gas = 0 -> RIPEMD out-of-gas -> failed call
+
+    expect.post[*tx.to].exists = true;
+    expect.post[0x03_address].exists = false;
+}
+
+TEST_F(state_transition, touch_revert_ripemd_london)
+{
+    // In range the quirk keeps the touch, so a pre-existing empty 0x03 leaf is swept by EIP-161
+    // even though the touching call reverted. Guards that the quirk stays active up to the Merge.
+    rev = EVMC_LONDON;
+    block.base_fee = 0;
+    tx.type = Transaction::Type::legacy;
+    tx.to = To;
+    pre[*tx.to] = {.code = call(0x03_address)};  // gas = 0 -> RIPEMD out-of-gas -> failed call
+    pre[0x03_address] = {};                      // pre-existing empty leaf
+
+    expect.post[*tx.to].exists = true;
+    expect.post[0x03_address].exists = false;  // deleted by the retained touch
+}


### PR DESCRIPTION
Handling 0x03 quirk only matters when the account is empty. Paris prevents empty accounts in a pre-state so the quirk condition cannot happen. Gate handling by pre-Paris: avoids state lookup in modern forks.