### PR TITLE
state: Split journal_create's `existed` bool into two named functions

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -131,7 +131,7 @@ size_t Host::copy_code(const address& addr, size_t code_offset, uint8_t* buffer_
 bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcept
 {
     if (m_state.find(beneficiary) == nullptr)
-        m_state.journal_create(beneficiary, false);
+        m_state.journal_new_account(beneficiary);
     auto& acc = m_state.get(addr);
     const auto balance = acc.balance;
     auto& beneficiary_acc = m_state.touch(beneficiary);
@@ -183,12 +183,17 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
 
     // TODO: find()+insert() probes m_modified twice for a new recipient.
     auto* new_acc = m_state.find(msg.recipient);
-    const bool new_acc_exists = new_acc != nullptr;
-    if (!new_acc_exists)
+    if (new_acc == nullptr)
+    {
         new_acc = &m_state.insert(msg.recipient);
-    else if (is_create_collision(*new_acc))
-        return evmc::Result{EVMC_FAILURE};  // TODO: Add EVMC errors for creation failures.
-    m_state.journal_create(msg.recipient, new_acc_exists);
+        m_state.journal_new_account(msg.recipient);
+    }
+    else
+    {
+        if (is_create_collision(*new_acc))
+            return evmc::Result{EVMC_FAILURE};  // TODO: Add EVMC errors for creation failures.
+        m_state.journal_create(msg.recipient);
+    }
 
     assert(new_acc != nullptr);
     assert(new_acc->nonce == 0);
@@ -258,7 +263,7 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
     {
         auto* recipient_acc = m_state.find(msg.recipient);
         if (recipient_acc == nullptr)
-            m_state.journal_create(msg.recipient, false);
+            m_state.journal_new_account(msg.recipient);
         // TODO: Both branches will insert new account so better to do it in common path.
 
         if (evmc::is_zero(msg.value))

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -364,9 +364,14 @@ void State::journal_bump_nonce(const address& addr)
     m_journal.emplace_back(JournalNonceBump{addr});
 }
 
-void State::journal_create(const address& addr, bool existed)
+void State::journal_create(const address& addr)
 {
-    m_journal.emplace_back(JournalCreate{{addr}, existed});
+    m_journal.emplace_back(JournalCreate{{addr}, true});
+}
+
+void State::journal_new_account(const address& addr)
+{
+    m_journal.emplace_back(JournalCreate{{addr}, false});
 }
 
 void State::journal_account_flags(const address& addr, const Account& acc)

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -116,7 +116,11 @@ public:
 
     void journal_bump_nonce(const address& addr);
 
-    void journal_create(const address& addr, bool existed);
+    /// Journals a create over a pre-existing account; revert resets its nonce and code.
+    void journal_create(const address& addr);
+
+    /// Journals a new-account creation; revert erases the account.
+    void journal_new_account(const address& addr);
 
     void journal_account_flags(const address& addr, const Account& acc);
 


### PR DESCRIPTION
journal_create(addr, existed) selected between two unrelated reverts via a bool: for a create over a pre-existing account it resets nonce/code; for a new account it erases the account. Two of the three call sites (selfdestruct, the CALL path) passed a compile-time-constant false, so the new-account intent was hidden behind a dispatch flag, and create() carried a `new_acc_exists` local only to feed it.

Split into journal_create(addr) and journal_new_account(addr); each emits the same JournalCreate entry it always did (existed = true / false respectively), so entry types and rollback are unchanged. selfdestruct and the CALL path call journal_new_account() directly; create() folds the choice into its existing find/insert branch and drops the local.