### PR TITLE
state: Recover sender address from transaction signature

### DIFF
--- a/test/integration/statetest/CMakeLists.txt
+++ b/test/integration/statetest/CMakeLists.txt
@@ -117,6 +117,24 @@ set_tests_properties(
 )
 
 add_test(
+    NAME ${PREFIX}/tx_invalid_signature
+    COMMAND evmone-statetest ${TESTS_TX}/invalid_signature.json
+)
+set_tests_properties(
+    ${PREFIX}/tx_invalid_signature PROPERTIES
+    PASS_REGULAR_EXPRESSION "unexpected invalid transaction: invalid transaction signature"
+)
+
+add_test(
+    NAME ${PREFIX}/tx_invalid_encoding
+    COMMAND evmone-statetest ${TESTS_TX}/invalid_encoding.json
+)
+set_tests_properties(
+    ${PREFIX}/tx_invalid_encoding PROPERTIES
+    PASS_REGULAR_EXPRESSION "unexpected invalid transaction: invalid transaction encoding"
+)
+
+add_test(
     NAME ${PREFIX}/filter
     COMMAND evmone-statetest ${TESTS_FILTER}/one_failing_of_two.json -k passing_test_case
 )

--- a/test/integration/statetest/tx/invalid_encoding.json
+++ b/test/integration/statetest/tx/invalid_encoding.json
@@ -1,0 +1,43 @@
+{
+  "invalid_encoding": {
+    "env": {
+      "currentBaseFee": "0x0a",
+      "currentCoinbase": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x020000",
+      "currentGasLimit": "0xff112233445566",
+      "currentNumber": "0x01",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+      "currentTimestamp": "0x03e8"
+    },
+    "post": {
+      "Shanghai": [
+        {
+          "hash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "txbytes": "0xc0"
+        }
+      ]
+    },
+    "pre": {},
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x5208"
+      ],
+      "gasPrice": "0x0a",
+      "nonce": "0x00",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "to": "",
+      "value": [
+        "0x00"
+      ]
+    }
+  }
+}

--- a/test/integration/statetest/tx/invalid_encoding.json
+++ b/test/integration/statetest/tx/invalid_encoding.json
@@ -1,0 +1,43 @@
+{
+  "invalid_encoding": {
+    "env": {
+      "currentBaseFee": "0x0a",
+      "currentCoinbase": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x020000",
+      "currentGasLimit": "0xff112233445566",
+      "currentNumber": "0x01",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+      "currentTimestamp": "0x03e8"
+    },
+    "post": {
+      "Shanghai": [
+        {
+          "hash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "txbytes": "0xc0"
+        }
+      ]
+    },
+    "pre": {},
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x00"
+      ],
+      "gasPrice": "0x0a",
+      "nonce": "0x00",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "to": "0x00",
+      "value": [
+        "0x00"
+      ]
+    }
+  }
+}

--- a/test/integration/statetest/tx/invalid_signature.json
+++ b/test/integration/statetest/tx/invalid_signature.json
@@ -1,0 +1,43 @@
+{
+  "invalid_signature": {
+    "env": {
+      "currentBaseFee": "0x0a",
+      "currentCoinbase": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x020000",
+      "currentGasLimit": "0xff112233445566",
+      "currentNumber": "0x01",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+      "currentTimestamp": "0x03e8"
+    },
+    "post": {
+      "Shanghai": [
+        {
+          "hash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "txbytes": "0xeb800a8252088080801b01a0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
+        }
+      ]
+    },
+    "pre": {},
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x5208"
+      ],
+      "gasPrice": "0x0a",
+      "nonce": "0x00",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "to": "",
+      "value": [
+        "0x00"
+      ]
+    }
+  }
+}

--- a/test/integration/statetest/tx/invalid_signature.json
+++ b/test/integration/statetest/tx/invalid_signature.json
@@ -1,0 +1,43 @@
+{
+  "invalid_signature": {
+    "env": {
+      "currentBaseFee": "0x0a",
+      "currentCoinbase": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x020000",
+      "currentGasLimit": "0xff112233445566",
+      "currentNumber": "0x01",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+      "currentTimestamp": "0x03e8"
+    },
+    "post": {
+      "Shanghai": [
+        {
+          "hash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "txbytes": "0xeb800a8252088080801b01a0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
+        }
+      ]
+    },
+    "pre": {},
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x00"
+      ],
+      "gasPrice": "0x0a",
+      "nonce": "0x00",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "to": "0x00",
+      "value": [
+        "0x00"
+      ]
+    }
+  }
+}

--- a/test/state/errors.hpp
+++ b/test/state/errors.hpp
@@ -33,6 +33,7 @@ enum ErrorCode : int  // NOLINT(*-use-enum-class)
     MAX_GAS_LIMIT_EXCEEDED,
     INVALID_CHAIN_ID,
     INVALID_ENCODING,
+    INVALID_SIGNATURE,
     UNKNOWN_ERROR,
 
     // Block-level validation.
