### PR TITLE
test: Regression-test top-level tx execution at sender nonce 2^64-2

### DIFF
--- a/test/unittests/state_transition_eip7702_test.cpp
+++ b/test/unittests/state_transition_eip7702_test.cpp
@@ -4,6 +4,7 @@
 
 #include "../utils/bytecode.hpp"
 #include "state_transition.hpp"
+#include <evmone/constants.hpp>
 
 using namespace evmc::literals;
 using namespace evmone::test;
@@ -42,6 +43,28 @@ TEST_F(state_transition, eip7702_set_code_transaction_authority_is_sender)
     expect.post[Sender].code = bytes{0xef, 0x01, 0x00} + hex(delegate);
     expect.post[To].exists = true;
     expect.post[delegate].exists = true;
+}
+
+TEST_F(state_transition, eip7702_set_code_self_authorization_reaching_nonce_max)
+{
+    // A self-authorization that bumps the sender nonce to MAX_NONCE (2^64-1) is valid: only a
+    // tx nonce == MAX_NONCE is rejected by EIP-2681, not reaching it during execution.
+    rev = EVMC_PRAGUE;
+
+    constexpr auto delegate = 0xde1e_address;
+
+    // The tx bumps the sender nonce 2^64-3 -> 2^64-2, then the self-authorization -> 2^64-1.
+    pre[Sender].nonce = MAX_NONCE - 2;
+    tx.nonce = MAX_NONCE - 2;
+    tx.to = To;
+    tx.type = Transaction::Type::set_code;
+    tx.authorization_list = {{.addr = delegate, .nonce = MAX_NONCE - 1, .signer = Sender}};
+    pre[To] = {.code = sstore(0, 1)};
+
+    expect.status = EVMC_SUCCESS;
+    expect.post[Sender].nonce = MAX_NONCE;
+    expect.post[Sender].code = bytes{0xef, 0x01, 0x00} + hex(delegate);
+    expect.post[To].storage[0x00_bytes32] = 0x01_bytes32;  // Proves the top-level call executed.
 }
 
 TEST_F(state_transition, eip7702_set_code_transaction_authority_is_to)

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "state_transition.hpp"
+#include <evmone/constants.hpp>
 #include <test/utils/bytecode.hpp>
 
 using namespace evmc::literals;
@@ -267,6 +268,30 @@ TEST_F(state_transition, invalid_access_list_amsterdam_gas_limit_below_floor)
     tx.access_list = {{To, {}}};
     tx.gas_limit = 28679;
     expect.tx_error = INTRINSIC_GAS_TOO_LOW;
+}
+
+TEST_F(state_transition, tx_at_sender_nonce_max_minus_1_call)
+{
+    // Regression: a top-level CALL tx must execute normally when the sender nonce is MAX_NONCE - 1
+    // (2^64-2). Only nonce == MAX_NONCE (2^64-1) is invalid per EIP-2681.
+    tx.to = To;
+    pre[Sender].nonce = MAX_NONCE - 1;
+    tx.nonce = MAX_NONCE - 1;
+
+    expect.status = EVMC_SUCCESS;
+    expect.post.at(Sender).nonce = MAX_NONCE;
+}
+
+TEST_F(state_transition, tx_at_sender_nonce_max_minus_1_create)
+{
+    // Regression: a top-level CREATE tx must execute normally when the sender nonce is
+    // MAX_NONCE - 1 (2^64-2). Only nonce == MAX_NONCE (2^64-1) is invalid per EIP-2681.
+    pre[Sender].nonce = MAX_NONCE - 1;
+    tx.nonce = MAX_NONCE - 1;
+
+    expect.status = EVMC_SUCCESS;
+    expect.post.at(Sender).nonce = MAX_NONCE;
+    expect.post[compute_create_address(Sender, MAX_NONCE - 1)] = {.nonce = 1, .code = bytes{}};
 }
 
 TEST_F(state_transition, tx_emits_log)


### PR DESCRIPTION
Closes #1495 (I think — see note below).

A top-level CALL or CREATE transaction from a sender at nonce `2^64-2` must
execute normally; only `nonce == 2^64-1` is invalid per EIP-2681. #1495
reported that evmone incorrectly aborted such transactions as a "light
failure" after bumping the sender's nonce.

I could not reproduce the bug on current `master`. It looks like it was
fixed incidentally by #1589 ("Compute the create address in the VM"),
which moved the EIP-2681 nonce check out of the path shared by all
depth-0 messages and into `create_impl`, which only runs for nested,
bytecode-triggered `CREATE`/`CREATE2`. That PR doesn't mention #1495 or
EIP-2681, so this may be worth double-checking on your end.

Since there was no test covering this scenario, I added two (`CALL` and
`CREATE`, both at sender nonce `2^64-2`) so a future refactor can't
silently reintroduce the bug.

Tested with `ctest -R "evmone/unittests"`: 1133/1133 passed.
