### PR TITLE
state: Dedup the recipient lookup in execute_message

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -181,6 +181,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     assert(msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2);
     assert(msg.recipient != address{});  // Must be computed already.
 
+    // TODO: find()+insert() probes m_modified twice for a new recipient.
     auto* new_acc = m_state.find(msg.recipient);
     const bool new_acc_exists = new_acc != nullptr;
     if (!new_acc_exists)
@@ -255,21 +256,22 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
 
     if (msg.kind == EVMC_CALL)
     {
-        const auto exists = m_state.find(msg.recipient) != nullptr;
-        if (!exists)
-            m_state.journal_create(msg.recipient, exists);
-    }
+        auto* recipient_acc = m_state.find(msg.recipient);
+        if (recipient_acc == nullptr)
+            m_state.journal_create(msg.recipient, false);
+        // TODO: Both branches will insert new account so better to do it in common path.
 
-    if (msg.kind == EVMC_CALL)
-    {
         if (evmc::is_zero(msg.value))
+        {
             m_state.touch(msg.recipient);
+        }
         else
         {
             // We skip touching if we send value, because account cannot end up empty.
             // It will either have value, or code that transfers this value out, or will be
             // selfdestructed anyway.
-            auto& dst_acc = m_state.get_or_insert(msg.recipient);
+            if (recipient_acc == nullptr)
+                recipient_acc = &m_state.insert(msg.recipient);
 
             // Transfer value: sender → recipient.
             // The sender's balance is already checked therefore the sender account must exist.
@@ -277,9 +279,9 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
             auto& sender_acc = m_state.get(msg.sender);
             assert(sender_acc.balance >= value);
             m_state.journal_balance_change(msg.sender, sender_acc.balance);
-            m_state.journal_balance_change(msg.recipient, dst_acc.balance);
+            m_state.journal_balance_change(msg.recipient, recipient_acc->balance);
             sender_acc.balance -= value;
-            dst_acc.balance += value;
+            recipient_acc->balance += value;
 
             if (m_rev >= EVMC_AMSTERDAM)
                 emit_transfer_log(m_logs, msg.sender, msg.recipient, value);


### PR DESCRIPTION
A value-transferring CALL looked the recipient up twice. Clean up this piece of code and lookup the account once.