@@ -106,6 +107,8 @@ inline const std::error_category& evmone_category() noexcept
                 return "invalid transaction chain id";
             case INVALID_ENCODING:
                 return "invalid transaction encoding";
+            case INVALID_SIGNATURE:
+                return "invalid transaction signature";
             case UNKNOWN_ERROR:
                 return "Unknown error";
             case INCORRECT_BLOCK_FORMAT:

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transaction.hpp"
-// TODO: Move the RLP encoder down into the state library, next to rlp_common.hpp. It lives in
-//   evmone.testutils, which links against evmone::state, so this include points the wrong way.
-//   It works only because the encoder is header-only.
+// TODO: The RLP encoder belongs in the state library, see the note in authorization.cpp.
 #include "../utils/rlp.hpp"
 #include "../utils/stdx/utility.hpp"
 #include "hash_utils.hpp"
@@ -145,33 +143,28 @@ std::optional<Transaction> decode_transaction(bytes_view data) noexcept
 
 std::optional<address> recover_sender(const Transaction& tx, bytes_view txbytes) noexcept
 {
-    // A transaction is signed over its own encoding with the signature left out, so the signed
-    // fields are a slice of txbytes: the payload without the trailing (v, r, s). Slicing them out
-    // avoids a second, signing-only encoder for every transaction type.
+    // The signing preimage is the transaction's encoding with the trailing (v, r, s) left out, so
+    // it is sliced out of txbytes instead of maintaining a second, signing-only encoder per type.
     const auto typed = tx.type != Transaction::Type::legacy;
-    auto payload = txbytes.substr(typed ? 1 : 0);  // Skip the EIP-2718 type byte.
+    auto envelope = txbytes.substr(typed ? 1 : 0);  // Skip the EIP-2718 type byte.
+    bytes_view payload;
+    [[maybe_unused]] const auto is_list = rlp::take_list_payload(envelope, payload);
+    assert(is_list);  // tx has been decoded from txbytes, so its list header is valid.
 
-    rlp::Header header;
-    [[maybe_unused]] const auto header_decoded = rlp::decode_header(payload, header);
-    assert(header_decoded);  // tx has been decoded from txbytes, so its list header is valid.
-
-    // The signature fields are canonically encoded, so their sizes locate the slice boundary.
+    // The decoder accepts only canonical integers, so re-encoding (v, r, s) gives their wire sizes.
     const auto signature_size =
         rlp::encode(tx.v).size() + rlp::encode(tx.r).size() + rlp::encode(tx.s).size();
-    assert(signature_size <= header.payload_length);
-    auto preimage = bytes{payload.substr(0, header.payload_length - signature_size)};
+    assert(signature_size <= payload.size());
+    auto preimage = bytes{payload.substr(0, payload.size() - signature_size)};
 
     // Since EIP-155 a legacy signature covers the chain id as well, and then (chain_id, 0, 0)
     // takes the place of the signature in the preimage.
-    const auto legacy_protected = !typed && tx.chain_id_protected();
-    if (legacy_protected)
-    {
-        preimage += rlp::encode(tx.chain_id);
-        preimage += bytes(2, rlp::SHORT_STRING_BASE);  // r = 0, s = 0
-    }
+    if (!typed && tx.chain_id_protected())
+        preimage += rlp::encode(tx.chain_id) + rlp::encode(uint64_t{}) + rlp::encode(uint64_t{});
 
-    // The decoder has bounded v: {0, 1} when typed, {27, 28} or >= 35 (EIP-155) when legacy.
-    const auto y_parity = typed ? tx.v != 0 : (tx.v - (legacy_protected ? 35 : 27)) % 2 != 0;
+    // A legacy v is 27 + y_parity, or 35 + 2 * chain_id + y_parity since EIP-155: both bases are
+    // odd, so an even v means y_parity 1 either way. A typed v is the parity itself.
+    const auto y_parity = typed ? tx.v != 0 : tx.v % 2 == 0;
 
     const auto h = keccak256((typed ? bytes{stdx::to_underlying(tx.type)} : bytes{}) +
                              rlp::internal::wrap_list(preimage));

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transaction.hpp"
+// TODO: Move the RLP encoder down into the state library, next to rlp_common.hpp. It lives in
+//   evmone.testutils, which links against evmone::state, so this include points the wrong way.
+//   It works only because the encoder is header-only.
+#include "../utils/rlp.hpp"
 #include "../utils/stdx/utility.hpp"
+#include "hash_utils.hpp"
 #include "rlp_decode.hpp"
+#include <evmone_precompiles/secp256k1.hpp>
 
 namespace evmone::state
 {
@@ -135,5 +141,43 @@ std::optional<Transaction> decode_transaction(bytes_view data) noexcept
     if (!decode_transaction_body(data, tx) || !data.empty())
         return std::nullopt;  // Malformed transaction or trailing data.
     return tx;
+}
+
+std::optional<address> recover_sender(const Transaction& tx, bytes_view txbytes) noexcept
+{
+    // A transaction is signed over its own encoding with the signature left out, so the signed
+    // fields are a slice of txbytes: the payload without the trailing (v, r, s). Slicing them out
+    // avoids a second, signing-only encoder for every transaction type.
+    const auto typed = tx.type != Transaction::Type::legacy;
+    auto payload = txbytes.substr(typed ? 1 : 0);  // Skip the EIP-2718 type byte.
+
+    rlp::Header header;
+    [[maybe_unused]] const auto header_decoded = rlp::decode_header(payload, header);
+    assert(header_decoded);  // tx has been decoded from txbytes, so its list header is valid.
+
+    // The signature fields are canonically encoded, so their sizes locate the slice boundary.
+    const auto signature_size =
+        rlp::encode(tx.v).size() + rlp::encode(tx.r).size() + rlp::encode(tx.s).size();
+    assert(signature_size <= header.payload_length);
+    auto preimage = bytes{payload.substr(0, header.payload_length - signature_size)};
+
+    // Protected legacy transactions sign chain_id by appending (chain_id, 0, 0) (EIP-155).
+    // TODO: Allocate bytes only in this case; use views for typed transactions.
+    const auto legacy_protected = !typed && tx.chain_id_protected();
+    if (legacy_protected)
+    {
+        preimage += rlp::encode(tx.chain_id);
+        preimage += bytes(2, rlp::SHORT_STRING_BASE);  // r = 0, s = 0
+    }
+
+    // The decoder has bounded v: {0, 1} when typed, {27, 28} or >= 35 (EIP-155) when legacy.
+    const auto y_parity = typed ? tx.v != 0 : (tx.v - (legacy_protected ? 35 : 27)) % 2 != 0;
+
+    const auto h = keccak256((typed ? bytes{stdx::to_underlying(tx.type)} : bytes{}) +
+                             rlp::internal::wrap_list(preimage));
+    const auto r_bytes = intx::be::store<bytes32>(tx.r);
+    const auto s_bytes = intx::be::store<bytes32>(tx.s);
+    return evmmax::secp256k1::ecrecover(
+        h.bytes, r_bytes.bytes, s_bytes.bytes, y_parity, evmmax::secp256k1::RecoveryMode::strict);
 }
 }  // namespace evmone::state

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transaction.hpp"
-// TODO: Move the RLP encoder down into the state library, next to rlp_common.hpp. It lives in
-//   evmone.testutils, which links against evmone::state, so this include points the wrong way.
-//   It works only because the encoder is header-only.
+// TODO: The RLP encoder belongs in the state library, see the note in authorization.cpp.
 #include "../utils/rlp.hpp"
 #include "../utils/stdx/utility.hpp"
 #include "hash_utils.hpp"
