### PR TITLE
Build the cryptography code with -O1 in Debug configurations

### DIFF
--- a/lib/evmone_precompiles/CMakeLists.txt
+++ b/lib/evmone_precompiles/CMakeLists.txt
@@ -42,3 +42,9 @@ target_sources(
     kzg_precomputed_lines.hpp
     kzg_precomputed_lines.cpp
 )
+
+# Enable optimizations in the cryptography code also in Debug builds, otherwise it is very slow.
+target_compile_options(
+    evmone_precompiles PRIVATE
+    $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:-O1>
+)


### PR DESCRIPTION
The 256-bit field arithmetic behind the precompiles is unusable when it is not optimized: a secp256k1 signature recovery takes ~16 ms at `-O0` against ~0.3 ms at `-O1`, a factor of 48. Nothing steps into this code with a debugger, but every Debug and sanitizer run of the test suites pays for it, and the tests that recover a sender per transaction pay it thousands of times.

Measured on the Cancun state tests (2339 cases, one signature recovery each) in a Debug build, user CPU time:

| precompiles | time |
|---|---|
| `-O0` | 273.6 s |
| `-O1` | 238.9 s |

The 34.7 s saved is 14.8 ms per case, matching the ~16 ms per recovery measured directly.

The option is appended after the configuration's own flags, so it wins for Debug, which sets no `-O` at all, and the generator expression leaves the optimized configurations untouched. It is scoped to the `evmone_precompiles` target alone: `lib/evmone` and every other target keep their configuration's flags unchanged. The `gcc-latest-memcheck` job already builds Debug with `-O1` for the same reason.
