### PR TITLE
test: Take the state test transaction from its encoding

### DIFF
--- a/test/state/errors.hpp
+++ b/test/state/errors.hpp
@@ -32,6 +32,7 @@ enum ErrorCode : int  // NOLINT(*-use-enum-class)
     EMPTY_AUTHORIZATION_LIST,
     MAX_GAS_LIMIT_EXCEEDED,
     INVALID_CHAIN_ID,
+    INVALID_ENCODING,
     UNKNOWN_ERROR,
 
     // Block-level validation.
@@ -103,6 +104,8 @@ inline const std::error_category& evmone_category() noexcept
                 return "max gas limit exceeded";
             case INVALID_CHAIN_ID:
                 return "invalid transaction chain id";
+            case INVALID_ENCODING:
+                return "invalid transaction encoding";
             case UNKNOWN_ERROR:
                 return "Unknown error";
             case INCORRECT_BLOCK_FORMAT:

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -24,12 +24,24 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             //     continue;
 
             const auto& expected = cases[case_index];
-            const auto tx = test.multi_tx.get(expected.indexes);
             auto state = test.pre_state;
             const auto blob_params = get_blob_params(rev, test.blob_schedule);
 
-            const auto res = transition(state, block, test.block_hashes, tx, rev, vm,
-                block.gas_limit, static_cast<int64_t>(state::max_blob_gas_per_block(blob_params)));
+            // Decode transaction from txbytes if available.
+            const auto template_tx = test.multi_tx.get(expected.indexes);
+            auto tx = std::optional{template_tx};
+            if (expected.txbytes.has_value())
+            {
+                tx = state::decode_transaction(*expected.txbytes);
+                if (tx.has_value())
+                    tx->sender = template_tx.sender;  // No recovery yet, take sender from JSON.
+            }
+
+            const auto res =
+                tx.has_value() ?
+                    transition(state, block, test.block_hashes, *tx, rev, vm, block.gas_limit,
+                        static_cast<int64_t>(state::max_blob_gas_per_block(blob_params))) :
+                    make_error_code(state::INVALID_ENCODING);
 
             if (holds_alternative<state::TransactionReceipt>(res))
             {

--- a/test/utils/statetest.hpp
+++ b/test/utils/statetest.hpp
@@ -51,6 +51,9 @@ struct StateTransitionTest
             hash256 state_hash;
             hash256 logs_hash = EmptyListHash;
             bool exception = false;
+
+            /// The full encoded transaction for this case. Not always available.
+            std::optional<bytes> txbytes;
         };
 
         evmc_revision rev;

--- a/test/utils/statetest_loader.cpp
+++ b/test/utils/statetest_loader.cpp
@@ -494,6 +494,9 @@ static void from_json(const json::json& j, StateTransitionTest::Case::Expectatio
     o.state_hash = from_json<hash256>(j.at("hash"));
     o.logs_hash = from_json<hash256>(j.at("logs"));
     o.exception = j.contains("expectException");
+    // Not load_if_exists(): it maps an absent key to bytes{}, which engages the optional.
+    if (const auto it = j.find("txbytes"); it != j.end())
+        o.txbytes = from_json<bytes>(*it);
 }
 
 static void from_json(const json::json& j_t, StateTransitionTest& o)


### PR DESCRIPTION
Load test transaction from its encoding in `"txbytes"` instead of trusting the decomposed JSON variant.
This detected some additional expect decoding failures in tests.
We still lack sender address recovery from signatures, so take it as previously from JSON `"sender"`.