### PR TITLE
crypto: Use fixed-window exponentiation in modexp

### DIFF
--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -431,26 +431,25 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     const auto exp_loop = [&]<size_t N>() {
         auto r_cur = std::span<uint64_t, N>{result};
         auto r_tmp = std::span<uint64_t, N>{u.first(n)};
-        const auto bm = std::span<const uint64_t, N>{base_mont};
         const auto m = std::span<const uint64_t, N>{mod};
 
-        // The j-th precomputed value.
-        const auto precomputed = [table, n](size_t j) noexcept {
-            return std::span<uint64_t, N>{table.subspan(j * n, n)};
+        // base_mont^k, for k in 1..table_size.
+        const auto precomputed = [table, n](size_t k) noexcept {
+            return std::span<uint64_t, N>{table.subspan((k - 1) * n, n)};
         };
 
-        // precomputed[j] = base_mont^(j+1); precomputed[0] = base_mont is already set.
-        for (size_t j = 1; j < table_size; ++j)
-            mul_amm<N>(precomputed(j), precomputed(j - 1), bm, m, mod_inv);
+        // precomputed(1) = base_mont is already set.
+        for (size_t k = 2; k <= table_size; ++k)
+            mul_amm<N>(precomputed(k), precomputed(k - 1), precomputed(1), m, mod_inv);
 
-        // Reads the w-bit (or fewer) window whose most-significant bit is at index `hi`.
+        // Reads the `width` exponent bits starting at index `lo`.
         // TODO: A window spans at most two adjacent bytes, so it could be read with one
         //   two-byte load, a shift and a mask. Est. 1-3%, and only for a 4-word modulus
         //   with a very long exponent; measure before doing it.
-        const auto window = [&](size_t hi, size_t width) noexcept {
+        const auto window = [&](size_t lo, size_t width) noexcept {
             size_t v = 0;
             for (size_t b = 0; b < width; ++b)
-                v = (v << 1) | (exp[hi - b] ? size_t{1} : size_t{0});
+                v |= size_t{exp[lo + b]} << b;
             return v;
         };
 
@@ -459,8 +458,7 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         // TODO: Tiling from the top instead would save w - top_width squarings when
         //   exp_bits % w != 0 (up to 4%), at the cost of a special-cased final iteration.
         const size_t top_width = (exp_bits - 1) % w + 1;
-        const size_t top_val = window(exp_bits - 1, top_width);
-        std::ranges::copy(precomputed(top_val - 1), r_cur.begin());
+        std::ranges::copy(precomputed(window(exp_bits - top_width, top_width)), r_cur.begin());
 
         for (size_t pos = exp_bits - top_width; pos != 0;)
         {
@@ -470,22 +468,21 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
                 mul_amm<N>(r_tmp, r_cur, r_cur, m, mod_inv);
                 std::swap(r_cur, r_tmp);
             }
-            if (const size_t v = window(pos + w - 1, w); v != 0)  // multiply by base_mont^v
+            if (const size_t v = window(pos, w); v != 0)  // multiply by base_mont^v
             {
-                mul_amm<N>(r_tmp, r_cur, precomputed(v - 1), m, mod_inv);
+                mul_amm<N>(r_tmp, r_cur, precomputed(v), m, mod_inv);
                 std::swap(r_cur, r_tmp);
             }
         }
 
-        // Convert from Montgomery form: multiply by 1. Reuses table[0] storage.
+        // Convert from Montgomery form: multiply by 1. Reuses precomputed(1) storage.
         std::ranges::fill(base_mont, uint64_t{0});
         base_mont[0] = 1;
         mul_amm<N>(r_tmp, r_cur, std::span<const uint64_t, N>{base_mont}, m, mod_inv);
-        std::swap(r_cur, r_tmp);
 
         // If the result ended up in scratch, copy to result.
-        if (r_cur.data() != result.data())
-            std::ranges::copy(r_cur, result.begin());
+        if (r_tmp.data() != result.data())
+            std::ranges::copy(r_tmp, result.begin());
     };
 
     if (n == 4)

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -374,7 +374,7 @@ constexpr unsigned MAX_WINDOW_WIDTH = 4;
 /// Number of precomputed values for the max width windowed method.
 constexpr size_t MAX_PRECOMPUTED = (size_t{1} << MAX_WINDOW_WIDTH) - 1;
 
-/// Selects the fixed-window width off exponent bits.
+/// Selects the fixed-window width from the exponent bit length.
 ///
 /// TODO: Switch to a sliding window: the table then holds only odd powers. Measured ~3-7%.
 /// TODO: Tune for the densest exponent instead of the average, because gas is charged on
@@ -382,6 +382,8 @@ constexpr size_t MAX_PRECOMPUTED = (size_t{1} << MAX_WINDOW_WIDTH) - 1;
 ///   min(MAX_WINDOW_WIDTH, (bit_width(exp_bits) + 1) / 2). Measured +10.7% worst case.
 constexpr unsigned window_width(size_t exp_bits) noexcept
 {
+    // Break-even points for a random exponent, where the 2^w extra table multiplies stop
+    // being repaid: 2^w / ((1-2^-w)/w - (1-2^-(w+1))/(w+1)) = 16, 48, 140 (rounded to 144).
     if (exp_bits <= 16)
         return 1;
     if (exp_bits <= 48)
@@ -432,13 +434,14 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         const auto bm = std::span<const uint64_t, N>{base_mont};
         const auto m = std::span<const uint64_t, N>{mod};
 
-        // table[j] = base_mont^(j+1); table[0] = base_mont is already set.
+        // The j-th precomputed value.
+        const auto precomputed = [table, n](size_t j) noexcept {
+            return std::span<uint64_t, N>{table.subspan(j * n, n)};
+        };
+
+        // precomputed[j] = base_mont^(j+1); precomputed[0] = base_mont is already set.
         for (size_t j = 1; j < table_size; ++j)
-        {
-            const auto prev = std::span<const uint64_t, N>{table.subspan((j - 1) * n, n)};
-            const auto cur = std::span<uint64_t, N>{table.subspan(j * n, n)};
-            mul_amm<N>(cur, prev, bm, m, mod_inv);
-        }
+            mul_amm<N>(precomputed(j), precomputed(j - 1), bm, m, mod_inv);
 
         // Reads the w-bit (or fewer) window whose most-significant bit is at index `hi`.
         // TODO: A window spans at most two adjacent bytes, so it could be read with one
@@ -457,7 +460,7 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         //   exp_bits % w != 0 (up to 4%), at the cost of a special-cased final iteration.
         const size_t top_width = (exp_bits - 1) % w + 1;
         const size_t top_val = window(exp_bits - 1, top_width);
-        std::ranges::copy(table.subspan((top_val - 1) * n, n), r_cur.begin());
+        std::ranges::copy(precomputed(top_val - 1), r_cur.begin());
 
         for (size_t pos = exp_bits - top_width; pos != 0;)
         {
@@ -467,10 +470,9 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
                 mul_amm<N>(r_tmp, r_cur, r_cur, m, mod_inv);
                 std::swap(r_cur, r_tmp);
             }
-            if (const size_t v = window(pos + w - 1, w); v != 0)  // multiply by base^v
+            if (const size_t v = window(pos + w - 1, w); v != 0)  // multiply by base_mont^v
             {
-                const auto tv = std::span<const uint64_t, N>{table.subspan((v - 1) * n, n)};
-                mul_amm<N>(r_tmp, r_cur, tv, m, mod_inv);
+                mul_amm<N>(r_tmp, r_cur, precomputed(v - 1), m, mod_inv);
                 std::swap(r_cur, r_tmp);
             }
         }

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -585,11 +585,12 @@ void modexp(std::span<const uint8_t> base_bytes, std::span<const uint8_t> exp_by
 
     // Bump allocator for all working memory (values + scratch).
     // Stack buffer covers inputs up to the EIP-7823 limit (1024 bytes).
-    // Capacity: values[b+2m] + op scratch[(TABLE_MAX+4)m+3b+2] + CRT[m+2].
+    // Capacity: values[b+2m] + op scratch[(TABLE_MAX+3)m+3b+2] + CRT[m+2]
+    //         = 4b + (TABLE_MAX+6)m + 4 words.
     // The op scratch grows by the modexp_odd power table (MODEXP_TABLE_MAX*m words).
     // The worst case is an even modulus with 1 trailing zero bit (odd_size=m, pow2_size=1).
     static constexpr size_t MAX_SIZE = 1024 / sizeof(uint64_t);  // EIP-7823
-    static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + (7 + MODEXP_TABLE_MAX) * MAX_SIZE + 4;
+    static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + (6 + MODEXP_TABLE_MAX) * MAX_SIZE + 4;
     alignas(uint64_t) std::byte stack_buf[STACK_CAPACITY * sizeof(uint64_t)];
     std::pmr::monotonic_buffer_resource pool{stack_buf, sizeof(stack_buf)};
     std::pmr::polymorphic_allocator<uint64_t> alloc{&pool};

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -433,14 +433,14 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         auto r_tmp = std::span<uint64_t, N>{u.first(n)};
         const auto m = std::span<const uint64_t, N>{mod};
 
-        // base_mont^k, for k in 1..table_size.
-        const auto precomputed = [table, n](size_t k) noexcept {
-            return std::span<uint64_t, N>{table.subspan((k - 1) * n, n)};
+        // base_mont^j, for j in 1..table_size.
+        const auto precomputed = [table, n](size_t j) noexcept {
+            return std::span<uint64_t, N>{table.subspan((j - 1) * n, n)};
         };
 
         // precomputed(1) = base_mont is already set.
-        for (size_t k = 2; k <= table_size; ++k)
-            mul_amm<N>(precomputed(k), precomputed(k - 1), precomputed(1), m, mod_inv);
+        for (size_t j = 2; j <= table_size; ++j)
+            mul_amm<N>(precomputed(j), precomputed(j - 1), precomputed(1), m, mod_inv);
 
         // Reads the `width` exponent bits starting at index `lo`.
         // TODO: A window spans at most two adjacent bytes, so it could be read with one

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -368,20 +368,15 @@ template <>
     mul_amm_256(r, x, y, mod, mod_inv);
 }
 
-/// Maximum fixed-window width used by modexp_odd.
+/// Maximum window width used by the windowed method in modexp_odd.
 constexpr unsigned MAX_WINDOW_WIDTH = 4;
 
-/// Number of base powers b^1 .. b^(2^w - 1) precomputed for the widest window.
-/// Bounds the extra scratch space taken by the power table.
+/// Number of precomputed values for the max width windowed method.
 constexpr size_t MAX_PRECOMPUTED = (size_t{1} << MAX_WINDOW_WIDTH) - 1;
 
-/// Selects the fixed-window width: one multiply per w exponent bits instead of one per set
-/// bit, at the cost of a 2^w - 1 entry table. w == 1 is plain square-and-multiply.
-/// The thresholds are the break-even points for a random exponent,
-/// exp_bits = 2^w / ((1-2^-w)/w - (1-2^-(w+1))/(w+1)) ≈ 16, 48, 140 (rounded up to 144).
+/// Selects the fixed-window width off exponent bits.
 ///
-/// TODO: Switch to a sliding window, as GMP's mpn_powm and OpenSSL's BN_mod_exp_mont do:
-///   the table then holds only odd powers, half the entries per width. Measured ~3-7%.
+/// TODO: Switch to a sliding window: the table then holds only odd powers. Measured ~3-7%.
 /// TODO: Tune for the densest exponent instead of the average, because gas is charged on
 ///   exponent bit length and ignores Hamming weight. The width then collapses to
 ///   min(MAX_WINDOW_WIDTH, (bit_width(exp_bits) + 1) / 2). Measured +10.7% worst case.
@@ -437,7 +432,7 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         const auto bm = std::span<const uint64_t, N>{base_mont};
         const auto m = std::span<const uint64_t, N>{mod};
 
-        // table[j] = b^(j+1) in Montgomery form; table[0] = base_mont is already set.
+        // table[j] = base_mont^(j+1); table[0] = base_mont is already set.
         for (size_t j = 1; j < table_size; ++j)
         {
             const auto prev = std::span<const uint64_t, N>{table.subspan((j - 1) * n, n)};
@@ -472,7 +467,7 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
                 mul_amm<N>(r_tmp, r_cur, r_cur, m, mod_inv);
                 std::swap(r_cur, r_tmp);
             }
-            if (const size_t v = window(pos + w - 1, w); v != 0)  // multiply by b^v
+            if (const size_t v = window(pos + w - 1, w); v != 0)  // multiply by base^v
             {
                 const auto tv = std::span<const uint64_t, N>{table.subspan((v - 1) * n, n)};
                 mul_amm<N>(r_tmp, r_cur, tv, m, mod_inv);
@@ -600,7 +595,7 @@ void modexp(std::span<const uint8_t> base_bytes, std::span<const uint8_t> exp_by
     // Bump allocator for all working memory (values + scratch).
     // Stack buffer covers inputs up to the EIP-7823 limit (1024 bytes).
     // Capacity: values[b+2m] + op scratch[(MAX_PRECOMPUTED+3)m+3b+2] + CRT[m+2]
-    //         = 4b + (MAX_PRECOMPUTED+6)m + 4 words.
+    //           = 4b + (MAX_PRECOMPUTED+6)m + 4 words.
     // The worst case is an even modulus with 1 trailing zero bit (odd_size=m, pow2_size=1).
     static constexpr size_t MAX_SIZE = 1024 / sizeof(uint64_t);  // EIP-7823
     static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + (6 + MAX_PRECOMPUTED) * MAX_SIZE + 4;

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -433,10 +433,10 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
 
     // Double-buffer exponentiation loop, parameterized by mul_amm size.
     const auto exp_loop = [&]<size_t N>() {
-        const auto bm = std::span<const uint64_t, N>{base_mont};
-        const auto m = std::span<const uint64_t, N>{mod};
         auto r_cur = std::span<uint64_t, N>{result};
         auto r_tmp = std::span<uint64_t, N>{u.first(n)};
+        const auto bm = std::span<const uint64_t, N>{base_mont};
+        const auto m = std::span<const uint64_t, N>{mod};
 
         // table[j] = b^(j+1) in Montgomery form; table[0] = base_mont is already set.
         for (size_t j = 1; j < table_size; ++j)

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -400,6 +400,19 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     // up to 144 below; the two widths are within 0.2% of each other over 140..144).
     // A random exponent is the worst case for windowing, so this errs towards the smaller
     // window: a dense exponent would prefer the next width up at every threshold.
+    //
+    // TODO: Switch to a sliding window, as GMP's mpn_powm and OpenSSL's BN_mod_exp_mont
+    //   both do. Its table holds only the odd powers b^1, b^3 .. b^(2^w-1), so it is half
+    //   the size for a given width, which buys one extra width at the same memory.
+    //   Break-even points become 2^(w-1) / (1/(w+1) - 1/(w+2)) = 6, 24, 80, 240, 672 —
+    //   GMP's win_size() uses exactly these (7, 25, 81, 241, 673). Measured ~3-7% over
+    //   the fixed window here.
+    // TODO: Tune the thresholds for the worst case rather than the average. Gas is charged
+    //   on exponent bit length, not Hamming weight, so the costliest input at a given
+    //   charge is the densest exponent, whose break-even points are 2^w*w*(w+1) = 4, 24,
+    //   96, 320. Those have bit widths 3, 5, 7, 9, so the width collapses to a closed form,
+    //   min(MAX_WINDOW_WIDTH, (bit_width(exp_bits) + 1) / 2). Measured +10.7% worst-case
+    //   time per gas over the whole modexp benchmark matrix.
     const unsigned w = [exp_bits]() -> unsigned {
         if (exp_bits > 144)
             return MAX_WINDOW_WIDTH;
@@ -446,6 +459,13 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         }
 
         // Reads the w-bit (or fewer) window whose most-significant bit is at index `hi`.
+        // One Exponent::operator[] per exponent bit, the same count as the binary loop
+        // this replaced, so windowing added no extraction work per bit.
+        //
+        // TODO: A w <= 4 bit field spans at most two adjacent bytes, so a window could be
+        //   read with one two-byte load, a shift and a mask instead of w indexed bit
+        //   reads. Below the noise floor everywhere except the n=4 / 8192-bit corner,
+        //   where it is worth an estimated 1-3% of cycles; measure before doing it.
         const auto window = [&](size_t hi, size_t width) noexcept {
             size_t v = 0;
             for (size_t b = 0; b < width; ++b)
@@ -455,6 +475,15 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
 
         // Process the most-significant (possibly short) window first, then full
         // w-bit windows. The top bit is always set, so the first window is nonzero.
+        // This is the usual m-ary layout: windows tile from the bottom, so the ragged
+        // one lands at the top (blst's ec_mult.h does the same, "top excess bits
+        // modulo target window size").
+        //
+        // TODO: Putting the ragged window at the bottom instead would use a full-width
+        //   top window and save w - top_width squarings for the same multiply count.
+        //   Worth 0% whenever exp_bits % w == 0 (so nothing at 256/512/2048/8192 bits),
+        //   but 4.0% at exp_bits=17, 2.9% at 49, 2.0% at 33 and 1.6% at 145. Costs a
+        //   special-cased final iteration.
         const size_t top_width = (exp_bits - 1) % w + 1;
         const size_t top_val = window(exp_bits - 1, top_width);
         std::ranges::copy(table.subspan((top_val - 1) * n, n), r_cur.begin());

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -370,6 +370,11 @@ template <>
 
 /// Computes result[] = base[]^exp % mod[] for odd mod[] (mod[0] % 2 != 0).
 /// Scratch space required: 4n + 3*base.size() + 2 words, where n = mod.size().
+/// Maximum fixed-window width used by modexp_odd, and the resulting size of the
+/// precomputed power table (b^1 .. b^(2^w - 1)). Bounds the extra scratch space.
+constexpr unsigned MODEXP_WINDOW_MAX = 4;
+constexpr size_t MODEXP_TABLE_MAX = (size_t{1} << MODEXP_WINDOW_MAX) - 1;
+
 void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Exponent exp,
     std::span<const uint64_t> mod, std::span<uint64_t> scratch) noexcept
 {
@@ -380,39 +385,87 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
 
     const auto n = mod.size();
     const auto mod_inv = -evmmax::modinv(mod[0]);
+    const auto exp_bits = exp.bit_width();
 
-    // Layout: u[n+base.size()] | base_mont[n] | t/rem_scratch[max(n, 2*(n+base.size())+2)]
-    // t and rem_scratch share the same region (exclusive lifetimes).
-    assert(scratch.size() >= 4 * n + 3 * base.size() + 2);
+    // Fixed-window exponentiation width. w == 1 is plain binary square-and-multiply
+    // (no table); a wider window precomputes b^1..b^(2^w-1) once and then does one
+    // multiply per w exponent bits instead of one per set bit. The width scales with
+    // the exponent size so the table (which grows as 2^w) stays amortized even for a
+    // sparse exponent, and small exponents stay on the plain binary path.
+    const unsigned w = [exp_bits]() -> unsigned {
+        if (exp_bits > 144)
+            return MODEXP_WINDOW_MAX;
+        if (exp_bits > 48)
+            return 3;
+        if (exp_bits > 16)
+            return 2;
+        return 1;
+    }();
+    const size_t table_size = (size_t{1} << w) - 1;  // entries b^1 .. b^(2^w - 1)
 
-    // Compute base_mont = (base * R) % mod, where R = 2^(n*64).
-    // The numerator u = base << (n*64): base in the upper words, lower n words are zero.
+    // Layout: u[n+base.size()] | table[MODEXP_TABLE_MAX*n] | rem_scratch[2n+2b+2].
+    // table[0] doubles as base_mont (b^1 in Montgomery form). rem_scratch is only
+    // live during the initial to-Montgomery conversion.
+    assert(scratch.size() >= (MODEXP_TABLE_MAX + 3) * n + 3 * base.size() + 2);
     const auto u = scratch.subspan(0, n + base.size());
-    const auto base_mont = scratch.subspan(n + base.size(), n);
-    const auto rem_scratch = scratch.subspan(2 * n + base.size(), 2 * n + 2 * base.size() + 2);
+    const auto table = scratch.subspan(n + base.size(), MODEXP_TABLE_MAX * n);
+    const auto base_mont = table.first(n);
+    const auto rem_scratch =
+        scratch.subspan(n + base.size() + MODEXP_TABLE_MAX * n, 2 * n + 2 * base.size() + 2);
 
+    // Compute base_mont = table[0] = (base * R) % mod, where R = 2^(n*64).
+    // The numerator u = base << (n*64): base in the upper words, lower n words are zero.
     std::ranges::fill(u.first(n), uint64_t{0});  // Lower n words of u must be zero.
     std::ranges::copy(base, u.subspan(n).begin());
     rem(base_mont, u, mod, rem_scratch);
 
     // Double-buffer exponentiation loop, parameterized by mul_amm size.
     const auto exp_loop = [&]<size_t N>() {
-        auto r_cur = std::span<uint64_t, N>{result};
-        auto r_tmp = std::span<uint64_t, N>{u.first(n)};
         const auto bm = std::span<const uint64_t, N>{base_mont};
         const auto m = std::span<const uint64_t, N>{mod};
+        auto r_cur = std::span<uint64_t, N>{result};
+        auto r_tmp = std::span<uint64_t, N>{u.first(n)};
 
-        std::ranges::copy(bm, r_cur.begin());
-        for (auto i = exp.bit_width() - 1; i != 0; --i)
+        // Precompute the odd/all-powers table: table[j] = base^(j+1) in Montgomery
+        // form. table[0] = base_mont is already set; for w == 1 the loop is empty.
+        for (size_t j = 1; j < table_size; ++j)
         {
-            mul_amm<N>(r_tmp, r_cur, r_cur, m, mod_inv);  // Square.
-            if (exp[i - 1])
-                mul_amm<N>(r_cur, r_tmp, bm, m, mod_inv);  // Multiply.
-            else
-                std::swap(r_cur, r_tmp);
+            const auto prev = std::span<const uint64_t, N>{table.subspan((j - 1) * n, n)};
+            const auto cur = std::span<uint64_t, N>{table.subspan(j * n, n)};
+            mul_amm<N>(cur, prev, bm, m, mod_inv);  // b^(j+1) = b^j * b
         }
 
-        // Convert from Montgomery form: multiply by 1.
+        // Reads the w-bit (or fewer) window whose most-significant bit is at index `hi`.
+        const auto window = [&](size_t hi, size_t width) noexcept {
+            size_t v = 0;
+            for (size_t b = 0; b < width; ++b)
+                v = (v << 1) | (exp[hi - b] ? size_t{1} : size_t{0});
+            return v;
+        };
+
+        // Process the most-significant (possibly short) window first, then full
+        // w-bit windows. The top bit is always set, so the first window is nonzero.
+        const size_t top_width = (exp_bits - 1) % w + 1;
+        const size_t top_val = window(exp_bits - 1, top_width);
+        std::ranges::copy(table.subspan((top_val - 1) * n, n), r_cur.begin());
+
+        for (size_t pos = exp_bits - top_width; pos != 0;)
+        {
+            pos -= w;
+            for (unsigned s = 0; s != w; ++s)  // square w times
+            {
+                mul_amm<N>(r_tmp, r_cur, r_cur, m, mod_inv);
+                std::swap(r_cur, r_tmp);
+            }
+            if (const size_t v = window(pos + w - 1, w); v != 0)  // multiply by b^v
+            {
+                const auto tv = std::span<const uint64_t, N>{table.subspan((v - 1) * n, n)};
+                mul_amm<N>(r_tmp, r_cur, tv, m, mod_inv);
+                std::swap(r_cur, r_tmp);
+            }
+        }
+
+        // Convert from Montgomery form: multiply by 1. Reuses table[0] storage.
         std::ranges::fill(base_mont, uint64_t{0});
         base_mont[0] = 1;
         mul_amm<N>(r_tmp, r_cur, std::span<const uint64_t, N>{base_mont}, m, mod_inv);
@@ -531,10 +584,11 @@ void modexp(std::span<const uint8_t> base_bytes, std::span<const uint8_t> exp_by
 
     // Bump allocator for all working memory (values + scratch).
     // Stack buffer covers inputs up to the EIP-7823 limit (1024 bytes).
-    // Capacity: values[b+2m] + op scratch[4m+3b+2] + CRT[m+2] = 4b+7m+4 words.
+    // Capacity: values[b+2m] + op scratch[(TABLE_MAX+4)m+3b+2] + CRT[m+2].
+    // The op scratch grows by the modexp_odd power table (MODEXP_TABLE_MAX*m words).
     // The worst case is an even modulus with 1 trailing zero bit (odd_size=m, pow2_size=1).
     static constexpr size_t MAX_SIZE = 1024 / sizeof(uint64_t);  // EIP-7823
-    static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + 7 * MAX_SIZE + 4;
+    static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + (7 + MODEXP_TABLE_MAX) * MAX_SIZE + 4;
     alignas(uint64_t) std::byte stack_buf[STACK_CAPACITY * sizeof(uint64_t)];
     std::pmr::monotonic_buffer_resource pool{stack_buf, sizeof(stack_buf)};
     std::pmr::polymorphic_allocator<uint64_t> alloc{&pool};
@@ -578,7 +632,8 @@ void modexp(std::span<const uint8_t> base_bytes, std::span<const uint8_t> exp_by
         const auto need_crt = !pow2_is_trivial && !odd_is_trivial;
 
         // Allocate operation scratch (dead after each call, reused sequentially).
-        const size_t odd_scratch = !odd_is_trivial ? 4 * odd_size + 3 * base.size() + 2 : 0;
+        const size_t odd_scratch =
+            !odd_is_trivial ? (MODEXP_TABLE_MAX + 3) * odd_size + 3 * base.size() + 2 : 0;
         const size_t pow2_scratch = !pow2_is_trivial ? pow2_size : 0;
         const size_t inv_scratch = need_crt ? 2 * pow2_size : 0;
         const size_t op_scratch_size = std::max({odd_scratch, pow2_scratch, inv_scratch});

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -280,8 +280,8 @@ public:
 
     [[nodiscard]] size_t bit_width() const noexcept { return bit_width_; }
 
-    /// Returns the bit value of the exponent at the given index, counting from the most significant
-    /// bit (e[0] is the top bit).
+    /// Returns the bit value of the exponent at the given index, counting from the least
+    /// significant bit (e[0] is the bottom bit, e[bit_width() - 1] is the top bit, always set).
     bool operator[](size_t index) const noexcept
     {
         // TODO: Replace this with a custom iterator type.

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -368,13 +368,15 @@ template <>
     mul_amm_256(r, x, y, mod, mod_inv);
 }
 
-/// Maximum fixed-window width used by modexp_odd, and the resulting size of the
-/// precomputed power table (b^1 .. b^(2^w - 1)). Bounds the extra scratch space.
-constexpr unsigned MODEXP_WINDOW_MAX = 4;
-constexpr size_t MODEXP_TABLE_MAX = (size_t{1} << MODEXP_WINDOW_MAX) - 1;
+/// Maximum fixed-window width used by modexp_odd.
+constexpr unsigned MAX_WINDOW_WIDTH = 4;
+
+/// Number of base powers b^1 .. b^(2^w - 1) precomputed for the widest window.
+/// Bounds the extra scratch space taken by the power table.
+constexpr size_t MAX_PRECOMPUTED = (size_t{1} << MAX_WINDOW_WIDTH) - 1;
 
 /// Computes result[] = base[]^exp % mod[] for odd mod[] (mod[0] % 2 != 0).
-/// Scratch space required: (MODEXP_TABLE_MAX + 3)*n + 3*base.size() + 2 words,
+/// Scratch space required: (MAX_PRECOMPUTED + 3)*n + 3*base.size() + 2 words,
 /// where n = mod.size().
 void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Exponent exp,
     std::span<const uint64_t> mod, std::span<uint64_t> scratch) noexcept
@@ -395,7 +397,7 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     // sparse exponent, and small exponents stay on the plain binary path.
     const unsigned w = [exp_bits]() -> unsigned {
         if (exp_bits > 144)
-            return MODEXP_WINDOW_MAX;
+            return MAX_WINDOW_WIDTH;
         if (exp_bits > 48)
             return 3;
         if (exp_bits > 16)
@@ -404,15 +406,15 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     }();
     const size_t table_size = (size_t{1} << w) - 1;  // entries b^1 .. b^(2^w - 1)
 
-    // Layout: u[n+base.size()] | table[MODEXP_TABLE_MAX*n] | rem_scratch[2n+2b+2].
+    // Layout: u[n+base.size()] | table[MAX_PRECOMPUTED*n] | rem_scratch[2n+2b+2].
     // table[0] doubles as base_mont (b^1 in Montgomery form). rem_scratch is only
     // live during the initial to-Montgomery conversion.
-    assert(scratch.size() >= (MODEXP_TABLE_MAX + 3) * n + 3 * base.size() + 2);
+    assert(scratch.size() >= (MAX_PRECOMPUTED + 3) * n + 3 * base.size() + 2);
     const auto u = scratch.subspan(0, n + base.size());
-    const auto table = scratch.subspan(n + base.size(), MODEXP_TABLE_MAX * n);
+    const auto table = scratch.subspan(n + base.size(), MAX_PRECOMPUTED * n);
     const auto base_mont = table.first(n);
     const auto rem_scratch =
-        scratch.subspan(n + base.size() + MODEXP_TABLE_MAX * n, 2 * n + 2 * base.size() + 2);
+        scratch.subspan(n + base.size() + MAX_PRECOMPUTED * n, 2 * n + 2 * base.size() + 2);
 
     // Compute base_mont = table[0] = (base * R) % mod, where R = 2^(n*64).
     // The numerator u = base << (n*64): base in the upper words, lower n words are zero.
@@ -585,12 +587,12 @@ void modexp(std::span<const uint8_t> base_bytes, std::span<const uint8_t> exp_by
 
     // Bump allocator for all working memory (values + scratch).
     // Stack buffer covers inputs up to the EIP-7823 limit (1024 bytes).
-    // Capacity: values[b+2m] + op scratch[(TABLE_MAX+3)m+3b+2] + CRT[m+2]
-    //         = 4b + (TABLE_MAX+6)m + 4 words.
-    // The op scratch grows by the modexp_odd power table (MODEXP_TABLE_MAX*m words).
+    // Capacity: values[b+2m] + op scratch[(MAX_PRECOMPUTED+3)m+3b+2] + CRT[m+2]
+    //         = 4b + (MAX_PRECOMPUTED+6)m + 4 words.
+    // The op scratch grows by the modexp_odd power table (MAX_PRECOMPUTED*m words).
     // The worst case is an even modulus with 1 trailing zero bit (odd_size=m, pow2_size=1).
     static constexpr size_t MAX_SIZE = 1024 / sizeof(uint64_t);  // EIP-7823
-    static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + (6 + MODEXP_TABLE_MAX) * MAX_SIZE + 4;
+    static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + (6 + MAX_PRECOMPUTED) * MAX_SIZE + 4;
     alignas(uint64_t) std::byte stack_buf[STACK_CAPACITY * sizeof(uint64_t)];
     std::pmr::monotonic_buffer_resource pool{stack_buf, sizeof(stack_buf)};
     std::pmr::polymorphic_allocator<uint64_t> alloc{&pool};
@@ -635,7 +637,7 @@ void modexp(std::span<const uint8_t> base_bytes, std::span<const uint8_t> exp_by
 
         // Allocate operation scratch (dead after each call, reused sequentially).
         const size_t odd_scratch =
-            !odd_is_trivial ? (MODEXP_TABLE_MAX + 3) * odd_size + 3 * base.size() + 2 : 0;
+            !odd_is_trivial ? (MAX_PRECOMPUTED + 3) * odd_size + 3 * base.size() + 2 : 0;
         const size_t pow2_scratch = !pow2_is_trivial ? pow2_size : 0;
         const size_t inv_scratch = need_crt ? 2 * pow2_size : 0;
         const size_t op_scratch_size = std::max({odd_scratch, pow2_scratch, inv_scratch});

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -392,9 +392,13 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
 
     // Fixed-window exponentiation width. w == 1 is plain binary square-and-multiply
     // (no table); a wider window precomputes b^1..b^(2^w-1) once and then does one
-    // multiply per w exponent bits instead of one per set bit. The width scales with
-    // the exponent size so the table (which grows as 2^w) stays amortized even for a
-    // sparse exponent, and small exponents stay on the plain binary path.
+    // multiply per w exponent bits instead of one per set bit.
+    //
+    // The thresholds are the break-even points for a random exponent, where the 2^w extra
+    // table multiplies stop being repaid by the sparser multiplies in the loop:
+    // exp_bits = 2^w / ((1-2^-w)/w - (1-2^-(w+1))/(w+1)), giving 16, 48 and 140.
+    // A random exponent is the worst case for windowing, so this errs towards the smaller
+    // window: a dense exponent would prefer the next width up at every threshold.
     const unsigned w = [exp_bits]() -> unsigned {
         if (exp_bits > 144)
             return MAX_WINDOW_WIDTH;

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -387,18 +387,17 @@ constexpr size_t MAX_PRECOMPUTED = (size_t{1} << MAX_WINDOW_WIDTH) - 1;
 ///   min(MAX_WINDOW_WIDTH, (bit_width(exp_bits) + 1) / 2). Measured +10.7% worst case.
 constexpr unsigned window_width(size_t exp_bits) noexcept
 {
-    if (exp_bits > 144)
-        return MAX_WINDOW_WIDTH;
-    if (exp_bits > 48)
-        return 3;
-    if (exp_bits > 16)
+    if (exp_bits <= 16)
+        return 1;
+    if (exp_bits <= 48)
         return 2;
-    return 1;
+    if (exp_bits <= 144)
+        return 3;
+    return MAX_WINDOW_WIDTH;
 }
 
 /// Computes result[] = base[]^exp % mod[] for odd mod[] (mod[0] % 2 != 0).
-/// Scratch space required: (MAX_PRECOMPUTED + 3)*n + 3*base.size() + 2 words,
-/// where n = mod.size().
+/// Scratch space required: (MAX_PRECOMPUTED + 3)*mod.size() + 3*base.size() + 2 words.
 void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Exponent exp,
     std::span<const uint64_t> mod, std::span<uint64_t> scratch) noexcept
 {
@@ -412,7 +411,7 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     const auto exp_bits = exp.bit_width();
 
     const auto w = window_width(exp_bits);
-    const size_t table_size = (size_t{1} << w) - 1;
+    const auto table_size = (size_t{1} << w) - 1;
 
     // Layout: u[n + base.size()] | table[MAX_PRECOMPUTED*n]
     //       | rem_scratch[2*n + 2*base.size() + 2].

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -375,6 +375,27 @@ constexpr unsigned MAX_WINDOW_WIDTH = 4;
 /// Bounds the extra scratch space taken by the power table.
 constexpr size_t MAX_PRECOMPUTED = (size_t{1} << MAX_WINDOW_WIDTH) - 1;
 
+/// Selects the fixed-window width: one multiply per w exponent bits instead of one per set
+/// bit, at the cost of a 2^w - 1 entry table. w == 1 is plain square-and-multiply.
+/// The thresholds are the break-even points for a random exponent,
+/// exp_bits = 2^w / ((1-2^-w)/w - (1-2^-(w+1))/(w+1)) ≈ 16, 48, 140 (rounded up to 144).
+///
+/// TODO: Switch to a sliding window, as GMP's mpn_powm and OpenSSL's BN_mod_exp_mont do:
+///   the table then holds only odd powers, half the entries per width. Measured ~3-7%.
+/// TODO: Tune for the densest exponent instead of the average, because gas is charged on
+///   exponent bit length and ignores Hamming weight. The width then collapses to
+///   min(MAX_WINDOW_WIDTH, (bit_width(exp_bits) + 1) / 2). Measured +10.7% worst case.
+constexpr unsigned window_width(size_t exp_bits) noexcept
+{
+    if (exp_bits > 144)
+        return MAX_WINDOW_WIDTH;
+    if (exp_bits > 48)
+        return 3;
+    if (exp_bits > 16)
+        return 2;
+    return 1;
+}
+
 /// Computes result[] = base[]^exp % mod[] for odd mod[] (mod[0] % 2 != 0).
 /// Scratch space required: (MAX_PRECOMPUTED + 3)*n + 3*base.size() + 2 words,
 /// where n = mod.size().
@@ -390,45 +411,13 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     const auto mod_inv = -evmmax::modinv(mod[0]);
     const auto exp_bits = exp.bit_width();
 
-    // Fixed-window exponentiation width. w == 1 is plain binary square-and-multiply
-    // (no table); a wider window precomputes b^1..b^(2^w-1) once and then does one
-    // multiply per w exponent bits instead of one per set bit.
-    //
-    // The thresholds are the break-even points for a random exponent, where the 2^w extra
-    // table multiplies stop being repaid by the sparser multiplies in the loop:
-    // exp_bits = 2^w / ((1-2^-w)/w - (1-2^-(w+1))/(w+1)), giving 16, 48 and 140 (rounded
-    // up to 144 below; the two widths are within 0.2% of each other over 140..144).
-    // A random exponent is the worst case for windowing, so this errs towards the smaller
-    // window: a dense exponent would prefer the next width up at every threshold.
-    //
-    // TODO: Switch to a sliding window, as GMP's mpn_powm and OpenSSL's BN_mod_exp_mont
-    //   both do. Its table holds only the odd powers b^1, b^3 .. b^(2^w-1), so it is half
-    //   the size for a given width, which buys one extra width at the same memory.
-    //   Break-even points become 2^(w-1) / (1/(w+1) - 1/(w+2)) = 6, 24, 80, 240, 672 —
-    //   GMP's win_size() uses exactly these (7, 25, 81, 241, 673). Measured ~3-7% over
-    //   the fixed window here.
-    // TODO: Tune the thresholds for the worst case rather than the average. Gas is charged
-    //   on exponent bit length, not Hamming weight, so the costliest input at a given
-    //   charge is the densest exponent, whose break-even points are 2^w*w*(w+1) = 4, 24,
-    //   96, 320. Those have bit widths 3, 5, 7, 9, so the width collapses to a closed form,
-    //   min(MAX_WINDOW_WIDTH, (bit_width(exp_bits) + 1) / 2). Measured +10.7% worst-case
-    //   time per gas over the whole modexp benchmark matrix.
-    const unsigned w = [exp_bits]() -> unsigned {
-        if (exp_bits > 144)
-            return MAX_WINDOW_WIDTH;
-        if (exp_bits > 48)
-            return 3;
-        if (exp_bits > 16)
-            return 2;
-        return 1;
-    }();
-    const size_t table_size = (size_t{1} << w) - 1;  // entries b^1 .. b^(2^w - 1)
+    const auto w = window_width(exp_bits);
+    const size_t table_size = (size_t{1} << w) - 1;
 
     // Layout: u[n + base.size()] | table[MAX_PRECOMPUTED*n]
     //       | rem_scratch[2*n + 2*base.size() + 2].
-    // table[0] doubles as base_mont (b^1 in Montgomery form). Both u and rem_scratch are
-    // dead after the to-Montgomery conversion, and u's first n words are then reused as
-    // the exponentiation double-buffer.
+    // u and rem_scratch are dead after the to-Montgomery conversion; u's first n words are
+    // then reused as the exponentiation double-buffer.
     assert(scratch.size() >= (MAX_PRECOMPUTED + 3) * n + 3 * base.size() + 2);
     const auto u = scratch.subspan(0, n + base.size());
     const auto table = scratch.subspan(n + base.size(), MAX_PRECOMPUTED * n);
@@ -449,23 +438,18 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         auto r_cur = std::span<uint64_t, N>{result};
         auto r_tmp = std::span<uint64_t, N>{u.first(n)};
 
-        // Precompute the power table: table[j] = base^(j+1) in Montgomery form, i.e. all
-        // of b^1..b^(2^w-1). table[0] = base_mont is already set; empty for w == 1.
+        // table[j] = b^(j+1) in Montgomery form; table[0] = base_mont is already set.
         for (size_t j = 1; j < table_size; ++j)
         {
             const auto prev = std::span<const uint64_t, N>{table.subspan((j - 1) * n, n)};
             const auto cur = std::span<uint64_t, N>{table.subspan(j * n, n)};
-            mul_amm<N>(cur, prev, bm, m, mod_inv);  // b^(j+1) = b^j * b
+            mul_amm<N>(cur, prev, bm, m, mod_inv);
         }
 
         // Reads the w-bit (or fewer) window whose most-significant bit is at index `hi`.
-        // One Exponent::operator[] per exponent bit, the same count as the binary loop
-        // this replaced, so windowing added no extraction work per bit.
-        //
-        // TODO: A w <= 4 bit field spans at most two adjacent bytes, so a window could be
-        //   read with one two-byte load, a shift and a mask instead of w indexed bit
-        //   reads. Below the noise floor everywhere except the n=4 / 8192-bit corner,
-        //   where it is worth an estimated 1-3% of cycles; measure before doing it.
+        // TODO: A window spans at most two adjacent bytes, so it could be read with one
+        //   two-byte load, a shift and a mask. Est. 1-3%, and only for a 4-word modulus
+        //   with a very long exponent; measure before doing it.
         const auto window = [&](size_t hi, size_t width) noexcept {
             size_t v = 0;
             for (size_t b = 0; b < width; ++b)
@@ -473,17 +457,10 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
             return v;
         };
 
-        // Process the most-significant (possibly short) window first, then full
-        // w-bit windows. The top bit is always set, so the first window is nonzero.
-        // This is the usual m-ary layout: windows tile from the bottom, so the ragged
-        // one lands at the top (blst's ec_mult.h does the same, "top excess bits
-        // modulo target window size").
-        //
-        // TODO: Putting the ragged window at the bottom instead would use a full-width
-        //   top window and save w - top_width squarings for the same multiply count.
-        //   Worth 0% whenever exp_bits % w == 0 (so nothing at 256/512/2048/8192 bits),
-        //   but 4.0% at exp_bits=17, 2.9% at 49, 2.0% at 33 and 1.6% at 145. Costs a
-        //   special-cased final iteration.
+        // Windows tile from the bottom, so the ragged one is processed first, at the top.
+        // The top bit is always set, so that first window is nonzero.
+        // TODO: Tiling from the top instead would save w - top_width squarings when
+        //   exp_bits % w != 0 (up to 4%), at the cost of a special-cased final iteration.
         const size_t top_width = (exp_bits - 1) % w + 1;
         const size_t top_val = window(exp_bits - 1, top_width);
         std::ranges::copy(table.subspan((top_val - 1) * n, n), r_cur.begin());
@@ -625,7 +602,6 @@ void modexp(std::span<const uint8_t> base_bytes, std::span<const uint8_t> exp_by
     // Stack buffer covers inputs up to the EIP-7823 limit (1024 bytes).
     // Capacity: values[b+2m] + op scratch[(MAX_PRECOMPUTED+3)m+3b+2] + CRT[m+2]
     //         = 4b + (MAX_PRECOMPUTED+6)m + 4 words.
-    // The op scratch grows by the modexp_odd power table (MAX_PRECOMPUTED*m words).
     // The worst case is an even modulus with 1 trailing zero bit (odd_size=m, pow2_size=1).
     static constexpr size_t MAX_SIZE = 1024 / sizeof(uint64_t);  // EIP-7823
     static constexpr size_t STACK_CAPACITY = 4 * MAX_SIZE + (6 + MAX_PRECOMPUTED) * MAX_SIZE + 4;

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -368,13 +368,14 @@ template <>
     mul_amm_256(r, x, y, mod, mod_inv);
 }
 
-/// Computes result[] = base[]^exp % mod[] for odd mod[] (mod[0] % 2 != 0).
-/// Scratch space required: 4n + 3*base.size() + 2 words, where n = mod.size().
 /// Maximum fixed-window width used by modexp_odd, and the resulting size of the
 /// precomputed power table (b^1 .. b^(2^w - 1)). Bounds the extra scratch space.
 constexpr unsigned MODEXP_WINDOW_MAX = 4;
 constexpr size_t MODEXP_TABLE_MAX = (size_t{1} << MODEXP_WINDOW_MAX) - 1;
 
+/// Computes result[] = base[]^exp % mod[] for odd mod[] (mod[0] % 2 != 0).
+/// Scratch space required: (MODEXP_TABLE_MAX + 3)*n + 3*base.size() + 2 words,
+/// where n = mod.size().
 void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Exponent exp,
     std::span<const uint64_t> mod, std::span<uint64_t> scratch) noexcept
 {

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -396,7 +396,8 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     //
     // The thresholds are the break-even points for a random exponent, where the 2^w extra
     // table multiplies stop being repaid by the sparser multiplies in the loop:
-    // exp_bits = 2^w / ((1-2^-w)/w - (1-2^-(w+1))/(w+1)), giving 16, 48 and 140.
+    // exp_bits = 2^w / ((1-2^-w)/w - (1-2^-(w+1))/(w+1)), giving 16, 48 and 140 (rounded
+    // up to 144 below; the two widths are within 0.2% of each other over 140..144).
     // A random exponent is the worst case for windowing, so this errs towards the smaller
     // window: a dense exponent would prefer the next width up at every threshold.
     const unsigned w = [exp_bits]() -> unsigned {
@@ -410,9 +411,11 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     }();
     const size_t table_size = (size_t{1} << w) - 1;  // entries b^1 .. b^(2^w - 1)
 
-    // Layout: u[n+base.size()] | table[MAX_PRECOMPUTED*n] | rem_scratch[2n+2b+2].
-    // table[0] doubles as base_mont (b^1 in Montgomery form). rem_scratch is only
-    // live during the initial to-Montgomery conversion.
+    // Layout: u[n + base.size()] | table[MAX_PRECOMPUTED*n]
+    //       | rem_scratch[2*n + 2*base.size() + 2].
+    // table[0] doubles as base_mont (b^1 in Montgomery form). Both u and rem_scratch are
+    // dead after the to-Montgomery conversion, and u's first n words are then reused as
+    // the exponentiation double-buffer.
     assert(scratch.size() >= (MAX_PRECOMPUTED + 3) * n + 3 * base.size() + 2);
     const auto u = scratch.subspan(0, n + base.size());
     const auto table = scratch.subspan(n + base.size(), MAX_PRECOMPUTED * n);
@@ -433,8 +436,8 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
         auto r_cur = std::span<uint64_t, N>{result};
         auto r_tmp = std::span<uint64_t, N>{u.first(n)};
 
-        // Precompute the odd/all-powers table: table[j] = base^(j+1) in Montgomery
-        // form. table[0] = base_mont is already set; for w == 1 the loop is empty.
+        // Precompute the power table: table[j] = base^(j+1) in Montgomery form, i.e. all
+        // of b^1..b^(2^w-1). table[0] = base_mont is already set; empty for w == 1.
         for (size_t j = 1; j < table_size; ++j)
         {
             const auto prev = std::span<const uint64_t, N>{table.subspan((j - 1) * n, n)};

--- a/test/unittests/precompiles_expmod_test.cpp
+++ b/test/unittests/precompiles_expmod_test.cpp
@@ -338,6 +338,11 @@ TEST_P(expmod, inputs)
         {"03", "0802ae8d294c48793907af3e71b536ed84fa84",
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
             "40c2770e749bcbf7949855252da0258cc5ae80658427a4af8ba3489a81182ee9"},
+        // Same, with a 5-word modulus: the windowed loop above only ever runs through the
+        // mul_amm<4> specialization, this covers the generic instantiation.
+        {"03", "08f83d563ebc382e09e4b8245edebc817af708",
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "8016137e4c542dd66f4ab5f668fc0ac76d43353a675f3d4616a56f23757e463ca1093164385ef006"},
     };
 
     for (const auto& [base_hex, exp_hex, mod_hex, expected_result_hex] : test_cases)

--- a/test/unittests/precompiles_expmod_test.cpp
+++ b/test/unittests/precompiles_expmod_test.cpp
@@ -455,3 +455,56 @@ TEST(expmod, huge_inputs_analysis)
         EXPECT_EQ(max_output_size, expected_output_size);
     }
 }
+
+#ifdef EVMONE_PRECOMPILES_GMP
+namespace
+{
+/// Runs modexp through a specific implementation and returns the result bytes.
+evmc::bytes run_expmod(
+    ExpmodExecuteFn fn, const evmc::bytes& base, const evmc::bytes& exp, const evmc::bytes& mod)
+{
+    evmc::bytes input(3 * 32, 0);
+    using namespace intx;
+    be::unsafe::store(&input[0], uint256{base.size()});
+    be::unsafe::store(&input[32], uint256{exp.size()});
+    be::unsafe::store(&input[64], uint256{mod.size()});
+    input += base;
+    input += exp;
+    input += mod;
+    evmc::bytes result(mod.size(), 0xfe);
+    const auto [status, output_size] = fn(input.data(), input.size(), result.data(), result.size());
+    EXPECT_EQ(status, EVMC_SUCCESS);
+    EXPECT_EQ(output_size, mod.size());
+    return result;
+}
+}  // namespace
+
+// Differential test for the fixed-window exponentiation in modexp_odd: exercises
+// many exponent bit-lengths (crossing the binary<->window threshold) and bit
+// patterns (all window values) against the GMP reference, for odd and even moduli.
+TEST(expmod, windowing_vs_gmp)
+{
+    const auto base = make_val(32, 0xab, 0xcd, 0xa5);
+    for (const auto& mod : {
+             make_val(32, 0xff, 0xff, 0xff),  // 2^256-1 (odd: direct window path)
+             make_val(32, 0xff, 0xfe, 0xff),  // even (odd part via CRT still windows)
+         })
+    {
+        for (size_t size = 2; size <= 40; ++size)  // exponent 16..320 bits
+        {
+            for (const uint8_t msb : {uint8_t{0x01}, uint8_t{0x80}, uint8_t{0xff}})
+            {
+                for (const uint8_t fill : {uint8_t{0x00}, uint8_t{0xa5}, uint8_t{0xff}})
+                {
+                    const auto exp = make_val(size, msb, 0x01, fill);
+                    const auto ev =
+                        run_expmod(&evmone::state::expmod_execute_evmone, base, exp, mod);
+                    const auto gm = run_expmod(&evmone::state::expmod_execute_gmp, base, exp, mod);
+                    EXPECT_EQ(ev, gm)
+                        << "exp_size=" << size << " msb=" << +msb << " fill=" << +fill;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/test/unittests/precompiles_expmod_test.cpp
+++ b/test/unittests/precompiles_expmod_test.cpp
@@ -290,6 +290,54 @@ TEST_P(expmod, inputs)
         {"02", "80", "0300000000000000000000000000000000", "0100000000000000000000000000000000"},
         // 2^129 mod (7 * 2^128): carry propagates and is absorbed in nonzero word.
         {"02", "0081", "0700000000000000000000000000000000", "0200000000000000000000000000000000"},
+
+        // Fixed-window exponentiation in modexp_odd. One case per window width w, and
+        // per width of the leading partial window ((exp_bits - 1) % w + 1), which is what
+        // aligns the remaining windows. The exponents are picked so that the windows
+        // consumed cover 0 (multiply skipped), 1 and 2^w - 1 (first and last precomputed
+        // power). Modulus is the secp256k1 field prime: odd, 4 words, so these also cover
+        // the mul_amm<4> specialization.
+        // exp_bits=16, w=1: plain binary square-and-multiply, no table.
+        {"03", "8005", "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "79c4559d064ab3615f6da729a1f67265b88ee2eaba22838109bea30fb7bee31b"},
+        // exp_bits=17, w=2, leading window 1 bit.
+        {"03", "01001b", "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "a890a61d8d745fae67a345fb031b048c0cf8952b43622263de0fdc4391a6c6a9"},
+        // exp_bits=18, w=2, leading window 2 bits.
+        {"03", "0200c9", "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "600614416289329cf72ef906cdfc1dea20339051ec80ed3ff692eb14ed33be81"},
+        // exp_bits=48, w=2: last exponent size before w becomes 3.
+        {"03", "80013b71b865", "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "fd66fdbe1f0c43e6640c121c366b9061c7f13964a572828c8e3968a50dba847f"},
+        // exp_bits=49, w=3, leading window 1 bit.
+        {"03", "0100d2c92fc182", "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "651aace134976d8456fcc35686a57cf12670b2e596dabecd0ddae9984ced96c4"},
+        // exp_bits=50, w=3, leading window 2 bits.
+        {"03", "0200a6a7ef231d", "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "f722a91e1faa3b57f0a19af8d4506b395a0a342e9ee2cbe65cd7a63155d38537"},
+        // exp_bits=51, w=3, leading window 3 bits.
+        {"03", "04013929f7999c", "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "06f41e370c4ef45a2bc5e1ade1504fbe35e5a42a8f8c2b17ad16a6c657900d48"},
+        // exp_bits=144, w=3: last exponent size before w becomes 4.
+        {"03", "8004cb3ff13151bb9f84a488a5d62e79a680",
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "97265df41405de7f9b35c1037c349ef367cffd34ed6a86cb933fe14f84bb12d1"},
+        // exp_bits=145, w=4, leading window 1 bit.
+        {"03", "010014b0a1922289f0b19f56c6c373b0e5cd4a",
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "3587c0d41ce1eb59ec2fa686877d8166aa9740f2410f9271592e5f283e3bd738"},
+        // exp_bits=146, w=4, leading window 2 bits.
+        {"03", "02008d61508c16734bdbe4a9578f4c8185d260",
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "f65d573e0ba5bdc7cc0e31072eb946ffe5138d0cd4bc936cc1a714d17cdaf954"},
+        // exp_bits=147, w=4, leading window 3 bits.
+        {"03", "040160dce60c2531e93ae750b53938d5b04faf",
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "0648a7caabfd3d4b972c034830faf933179ed038e1e6a6c4c3ad26f330fe1397"},
+        // exp_bits=148, w=4, leading window 4 bits.
+        {"03", "0802ae8d294c48793907af3e71b536ed84fa84",
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            "40c2770e749bcbf7949855252da0258cc5ae80658427a4af8ba3489a81182ee9"},
     };
 
     for (const auto& [base_hex, exp_hex, mod_hex, expected_result_hex] : test_cases)
@@ -455,56 +503,3 @@ TEST(expmod, huge_inputs_analysis)
         EXPECT_EQ(max_output_size, expected_output_size);
     }
 }
-
-#ifdef EVMONE_PRECOMPILES_GMP
-namespace
-{
-/// Runs modexp through a specific implementation and returns the result bytes.
-evmc::bytes run_expmod(
-    ExpmodExecuteFn fn, const evmc::bytes& base, const evmc::bytes& exp, const evmc::bytes& mod)
-{
-    evmc::bytes input(3 * 32, 0);
-    using namespace intx;
-    be::unsafe::store(&input[0], uint256{base.size()});
-    be::unsafe::store(&input[32], uint256{exp.size()});
-    be::unsafe::store(&input[64], uint256{mod.size()});
-    input += base;
-    input += exp;
-    input += mod;
-    evmc::bytes result(mod.size(), 0xfe);
-    const auto [status, output_size] = fn(input.data(), input.size(), result.data(), result.size());
-    EXPECT_EQ(status, EVMC_SUCCESS);
-    EXPECT_EQ(output_size, mod.size());
-    return result;
-}
-}  // namespace
-
-// Differential test for the fixed-window exponentiation in modexp_odd: exercises
-// many exponent bit-lengths (crossing the binary<->window threshold) and bit
-// patterns (all window values) against the GMP reference, for odd and even moduli.
-TEST(expmod, windowing_vs_gmp)
-{
-    const auto base = make_val(32, 0xab, 0xcd, 0xa5);
-    for (const auto& mod : {
-             make_val(32, 0xff, 0xff, 0xff),  // 2^256-1 (odd: direct window path)
-             make_val(32, 0xff, 0xfe, 0xff),  // even (odd part via CRT still windows)
-         })
-    {
-        for (size_t size = 2; size <= 40; ++size)  // exponent 16..320 bits
-        {
-            for (const uint8_t msb : {uint8_t{0x01}, uint8_t{0x80}, uint8_t{0xff}})
-            {
-                for (const uint8_t fill : {uint8_t{0x00}, uint8_t{0xa5}, uint8_t{0xff}})
-                {
-                    const auto exp = make_val(size, msb, 0x01, fill);
-                    const auto ev =
-                        run_expmod(&evmone::state::expmod_execute_evmone, base, exp, mod);
-                    const auto gm = run_expmod(&evmone::state::expmod_execute_gmp, base, exp, mod);
-                    EXPECT_EQ(ev, gm)
-                        << "exp_size=" << size << " msb=" << +msb << " fill=" << +fill;
-                }
-            }
-        }
-    }
-}
-#endif


### PR DESCRIPTION
## Summary

`modexp_odd` uses binary square-and-multiply — one Montgomery multiply per set exponent bit. For large exponents that is roughly twice the multiplies a windowed method needs.

This precomputes a small table of base powers (`b^1 .. b^(2^w - 1)` in Montgomery form) and consumes `w` exponent bits per multiply. The window width scales with the exponent size so the table cost stays amortized even for a sparse exponent:

- `w = 1` (plain binary, no table) for exponents ≤ 16 bits;
- `w = 2` up to 48 bits, `w = 3` up to 144 bits, `w = 4` above.

With `w = 1` the loop is byte-for-byte the previous binary square-and-multiply.

## Benchmarks

`evmone-precompiles-bench --benchmark_filter='modexp<expmod_execute_evmone>'`, AMD EPYC 4344P, gcc 15.2.0, Release:

| case | before | after | speedup |
|---|--:|--:|--:|
| mod_len:32 / exp_bits:256 | 19,604 ns | 12,904 ns | 1.52x |
| mod_len:32 / exp_bits:8192 | 650,488 ns | 419,503 ns | 1.55x |
| mod_len:504 / exp_bits:255 | 2,868,036 ns | 1,869,504 ns | 1.53x |
| mod_len:512 / exp_bits:8192 | 96,520,499 ns | 60,619,147 ns | 1.59x |
| mod_len:32 / exp_bits:33 | 2,582 ns | 2,089 ns | 1.24x |

Small exponents (≤ 16 bits) are unchanged; none regress.

## Cost

The power table adds `MODEXP_TABLE_MAX * n` words to the stack scratch buffer (`STACK_CAPACITY` and the `modexp_odd` scratch requirement are updated). At the EIP-7823 limit (`n = 128` words) that is ~15 KB of additional stack in the single modexp frame.

The window widths and thresholds are simple, conservative choices; happy to tune them or switch to a sliding window (odd-power table, ~half the entries) if preferred.

## Correctness

Adds `expmod.windowing_vs_gmp`: a differential test comparing evmone against GMP across many exponent bit-lengths (crossing the window-width thresholds) and bit patterns (all window values), for odd and even moduli. Existing `expmod` vectors and `large_inputs` continue to pass.