@@ -145,33 +143,28 @@ std::optional<Transaction> decode_transaction(bytes_view data) noexcept
 
 std::optional<address> recover_sender(const Transaction& tx, bytes_view txbytes) noexcept
 {
-    // A transaction is signed over its own encoding with the signature left out, so the signed
-    // fields are a slice of txbytes: the payload without the trailing (v, r, s). Slicing them out
-    // avoids a second, signing-only encoder for every transaction type.
+    // The signing preimage is the transaction's encoding without the trailing (v, r, s).
     const auto typed = tx.type != Transaction::Type::legacy;
-    auto payload = txbytes.substr(typed ? 1 : 0);  // Skip the EIP-2718 type byte.
+    auto envelope = txbytes.substr(typed ? 1 : 0);  // Skip the EIP-2718 type byte.
+    bytes_view payload;
+    [[maybe_unused]] const auto is_list = rlp::take_list_payload(envelope, payload);
+    assert(is_list);  // tx has been decoded from txbytes, so its list header is valid.
 
-    rlp::Header header;
-    [[maybe_unused]] const auto header_decoded = rlp::decode_header(payload, header);
-    assert(header_decoded);  // tx has been decoded from txbytes, so its list header is valid.
-
-    // The signature fields are canonically encoded, so their sizes locate the slice boundary.
+    // Find the length of the encoded signature to find the preimage length.
+    // The decoder accepts only canonical integers, so re-encoding (v, r, s) gives their wire sizes.
     const auto signature_size =
         rlp::encode(tx.v).size() + rlp::encode(tx.r).size() + rlp::encode(tx.s).size();
-    assert(signature_size <= header.payload_length);
-    auto preimage = bytes{payload.substr(0, header.payload_length - signature_size)};
+    assert(signature_size <= payload.size());
+    auto preimage = bytes{payload.substr(0, payload.size() - signature_size)};
 
     // Protected legacy transactions sign chain_id by appending (chain_id, 0, 0) (EIP-155).
     // TODO: Allocate bytes only in this case; use views for typed transactions.
-    const auto legacy_protected = !typed && tx.chain_id_protected();
-    if (legacy_protected)
-    {
-        preimage += rlp::encode(tx.chain_id);
-        preimage += bytes(2, rlp::SHORT_STRING_BASE);  // r = 0, s = 0
-    }
+    if (!typed && tx.chain_id_protected())
+        preimage += rlp::encode(tx.chain_id) + rlp::encode(uint64_t{}) + rlp::encode(uint64_t{});
 
-    // The decoder has bounded v: {0, 1} when typed, {27, 28} or >= 35 (EIP-155) when legacy.
-    const auto y_parity = typed ? tx.v != 0 : (tx.v - (legacy_protected ? 35 : 27)) % 2 != 0;
+    // A typed v is {0, 1}. A legacy v is 27 + y_parity, or 35 + 2 * chain_id + y_parity (EIP-155):
+    // both bases are odd, so an even v means y_parity 1.
+    const auto y_parity = typed ? tx.v != 0 : tx.v % 2 == 0;
 
     const auto h = keccak256((typed ? bytes{stdx::to_underlying(tx.type)} : bytes{}) +
                              rlp::internal::wrap_list(preimage));

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transaction.hpp"
+// TODO: Move the RLP encoder down into the state library, next to rlp_common.hpp. It lives in
+//   evmone.testutils, which links against evmone::state, so this include points the wrong way.
+//   It works only because the encoder is header-only.
+#include "../utils/rlp.hpp"
 #include "../utils/stdx/utility.hpp"
+#include "hash_utils.hpp"
 #include "rlp_decode.hpp"
+#include <evmone_precompiles/secp256k1.hpp>
 
 namespace evmone::state
 {
@@ -135,5 +141,43 @@ std::optional<Transaction> decode_transaction(bytes_view data) noexcept
     if (!decode_transaction_body(data, tx) || !data.empty())
         return std::nullopt;  // Malformed transaction or trailing data.
     return tx;
+}
+
+std::optional<address> recover_sender(const Transaction& tx, bytes_view txbytes) noexcept
+{
+    // A transaction is signed over its own encoding with the signature left out, so the signed
+    // fields are a slice of txbytes: the payload without the trailing (v, r, s). Slicing them out
+    // avoids a second, signing-only encoder for every transaction type.
+    const auto typed = tx.type != Transaction::Type::legacy;
+    auto payload = txbytes.substr(typed ? 1 : 0);  // Skip the EIP-2718 type byte.
+
+    rlp::Header header;
+    [[maybe_unused]] const auto header_decoded = rlp::decode_header(payload, header);
+    assert(header_decoded);  // tx has been decoded from txbytes, so its list header is valid.
+
+    // The signature fields are canonically encoded, so their sizes locate the slice boundary.
+    const auto signature_size =
+        rlp::encode(tx.v).size() + rlp::encode(tx.r).size() + rlp::encode(tx.s).size();
+    assert(signature_size <= header.payload_length);
+    auto preimage = bytes{payload.substr(0, header.payload_length - signature_size)};
+
+    // Since EIP-155 a legacy signature covers the chain id as well, and then (chain_id, 0, 0)
+    // takes the place of the signature in the preimage.
+    const auto legacy_protected = !typed && tx.chain_id_protected();
+    if (legacy_protected)
+    {
+        preimage += rlp::encode(tx.chain_id);
+        preimage += bytes(2, rlp::SHORT_STRING_BASE);  // r = 0, s = 0
+    }
+
+    // The decoder has bounded v: {0, 1} when typed, {27, 28} or >= 35 (EIP-155) when legacy.
+    const auto y_parity = typed ? tx.v != 0 : (tx.v - (legacy_protected ? 35 : 27)) % 2 != 0;
+
+    const auto h = keccak256((typed ? bytes{stdx::to_underlying(tx.type)} : bytes{}) +
+                             rlp::internal::wrap_list(preimage));
+    const auto r_bytes = intx::be::store<bytes32>(tx.r);
+    const auto s_bytes = intx::be::store<bytes32>(tx.s);
+    return evmmax::secp256k1::ecrecover(
+        h.bytes, r_bytes.bytes, s_bytes.bytes, y_parity, evmmax::secp256k1::RecoveryMode::strict);
 }
 }  // namespace evmone::state

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -89,11 +89,12 @@ struct Transaction
 [[nodiscard]] std::optional<Transaction> decode_transaction(bytes_view data) noexcept;
 
 /// Recovers the sender (the signer) of the transaction @p tx decoded from @p txbytes,
