### PR TITLE
state: Don't create state entries for precompiles in access_account

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -385,13 +385,21 @@ evmc_access_status Host::access_account(const address& addr) noexcept
     if (m_rev < EVMC_BERLIN)
         return EVMC_ACCESS_COLD;  // Ignore before Berlin.
 
-    auto& acc = m_state.get_or_insert(addr, {.erase_if_empty = true});
+    auto* acc = m_state.find(addr);
 
-    if (acc.access_status == EVMC_ACCESS_WARM || is_precompile(m_rev, addr))
+    if (acc != nullptr && acc->access_status == EVMC_ACCESS_WARM)
         return EVMC_ACCESS_WARM;
 
-    m_state.journal_account_flags(addr, acc);
-    acc.access_status = EVMC_ACCESS_WARM;
+    if (is_precompile(m_rev, addr))  // Precompiles are always warm. Don't insert to state.
+        return EVMC_ACCESS_WARM;
+
+    // TODO: On a modified-set miss the account is looked up twice. This can be improved with
+    //   a try_emplace-like API, but the miss happens only in ~39% of the calls on Mainnet.
+    if (acc == nullptr)
+        acc = &m_state.insert(addr, {.erase_if_empty = true});
+
+    m_state.journal_account_flags(addr, *acc);
+    acc->access_status = EVMC_ACCESS_WARM;
     return EVMC_ACCESS_COLD;
 }
 

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -5,6 +5,7 @@
 #include "state.hpp"
 #include "../utils/stdx/utility.hpp"
 #include "host.hpp"
+#include "precompiles.hpp"
 #include "state_view.hpp"
 #include <evmone/constants.hpp>
 #include <evmone/delegation.hpp>
@@ -630,6 +631,8 @@ TransactionReceipt transition(const StateView& state_view, const BlockInfo& bloc
     for (const auto& [a, storage_keys] : tx.access_list)
     {
         host.access_account(a);
+        if (is_precompile(rev, a))  // Precompile storage is never accessed.
+            continue;
         for (const auto& key : storage_keys)
             state.get_storage(a, key).access_status = EVMC_ACCESS_WARM;
     }

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -247,6 +247,17 @@ TEST_F(state_transition, access_list_cost_osaka_unchanged)
     expect.gas_used = 25300;
 }
 
+TEST_F(state_transition, access_list_precompile_with_storage_keys)
+{
+    // An access list may name a precompile with storage keys (EIP-2930). Intrinsic gas is charged
+    // for both, though access_account() creates no state entry and the key warming is skipped.
+    rev = EVMC_OSAKA;
+    tx.to = To;
+    tx.access_list = {{0x01_address, {0x01_bytes32}}};
+    // intrinsic = 21000 + 2400 + 1900 = 25300
+    expect.gas_used = 25300;
+}
+
 TEST_F(state_transition, access_list_floor_amsterdam)
 {
     // EIP-7981: access-list bytes count toward the floor.


### PR DESCRIPTION
Don't insert new nodes to State just to mark a precompile as warm
(they are warm by default).

We also split access_account() into find-precompile-insert.
This is double lookup in the worst case but overall performs better
on Mainnet.

We also ignore storage entries in access list targeting precompiles.