### PR TITLE
state: Recognize chain-id protected legacy transaction

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -438,10 +438,7 @@ std::variant<TransactionProperties, std::error_code> validate_transaction(
     const StateView& state_view, const BlockInfo& block, const Transaction& tx, evmc_revision rev,
     int64_t block_gas_left, int64_t blob_gas_left) noexcept
 {
-    // chain_id must match the chain; a legacy tx may use 0 (unspecified, EIP-155).
-    // TODO: chain_id 0 is not "unspecified" for a legacy tx protected for chain 0 (v 35/36);
-    //   telling it apart from an unprotected tx (v 27/28) needs the signature v from txbytes.
-    if (tx.chain_id != block.chain_id && (tx.type != Transaction::Type::legacy || tx.chain_id != 0))
+    if (tx.chain_id_protected() && tx.chain_id != block.chain_id)
         return make_error_code(INVALID_CHAIN_ID);
 
     switch (tx.type)  // Validate "special" transaction types.

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -8,8 +8,6 @@
 
 namespace evmone::state
 {
-using intx::uint256;
-
 bool decode(bytes_view& from, Authorization& to) noexcept
 {
     bytes_view payload;
@@ -97,34 +95,17 @@ namespace
 
     if (to.type == Transaction::Type::legacy)
     {
-        // Legacy v encodes the recovery id and, since EIP-155, the chain id.
-        // TODO: This normalizes v into (y_parity, chain_id), so Transaction::v holds the parity
-        //   here while loader-produced transactions hold the raw wire v; re-encoding a decoded
-        //   legacy transaction therefore does not reproduce its bytes, and v=35/36 becomes
-        //   indistinguishable from the pre-EIP-155 v=27/28. Fix by distinguishing protected and
-        //   unprotected legacy transaction types (or by keeping the raw v and splitting at
-        //   signer recovery).
-        uint256 v_u256;
-        if (!rlp::decode<uint256>(body, v_u256))
+        // Legacy v carries the recovery id and, since EIP-155, the chain id. It is kept verbatim,
+        // the way rlp_encode() writes it, and the chain id derived alongside. Requiring the whole
+        // v to fit uint64_t bounds the chain id to 2**63 - 18, the same limit the JSON transaction
+        // loader has.
+        if (!rlp::decode(body, to.v))
             return false;
 
-        if (v_u256 == 27 || v_u256 == 28)  // Pre-EIP-155: no chain id.
-        {
-            to.v = (v_u256 == 28) ? 1 : 0;
-            to.chain_id = 0;
-        }
-        else if (v_u256 >= 35)  // EIP-155: v = 35 + 2 * chain_id + y_parity.
-        {
-            to.v = (v_u256 - 35) % 2 == 0 ? 0 : 1;
-            const auto chain_id = (v_u256 - 35 - to.v) / 2;
-            if (chain_id > std::numeric_limits<uint64_t>::max())
-                return false;  // chain id must fit the 64-bit Transaction::chain_id.
-            to.chain_id = static_cast<uint64_t>(chain_id);
-        }
-        else
-        {
-            return false;  // Invalid legacy signature v.
-        }
+        if (to.v >= 35)  // EIP-155: v = 35 + 2 * chain_id + y_parity.
+            to.chain_id = (to.v - 35) / 2;
+        else if (to.v != 27 && to.v != 28)  // Pre-EIP-155: bound to no chain, chain_id unused.
+            return false;
     }
     else
     {

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -55,6 +55,12 @@ struct Transaction
     /// Returns amount of blob gas used by this transaction
     [[nodiscard]] uint64_t blob_gas_used() const { return GAS_PER_BLOB * blob_hashes.size(); }
 
+    /// Whether the transaction specifies expected chain id. Always true for typed transactions.
+    [[nodiscard]] bool chain_id_protected() const noexcept
+    {
+        return type != Type::legacy || v >= 35;
+    }
+
     Type type = Type::legacy;
     bytes data;
     int64_t gas_limit = 0;
@@ -70,6 +76,9 @@ struct Transaction
     uint64_t nonce = 0;
     intx::uint256 r;
     intx::uint256 s;
+
+    /// The verbatim v value of the signature.
+    /// It encodes y_parity and for legacy transactions chain id.
     uint64_t v = 0;
     AuthorizationList authorization_list;
 };
@@ -77,8 +86,6 @@ struct Transaction
 /// Decodes a transaction from its complete serialization @p data.
 ///
 /// Handles the legacy RLP list and the EIP-2718 typed envelope (type byte followed by an RLP list).
-/// TODO: Not a strict inverse of rlp::encode: a legacy transaction's wire v is normalized into
-///   (chain_id, y_parity), so re-encoding a decoded legacy tx need not reproduce its bytes.
 [[nodiscard]] std::optional<Transaction> decode_transaction(bytes_view data) noexcept;
 
 /// Transaction properties computed during the validation needed for the execution.

--- a/test/unittests/state_rlp_decode_test.cpp
+++ b/test/unittests/state_rlp_decode_test.cpp
@@ -182,21 +182,15 @@ TEST(state_rlp_decode, tx_round_trip)
 
 TEST(state_rlp_decode, tx_round_trip_legacy)
 {
-    // The legacy encoder writes v verbatim while the decoder splits it into (chain_id, y_parity)
-    // and mirrors the single gas price into max_priority_gas_price; so the decoded form differs
-    // from the input in exactly those fields.
-    // EIP-155: v = 35 + 2 * chain_id + parity. v = 35 is the lowest accepted value, and its chain
-    // id 0 makes it indistinguishable from the pre-EIP-155 v = 27 once decoded.
-    struct LegacyV
+    // A legacy transaction has a single wire gas price, so the decoded form differs from the input
+    // in max_priority_gas_price; v is kept verbatim and the chain id derived from it.
+    // EIP-155: v = 35 + 2 * chain_id + parity, with v = 35 the lowest accepted value; before it,
+    // v is 27 or 28 and the transaction is bound to no chain.
+    for (const auto& [v, chain_id] :
+        {std::pair{27u, uint64_t{0}}, std::pair{28u, uint64_t{0}}, std::pair{35u, uint64_t{0}},
+            std::pair{36u, uint64_t{0}}, std::pair{37u, uint64_t{1}}, std::pair{38u, uint64_t{1}}})
     {
-        unsigned raw_v;
-        unsigned parity;
-        uint64_t chain_id;
-    };
-    for (const auto& [raw_v, parity, chain_id] :
-        {LegacyV{35, 0, 0}, LegacyV{36, 1, 0}, LegacyV{37, 0, 1}, LegacyV{38, 1, 1}})
-    {
-        SCOPED_TRACE(raw_v);
+        SCOPED_TRACE(v);
         const state::Transaction in{
             .type = state::Transaction::Type::legacy,
             .data = "0xdeadbeef"_hex,
@@ -207,29 +201,22 @@ TEST(state_rlp_decode, tx_round_trip_legacy)
             .nonce = 7,
             .r = 0x1111_u256,
             .s = 0x2222_u256,
-            .v = raw_v,
+            .v = v,
         };
 
         auto expected = in;
         expected.max_priority_gas_price = in.max_gas_price;
         expected.chain_id = chain_id;
-        expected.v = parity;
         expect_tx_eq(expected, round_trip(in));
     }
 
-    // Pre-EIP-155: v in {27, 28}, no chain id, CREATE.
-    for (const auto& [raw_v, parity] : {std::pair{27u, 0u}, std::pair{28u, 1u}})
-    {
-        SCOPED_TRACE(raw_v);
-        auto in = MINIMAL_LEGACY_TX;
-        in.v = raw_v;
-
-        auto expected = in;
-        expected.max_priority_gas_price = in.max_gas_price;
-        expected.chain_id = 0;
-        expected.v = parity;
-        expect_tx_eq(expected, round_trip(in));
-    }
+    // The largest chain id a legacy transaction can carry: any larger one has a v above uint64.
+    auto in = MINIMAL_LEGACY_TX;
+    in.v = std::numeric_limits<uint64_t>::max();
+    auto expected = in;
+    expected.max_priority_gas_price = in.max_gas_price;
+    expected.chain_id = (std::numeric_limits<uint64_t>::max() - 35) / 2;
+    expect_tx_eq(expected, round_trip(in));
 }
 
 TEST(state_rlp_decode, tx_set_code_auth_y_parity_overflow_rejected)
@@ -477,9 +464,10 @@ TEST(state_rlp_decode, tx_rejects_invalid_legacy_v)
     EXPECT_FALSE(state::decode_transaction(rlp::encode(tx)).has_value());
 }
 
-TEST(state_rlp_decode, tx_rejects_chain_id_over_uint64)
+TEST(state_rlp_decode, tx_rejects_legacy_v_over_uint64)
 {
-    // Regression: an EIP-155 chain id that does not fit uint64 must be rejected, not truncated.
+    // Regression: a legacy v that does not fit uint64 must be rejected, not truncated. This bounds
+    // the EIP-155 chain id to (2**64 - 36) / 2, the limit the JSON transaction loader also has.
     // Hand-crafted legacy tx with v = 2**65 + 35, i.e. chain id 2**64.
     const auto rlp = "0xd2808080808080890200000000000000230101"_hex;
     EXPECT_FALSE(state::decode_transaction(rlp).has_value());

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -62,6 +62,18 @@ TEST_F(state_transition, invalid_tx_wrong_chain_id_legacy)
     tx.type = Transaction::Type::legacy;
     tx.to = To;
     tx.chain_id = 2;  // Mismatches the block chain id (1).
+    tx.v = 35 + 2 * tx.chain_id;
+    expect.tx_error = INVALID_CHAIN_ID;
+}
+
+TEST_F(state_transition, invalid_tx_legacy_protected_chain_id_0)
+{
+    // A legacy transaction signed for chain 0 (EIP-155) is bound to it like any other, unlike an
+    // unprotected one. No EEST fixture signs for chain 0, which is why this is pinned here.
+    tx.type = Transaction::Type::legacy;
+    tx.to = To;
+    tx.chain_id = 0;
+    tx.v = 35;
     expect.tx_error = INVALID_CHAIN_ID;
 }
 

--- a/test/utils/rlp_encode.cpp
+++ b/test/utils/rlp_encode.cpp
@@ -22,8 +22,6 @@ namespace evmone::state
     if (tx.type == Transaction::Type::legacy)
     {
         // rlp [nonce, gas_price, gas_limit, to, value, data, v, r, s];
-        // v is written verbatim. TODO: chain_id 0 is ambiguous — unprotected (v 27/28) vs
-        //   protected for chain 0 (v 35/36) — so v must not be re-derived from chain_id.
         return rlp::encode_tuple(tx.nonce, tx.max_gas_price, static_cast<uint64_t>(tx.gas_limit),
             tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data, tx.v, tx.r, tx.s);
     }

--- a/test/utils/statetest_export.cpp
+++ b/test/utils/statetest_export.cpp
@@ -122,6 +122,7 @@ json::json to_state_test(std::string_view test_name, const state::BlockInfo& blo
     jtx["secretKey"] = hex0x(SenderSecretKey);
     jtx["chainId"] = hex0x(tx.chain_id);
     jtx["nonce"] = hex0x(tx.nonce);
+    jtx["v"] = hex0x(tx.v);
     if (tx.type >= Transaction::Type::eip1559)
     {
         jtx["maxFeePerGas"] = hex0x(tx.max_gas_price);

--- a/test/utils/statetest_loader.cpp
+++ b/test/utils/statetest_loader.cpp
@@ -479,6 +479,8 @@ static void from_json(const json::json& j, TestMultiTransaction& o)
 
     for (const auto& j_value : j.at("value"))
         o.values.emplace_back(from_json<intx::uint256>(j_value));
+
+    o.v = load_if_exists<uint64_t>(j, "v");
 }
 
 static void from_json(const json::json& j, TestMultiTransaction::Indexes& o)


### PR DESCRIPTION
The chain id check exempted every legacy transaction with chain_id 0, because the decoder folded the wire v into (chain_id, y_parity), and that makes v = 35/36 -- protected for chain 0 (EIP-155) -- indistinguishable from the unprotected v = 27/28. A transaction signed for chain 0 was therefore accepted on any chain.

Keep v verbatim instead, the way rlp_encode() writes it and the JSON transaction loader reads it, and derive chain_id next to it: v >= 35 is exactly the EIP-155 form, so Transaction::chain_id_protected() decides the check, and decoding a transaction becomes the inverse of encoding it. Requiring the whole v to fit uint64_t bounds a legacy chain id to 2**63 - 18, the limit the loader already had.

A state test identifies its sender directly and usually carries no signature, so the exported transaction now also carries v; without it a re-executed test would take every legacy transaction for an unprotected one.