-/// std::nullopt if the signature is invalid: r or s outside [1, secp256k1n), or s in the upper
-/// half (EIP-2).
+/// or std::nullopt if the signature is invalid.
 ///
 /// The serialization is needed as well because the signing preimage is a slice of it; @p tx must
 /// be what decode_transaction(@p txbytes) returned.
+///
+/// The recovery is strict at every revision: r, s in [1, secp256k1n) and low s (EIP-2).
 [[nodiscard]] std::optional<address> recover_sender(
     const Transaction& tx, bytes_view txbytes) noexcept;
 

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -88,6 +88,15 @@ struct Transaction
 /// Handles the legacy RLP list and the EIP-2718 typed envelope (type byte followed by an RLP list).
 [[nodiscard]] std::optional<Transaction> decode_transaction(bytes_view data) noexcept;
 
+/// Recovers the sender (the signer) of the transaction @p tx decoded from @p txbytes,
+/// std::nullopt if the signature is invalid: r or s outside [1, secp256k1n), or s in the upper
+/// half (EIP-2).
+///
+/// The serialization is needed as well because the signing preimage is a slice of it; @p tx must
+/// be what decode_transaction(@p txbytes) returned.
+[[nodiscard]] std::optional<address> recover_sender(
+    const Transaction& tx, bytes_view txbytes) noexcept;
+
 /// Transaction properties computed during the validation needed for the execution.
 struct TransactionProperties
 {

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -88,9 +88,9 @@ struct Transaction
 /// Handles the legacy RLP list and the EIP-2718 typed envelope (type byte followed by an RLP list).
 [[nodiscard]] std::optional<Transaction> decode_transaction(bytes_view data) noexcept;
 
-/// Recovers the sender (the signer) of the transaction @p tx decoded from @p txbytes,
-/// std::nullopt if the signature is invalid: r or s outside [1, secp256k1n), or s in the upper
-/// half (EIP-2).
+/// Recovers the sender (the signer) of the transaction @p tx decoded from @p txbytes, or
+/// std::nullopt if the signature is invalid, e.g. r or s outside [1, secp256k1n) or s in the
+/// upper half (EIP-2).
 ///
 /// The serialization is needed as well because the signing preimage is a slice of it; @p tx must
 /// be what decode_transaction(@p txbytes) returned.

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -88,6 +88,20 @@ struct Transaction
 /// Handles the legacy RLP list and the EIP-2718 typed envelope (type byte followed by an RLP list).
 [[nodiscard]] std::optional<Transaction> decode_transaction(bytes_view data) noexcept;
 
+/// Recovers the sender (the signer) of the transaction @p tx decoded from @p txbytes,
+/// std::nullopt if the signature is invalid: r or s outside [1, secp256k1n), or s in the upper
+/// half (EIP-2).
+///
+/// The serialization is needed as well because the signing preimage is a slice of it; @p tx must
+/// be what decode_transaction(@p txbytes) returned.
+///
+/// Both rules are applied at every revision, although EIP-2 (low s) starts at Homestead and
+/// EIP-155 (v carrying the chain id) at Spurious Dragon. The fixtures do not notice: they are
+/// signed canonically, and no transaction predating Spurious Dragon carries an EIP-155 v.
+/// Replaying real pre-Homestead history would, as about half of those signatures have a high s.
+[[nodiscard]] std::optional<address> recover_sender(
+    const Transaction& tx, bytes_view txbytes) noexcept;
+
 /// Transaction properties computed during the validation needed for the execution.
 struct TransactionProperties
 {

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -28,9 +28,9 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             auto state = test.pre_state;
             const auto blob_params = get_blob_params(rev, test.blob_schedule);
 
-            // Decode transaction from txbytes if available.
-            const auto template_tx = test.multi_tx.get(expected.indexes);
-            auto tx = std::optional{template_tx};
+            // Decode the transaction from txbytes if available, else take the JSON template.
+            auto tx = std::optional{test.multi_tx.get(expected.indexes)};
+            auto error = state::INVALID_ENCODING;
             if (expected.txbytes.has_value())
             {
                 tx = state::decode_transaction(*expected.txbytes);
@@ -39,7 +39,15 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
                     // Decoding is the inverse of encoding: what decoded must encode back exactly.
                     EXPECT_EQ(rlp::encode(*tx), *expected.txbytes);
 
-                    tx->sender = template_tx.sender;  // No recovery yet, take sender from JSON.
+                    // Recover the signer, as a node does, instead of taking it from JSON.
+                    const auto sender = state::recover_sender(*tx, *expected.txbytes);
+                    if (sender.has_value())
+                        tx->sender = *sender;
+                    else
+                    {
+                        tx.reset();
+                        error = state::INVALID_SIGNATURE;
+                    }
                 }
             }
 
@@ -47,7 +55,7 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
                 tx.has_value() ?
                     transition(state, block, test.block_hashes, *tx, rev, vm, block.gas_limit,
                         static_cast<int64_t>(state::max_blob_gas_per_block(blob_params))) :
-                    make_error_code(state::INVALID_ENCODING);
+                    make_error_code(error);
 
             if (holds_alternative<state::TransactionReceipt>(res))
             {

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -28,13 +28,14 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             auto state = test.pre_state;
             const auto blob_params = get_blob_params(rev, test.blob_schedule);
 
-            // Decode the transaction from txbytes if available, else take the JSON template.
-            auto tx = std::optional{test.multi_tx.get(expected.indexes)};
-            auto error = state::INVALID_ENCODING;
+            std::optional<state::Transaction> tx;
+            std::error_code error;
             if (expected.txbytes.has_value())
             {
                 tx = state::decode_transaction(*expected.txbytes);
-                if (tx.has_value())
+                if (!tx.has_value())
+                    error = make_error_code(state::INVALID_ENCODING);
+                else
                 {
                     // Decoding is the inverse of encoding: what decoded must encode back exactly.
                     EXPECT_EQ(rlp::encode(*tx), *expected.txbytes);
@@ -44,18 +45,16 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
                     if (sender.has_value())
                         tx->sender = *sender;
                     else
-                    {
-                        tx.reset();
-                        error = state::INVALID_SIGNATURE;
-                    }
+                        error = make_error_code(state::INVALID_SIGNATURE);
                 }
             }
+            else
+                tx = test.multi_tx.get(expected.indexes);
 
             const auto res =
-                tx.has_value() ?
-                    transition(state, block, test.block_hashes, *tx, rev, vm, block.gas_limit,
-                        static_cast<int64_t>(state::max_blob_gas_per_block(blob_params))) :
-                    make_error_code(error);
+                error ? error :
+                        transition(state, block, test.block_hashes, *tx, rev, vm, block.gas_limit,
+                            static_cast<int64_t>(state::max_blob_gas_per_block(blob_params)));
 
             if (holds_alternative<state::TransactionReceipt>(res))
             {

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -28,13 +28,16 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             auto state = test.pre_state;
             const auto blob_params = get_blob_params(rev, test.blob_schedule);
 
-            // Decode the transaction from txbytes if available, else take the JSON template.
-            auto tx = std::optional{test.multi_tx.get(expected.indexes)};
-            auto error = state::INVALID_ENCODING;
+            std::optional<state::Transaction> tx;
+            std::error_code error;
             if (expected.txbytes.has_value())
             {
                 tx = state::decode_transaction(*expected.txbytes);
-                if (tx.has_value())
+                if (!tx.has_value())
+                {
+                    error = make_error_code(state::INVALID_ENCODING);
+                }
+                else
                 {
                     // Decoding is the inverse of encoding: what decoded must encode back exactly.
                     EXPECT_EQ(rlp::encode(*tx), *expected.txbytes);
@@ -44,18 +47,18 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
                     if (sender.has_value())
                         tx->sender = *sender;
                     else
-                    {
-                        tx.reset();
-                        error = state::INVALID_SIGNATURE;
-                    }
+                        error = make_error_code(state::INVALID_SIGNATURE);
                 }
+            }
+            else
+            {
+                tx = test.multi_tx.get(expected.indexes);
             }
 
             const auto res =
-                tx.has_value() ?
-                    transition(state, block, test.block_hashes, *tx, rev, vm, block.gas_limit,
-                        static_cast<int64_t>(state::max_blob_gas_per_block(blob_params))) :
-                    make_error_code(error);
+                error ? error :
+                        transition(state, block, test.block_hashes, *tx, rev, vm, block.gas_limit,
+                            static_cast<int64_t>(state::max_blob_gas_per_block(blob_params)));
 
             if (holds_alternative<state::TransactionReceipt>(res))
             {

--- a/test/unittests/state_rlp_decode_test.cpp
+++ b/test/unittests/state_rlp_decode_test.cpp
@@ -2,6 +2,7 @@
 // Copyright 2026 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <evmone_precompiles/secp256k1.hpp>
 #include <gtest/gtest.h>
 #include <test/state/rlp_decode.hpp>
 #include <test/state/transaction.hpp>
@@ -35,6 +36,14 @@ state::Transaction round_trip(const state::Transaction& tx)
     EXPECT_TRUE(decoded.has_value());
     // The argument cannot be spelled {}: value_or() deduces its parameter type (libc++ rejects it).
     return decoded.value_or(state::Transaction{});
+}
+
+/// Decodes @p txbytes and recovers the sender of the transaction; it must decode.
+std::optional<address> recover(const bytes& txbytes)
+{
+    const auto tx = state::decode_transaction(txbytes);
+    EXPECT_TRUE(tx.has_value());
+    return state::recover_sender(tx.value(), txbytes);
 }
 
 /// Compares all decoded fields of two transactions (sender is not recovered by the decoder).
@@ -633,18 +642,12 @@ TEST(state_rlp_decode, decode_authorization_field_positions)
 
 TEST(state_rlp_decode, recover_sender_legacy_protected)
 {
-    // The same fields and signature, signed once over the pre-EIP-155 preimage and once over the
-    // EIP-155 one for chain 0 (wire v = 35/36). Both decode to chain_id 0 and the same y_parity,
-    // so only the verbatim v tells them apart. No EEST fixture signs for chain 0, which is why
-    // this is pinned here.
-    // Signer of both: 0x1d694d5ad94f32132ff5c14c901d3ddbee90a550 (private key 0xa5).
+    // The same fields signed twice: over the pre-EIP-155 preimage and over the EIP-155 one for
+    // chain 0 (wire v = 35/36). Both decode to chain_id 0, so only the verbatim v says which
+    // preimage was signed. No EEST fixture signs for chain 0, which is why this is pinned here.
+    // Signer of both: 0x1d694d5ad94f32132ff5c14c901d3ddbee90a550 (private key 0xa5). evmone only
+    // recovers, so changing the fields means re-signing each preimage elsewhere, with a low s.
     constexpr auto signer = 0x1d694d5ad94f32132ff5c14c901d3ddbee90a550_address;
-
-    const auto recover = [](const bytes& txbytes) {
-        const auto tx = state::decode_transaction(txbytes);
-        EXPECT_TRUE(tx.has_value());
-        return tx.has_value() ? state::recover_sender(*tx, txbytes) : std::nullopt;
-    };
 
     const auto protected_tx =
         "0xf86807820102825208949232a548dd9e81bac65500b5e0d918f8ba93675c83abcdef84deadbeef23"
@@ -661,13 +664,21 @@ TEST(state_rlp_decode, recover_sender_legacy_protected)
 
 TEST(state_rlp_decode, recover_sender_rejects_out_of_range_s)
 {
-    // A transaction that decodes but has no signer: s must be in [1, secp256k1n), and EIP-2 bounds
-    // it to the lower half. The curve order is a canonical 32-byte integer, so the encoding is
-    // fine and only the recovery rejects it.
+    // s = the curve order is outside [1, secp256k1n) yet a canonical 32-byte integer, so the
+    // transaction decodes and only the recovery rejects it.
     auto tx = MINIMAL_LEGACY_TX;
-    tx.s = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_u256;  // secp256k1n
-    const auto txbytes = rlp::encode(tx);
-    const auto decoded = state::decode_transaction(txbytes);
-    ASSERT_TRUE(decoded.has_value());
-    EXPECT_FALSE(state::recover_sender(*decoded, txbytes).has_value());
+    tx.s = evmmax::secp256k1::Curve::ORDER;
+    EXPECT_FALSE(recover(rlp::encode(tx)).has_value());
+}
+
+TEST(state_rlp_decode, recover_sender_rejects_high_s)
+{
+    // EIP-2 bounds s to the lower half of the curve order, on top of the [1, secp256k1n) range.
+    // One above the bound differs from the largest accepted s in nothing else.
+    auto tx = MINIMAL_LEGACY_TX;
+    tx.s = evmmax::secp256k1::Curve::ORDER / 2;
+    EXPECT_TRUE(recover(rlp::encode(tx)).has_value());
+
+    tx.s += 1;
+    EXPECT_FALSE(recover(rlp::encode(tx)).has_value());
 }

--- a/test/unittests/state_rlp_decode_test.cpp
+++ b/test/unittests/state_rlp_decode_test.cpp
@@ -630,3 +630,44 @@ TEST(state_rlp_decode, decode_authorization_field_positions)
     EXPECT_TRUE(v.empty());
     EXPECT_EQ(a.nonce, 7u);
 }
+
+TEST(state_rlp_decode, recover_sender_legacy_protected)
+{
+    // The same fields and signature, signed once over the pre-EIP-155 preimage and once over the
+    // EIP-155 one for chain 0 (wire v = 35/36). Both decode to chain_id 0 and the same y_parity,
+    // so only the verbatim v tells them apart. No EEST fixture signs for chain 0, which is why
+    // this is pinned here.
+    // Signer of both: 0x1d694d5ad94f32132ff5c14c901d3ddbee90a550 (private key 0xa5).
+    constexpr auto signer = 0x1d694d5ad94f32132ff5c14c901d3ddbee90a550_address;
+
+    const auto recover = [](const bytes& txbytes) {
+        const auto tx = state::decode_transaction(txbytes);
+        EXPECT_TRUE(tx.has_value());
+        return tx.has_value() ? state::recover_sender(*tx, txbytes) : std::nullopt;
+    };
+
+    const auto protected_tx =
+        "0xf86807820102825208949232a548dd9e81bac65500b5e0d918f8ba93675c83abcdef84deadbeef23"
+        "a0d6c3bc8b0fc4456b4687ef74c42a70f0dfd2b2d2575a6f614749685164fe85c2"
+        "a02264f7f854576e62b8c8415e5f6fdd0ead0876c2b13b8e8d70ddda9239b95f16"_hex;
+    EXPECT_EQ(recover(protected_tx), signer);
+
+    const auto unprotected_tx =
+        "0xf86807820102825208949232a548dd9e81bac65500b5e0d918f8ba93675c83abcdef84deadbeef1c"
+        "a07290c0bb6429493499b400d2912ef585ee39b7c722d086f6de5b175cb495feae"
+        "a011417a917fff6e40eb2f74cdd22fb15c268c0ee6fd5ad97fc55af15aab9ae27f"_hex;
+    EXPECT_EQ(recover(unprotected_tx), signer);
+}
+
+TEST(state_rlp_decode, recover_sender_rejects_out_of_range_s)
+{
+    // A transaction that decodes but has no signer: s must be in [1, secp256k1n), and EIP-2 bounds
+    // it to the lower half. The curve order is a canonical 32-byte integer, so the encoding is
+    // fine and only the recovery rejects it.
+    auto tx = MINIMAL_LEGACY_TX;
+    tx.s = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_u256;  // secp256k1n
+    const auto txbytes = rlp::encode(tx);
+    const auto decoded = state::decode_transaction(txbytes);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_FALSE(state::recover_sender(*decoded, txbytes).has_value());
+}

--- a/test/unittests/state_rlp_decode_test.cpp
+++ b/test/unittests/state_rlp_decode_test.cpp
@@ -2,6 +2,7 @@
 // Copyright 2026 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <evmone_precompiles/secp256k1.hpp>
 #include <gtest/gtest.h>
 #include <test/state/rlp_decode.hpp>
 #include <test/state/transaction.hpp>
@@ -35,6 +36,14 @@ state::Transaction round_trip(const state::Transaction& tx)
     EXPECT_TRUE(decoded.has_value());
     // The argument cannot be spelled {}: value_or() deduces its parameter type (libc++ rejects it).
     return decoded.value_or(state::Transaction{});
+}
+
+/// Decodes @p txbytes and recovers the sender of the transaction; it must decode.
+std::optional<address> recover(const bytes& txbytes)
+{
+    const auto tx = state::decode_transaction(txbytes);
+    EXPECT_TRUE(tx.has_value());
+    return tx.has_value() ? state::recover_sender(*tx, txbytes) : std::nullopt;
 }
 
 /// Compares all decoded fields of two transactions (sender is not recovered by the decoder).
@@ -633,18 +642,11 @@ TEST(state_rlp_decode, decode_authorization_field_positions)
 
 TEST(state_rlp_decode, recover_sender_legacy_protected)
 {
-    // The same fields and signature, signed once over the pre-EIP-155 preimage and once over the
-    // EIP-155 one for chain 0 (wire v = 35/36). Both decode to chain_id 0 and the same y_parity,
-    // so only the verbatim v tells them apart. No EEST fixture signs for chain 0, which is why
-    // this is pinned here.
+    // The same fields signed twice: over the pre-EIP-155 preimage and over the EIP-155 one for
+    // chain 0 (wire v = 35/36). Both decode to chain_id 0, so only the verbatim v says which
+    // preimage was signed. No EEST fixture signs for chain 0, which is why this is pinned here.
     // Signer of both: 0x1d694d5ad94f32132ff5c14c901d3ddbee90a550 (private key 0xa5).
     constexpr auto signer = 0x1d694d5ad94f32132ff5c14c901d3ddbee90a550_address;
-
-    const auto recover = [](const bytes& txbytes) {
-        const auto tx = state::decode_transaction(txbytes);
-        EXPECT_TRUE(tx.has_value());
-        return tx.has_value() ? state::recover_sender(*tx, txbytes) : std::nullopt;
-    };
 
     const auto protected_tx =
         "0xf86807820102825208949232a548dd9e81bac65500b5e0d918f8ba93675c83abcdef84deadbeef23"
@@ -661,13 +663,9 @@ TEST(state_rlp_decode, recover_sender_legacy_protected)
 
 TEST(state_rlp_decode, recover_sender_rejects_out_of_range_s)
 {
-    // A transaction that decodes but has no signer: s must be in [1, secp256k1n), and EIP-2 bounds
-    // it to the lower half. The curve order is a canonical 32-byte integer, so the encoding is
-    // fine and only the recovery rejects it.
+    // s = the curve order is outside [1, secp256k1n) yet a canonical 32-byte integer, so the
+    // transaction decodes and only the recovery rejects it.
     auto tx = MINIMAL_LEGACY_TX;
-    tx.s = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_u256;  // secp256k1n
-    const auto txbytes = rlp::encode(tx);
-    const auto decoded = state::decode_transaction(txbytes);
-    ASSERT_TRUE(decoded.has_value());
-    EXPECT_FALSE(state::recover_sender(*decoded, txbytes).has_value());
+    tx.s = evmmax::secp256k1::Curve::ORDER;
+    EXPECT_FALSE(recover(rlp::encode(tx)).has_value());
 }

--- a/test/unittests/state_rlp_decode_test.cpp
+++ b/test/unittests/state_rlp_decode_test.cpp
@@ -43,7 +43,7 @@ std::optional<address> recover(const bytes& txbytes)
 {
     const auto tx = state::decode_transaction(txbytes);
     EXPECT_TRUE(tx.has_value());
-    return tx.has_value() ? state::recover_sender(*tx, txbytes) : std::nullopt;
+    return state::recover_sender(tx.value(), txbytes);
 }
 
 /// Compares all decoded fields of two transactions (sender is not recovered by the decoder).

--- a/test/utils/statetest_export.cpp
+++ b/test/utils/statetest_export.cpp
@@ -63,6 +63,12 @@ std::string_view to_test_fork_name(evmc_revision rev) noexcept
         return "TR_BLOBLIST_OVERSIZE";
     case INVALID_CHAIN_ID:
         return "TransactionException.INVALID_CHAINID";
+    case INVALID_ENCODING:
+        // EEST names every way an encoding can be malformed separately (RLP_*), so there is no
+        // single constant to export here; the plain message follows UNKNOWN_ERROR below.
+        return "Invalid transaction encoding";
+    case INVALID_SIGNATURE:
+        return "TransactionException.INVALID_SIGNATURE_VRS";
     case UNKNOWN_ERROR:
         return "Unknown error";
     default:


### PR DESCRIPTION
Add procedure to do full transaction sender address recovery from the transaction signature. Wire this to the `evmone-statetest` and ignore JSON `"sender"` field.