### PR TITLE
test: Unify the JSON loaders' optional-key helper

### DIFF
--- a/test/unittests/statetest_loader_block_info_test.cpp
+++ b/test/unittests/statetest_loader_block_info_test.cpp
@@ -299,6 +299,32 @@ TEST(statetest_loader, block_info_current_blob_gas)
     EXPECT_EQ(bi.excess_blob_gas, 2);
 }
 
+TEST(statetest_loader, block_info_blob_gas_used)
+{
+    constexpr std::string_view absent_input = R"({
+        "currentNumber": "0",
+        "currentTimestamp": "0",
+        "currentGasLimit": "0",
+        "currentCoinbase": ""
+    })";
+    constexpr std::string_view zero_input = R"({
+        "currentNumber": "0",
+        "currentTimestamp": "0",
+        "currentGasLimit": "0",
+        "currentCoinbase": "",
+        "blobGasUsed": "0"
+    })";
+
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
+
+    // An absent "blobGasUsed" must leave the optional disengaged, not engage it with zero.
+    EXPECT_FALSE(test::from_json_with_rev(json::json::parse(absent_input), EVMC_CANCUN, blob_params)
+            .blob_gas_used.has_value());
+    EXPECT_EQ(test::from_json_with_rev(json::json::parse(zero_input), EVMC_CANCUN, blob_params)
+                  .blob_gas_used,
+        0);
+}
+
 TEST(statetest_loader, block_info_parent_beacon_block_root)
 {
     constexpr std::string_view input = R"({

--- a/test/utils/blockchaintest_loader.cpp
+++ b/test/utils/blockchaintest_loader.cpp
@@ -10,24 +10,6 @@
 namespace evmone::test
 {
 
-namespace
-{
-template <typename T>
-T load_if_exists(const json::json& j, std::string_view key)
-{
-    if (const auto it = j.find(key); it != j.end())
-        return from_json<T>(*it);
-    return {};
-}
-template <typename T>
-std::optional<T> load_optional(const json::json& j, std::string_view key)
-{
-    if (const auto it = j.find(key); it != j.end())
-        return from_json<T>(*it);
-    return std::nullopt;
-}
-}  // namespace
-
 template <>
 BlockHeader from_json<BlockHeader>(const json::json& j)
 {
@@ -37,22 +19,22 @@ BlockHeader from_json<BlockHeader>(const json::json& j)
         .state_root = from_json<hash256>(j.at("stateRoot")),
         .receipts_root = from_json<hash256>(j.at("receiptTrie")),
         .logs_bloom = state::bloom_filter_from_bytes(from_json<bytes>(j.at("bloom"))),
-        .difficulty = load_if_exists<int64_t>(j, "difficulty"),
-        .prev_randao = load_if_exists<bytes32>(j, "mixHash"),
+        .difficulty = load_or<int64_t>(j, "difficulty", 0),
+        .prev_randao = load_or<bytes32>(j, "mixHash", {}),
         .block_number = from_json<int64_t>(j.at("number")),
         .gas_limit = from_json<int64_t>(j.at("gasLimit")),
         .gas_used = from_json<int64_t>(j.at("gasUsed")),
         .timestamp = from_json<int64_t>(j.at("timestamp")),
         .extra_data = from_json<bytes>(j.at("extraData")),
-        .base_fee_per_gas = load_if_exists<uint64_t>(j, "baseFeePerGas"),
+        .base_fee_per_gas = load_or<uint64_t>(j, "baseFeePerGas", 0),
         .hash = from_json<hash256>(j.at("hash")),
         .transactions_root = from_json<hash256>(j.at("transactionsTrie")),
-        .withdrawal_root = load_if_exists<hash256>(j, "withdrawalsRoot"),
-        .parent_beacon_block_root = load_if_exists<hash256>(j, "parentBeaconBlockRoot"),
+        .withdrawal_root = load_or<hash256>(j, "withdrawalsRoot", {}),
+        .parent_beacon_block_root = load_or<hash256>(j, "parentBeaconBlockRoot", {}),
         .blob_gas_used = load_optional<uint64_t>(j, "blobGasUsed"),
         .excess_blob_gas = load_optional<uint64_t>(j, "excessBlobGas"),
-        .requests_hash = load_if_exists<hash256>(j, "requestsHash"),
-        .slot_number = load_if_exists<uint64_t>(j, "slotNumber"),
+        .requests_hash = load_or<hash256>(j, "requestsHash", {}),
+        .slot_number = load_or<uint64_t>(j, "slotNumber", 0),
     };
 }
 
@@ -178,10 +160,8 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
     uint64_t chain_id = 1;
     if (const auto config_it = j.find("config"); config_it != j.end())
     {
-        if (const auto bs_it = config_it->find("blobSchedule"); bs_it != config_it->end())
-            bt.blob_schedule = from_json<BlobSchedule>(*bs_it);
-        if (const auto cid_it = config_it->find("chainid"); cid_it != config_it->end())
-            chain_id = from_json<uint64_t>(*cid_it);
+        bt.blob_schedule = load_or<BlobSchedule>(*config_it, "blobSchedule", {});
+        chain_id = load_or<uint64_t>(*config_it, "chainid", chain_id);
     }
     for (const auto& el : j.at("blocks"))
     {
@@ -214,10 +194,11 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
 
     bt.expectation.last_block_hash = from_json<hash256>(j.at("lastblockhash"));
 
-    if (const auto it = j.find("postState"); it != j.end())
-        bt.expectation.post_state = from_json<TestState>(*it);
-    else if (const auto it_hash = j.find("postStateHash"); it_hash != j.end())
-        bt.expectation.post_state = from_json<hash256>(*it_hash);
+    // A test states its expected post state either in full or by its hash, never neither.
+    if (auto post_state = load_optional<TestState>(j, "postState"))
+        bt.expectation.post_state = std::move(*post_state);
+    else
+        bt.expectation.post_state = from_json<hash256>(j.at("postStateHash"));
 
     return bt;
 }

--- a/test/utils/statetest.hpp
+++ b/test/utils/statetest.hpp
@@ -9,6 +9,7 @@
 #include <test/state/errors.hpp>
 #include <test/state/transaction.hpp>
 #include <test/utils/test_state.hpp>
+#include <optional>
 
 namespace json = nlohmann;
 
@@ -114,6 +115,27 @@ state::BlobParams from_json<state::BlobParams>(const json::json& j);
 
 template <>
 BlobSchedule from_json<BlobSchedule>(const json::json& j);
+
+/// Loads the value of the JSON object's @p key, std::nullopt if the object has no such key.
+template <typename T>
+std::optional<T> load_optional(const json::json& j, std::string_view key)
+{
+    if (const auto it = j.find(key); it != j.end())
+        return from_json<T>(*it);
+    return std::nullopt;
+}
+
+/// Loads the value of the JSON object's @p key, @p default_value if the object has no such key.
+/// The default is spelled at the call site, {} for the zero value.
+///
+/// TODO: Inline as load_optional().value_or({}) once the minimum standard library declares
+///   value_or()'s parameter with a defaulted template argument. Deduced, as it is in C++20,
+///   it does not accept a braced initializer.
+template <typename T>
+T load_or(const json::json& j, std::string_view key, T default_value)
+{
+    return load_optional<T>(j, key).value_or(std::move(default_value));
+}
 
 /// Exports the State (accounts) to JSON format (aka pre/post/alloc state).
 json::json to_json(const TestState& state);

--- a/test/utils/statetest_loader.cpp
+++ b/test/utils/statetest_loader.cpp
@@ -14,17 +14,6 @@ namespace evmone::test
 namespace json = nlohmann;
 using evmc::from_hex;
 
-namespace
-{
-template <typename T>
-T load_if_exists(const json::json& j, std::string_view key)
-{
-    if (const auto it = j.find(key); it != j.end())
-        return from_json<T>(*it);
-    return {};
-}
-}  // namespace
-
 template <>
 uint8_t from_json<uint8_t>(const json::json& j)
 {
@@ -235,39 +224,24 @@ state::Withdrawal from_json<state::Withdrawal>(const json::json& j)
 state::BlockInfo from_json_with_rev(
     const json::json& j, evmc_revision rev, state::BlobParams blob_params)
 {
-    evmc::bytes32 prev_randao;
-    int64_t current_difficulty = 0;
-    int64_t parent_difficulty = 0;
-    const auto prev_randao_it = j.find("currentRandom");
-    const auto current_difficulty_it = j.find("currentDifficulty");
-    const auto parent_difficulty_it = j.find("parentDifficulty");
-
-    if (current_difficulty_it != j.end())
-        current_difficulty = from_json<int64_t>(*current_difficulty_it);
-    if (parent_difficulty_it != j.end())
-        parent_difficulty = from_json<int64_t>(*parent_difficulty_it);
-
-    // When it's not defined init it with difficulty value.
-    if (prev_randao_it != j.end())
-        prev_randao = from_json<bytes32>(*prev_randao_it);
-    else if (current_difficulty_it != j.end())
-        prev_randao = from_json<bytes32>(*current_difficulty_it);
-    else if (parent_difficulty_it != j.end())
-        prev_randao = from_json<bytes32>(*parent_difficulty_it);
-
-    hash256 parent_uncle_hash;
-    const auto parent_uncle_hash_it = j.find("parentUncleHash");
-    if (parent_uncle_hash_it != j.end())
-        parent_uncle_hash = from_json<hash256>(*parent_uncle_hash_it);
+    // When prev_randao is not defined init it with the difficulty value.
+    bytes32 prev_randao;
+    for (const auto key : {"currentRandom", "currentDifficulty", "parentDifficulty"})
+    {
+        if (const auto v = load_optional<bytes32>(j, key))
+        {
+            prev_randao = *v;
+            break;
+        }
+    }
 
     uint64_t base_fee = 0;
-    if (j.contains("currentBaseFee"))
-        base_fee = from_json<uint64_t>(j.at("currentBaseFee"));
-    else if (j.contains("parentBaseFee"))
+    if (const auto current_base_fee = load_optional<uint64_t>(j, "currentBaseFee"))
+        base_fee = *current_base_fee;
+    else if (const auto parent_base_fee = load_optional<uint64_t>(j, "parentBaseFee"))
     {
         base_fee = calculate_current_base_fee_eip1559(from_json<uint64_t>(j.at("parentGasUsed")),
-            from_json<uint64_t>(j.at("parentGasLimit")),
-            from_json<uint64_t>(j.at("parentBaseFee")));
+            from_json<uint64_t>(j.at("parentGasLimit")), *parent_base_fee);
     }
 
     std::vector<state::Withdrawal> withdrawals;
@@ -287,43 +261,35 @@ state::BlockInfo from_json_with_rev(
         }
     }
 
-    int64_t parent_timestamp = 0;
-    auto parent_timestamp_it = j.find("parentTimestamp");
-    if (parent_timestamp_it != j.end())
-        parent_timestamp = from_json<int64_t>(*parent_timestamp_it);
-
     uint64_t excess_blob_gas = 0;
-    if (const auto it = j.find("parentExcessBlobGas"); it != j.end())
+    if (const auto parent_excess_blob_gas = load_optional<uint64_t>(j, "parentExcessBlobGas"))
     {
-        const auto parent_excess_blob_gas = from_json<uint64_t>(*it);
         const auto parent_blob_gas_used = from_json<uint64_t>(j.at("parentBlobGasUsed"));
         const auto parent_base_fee = from_json<uint64_t>(j.at("parentBaseFee"));
         const auto parent_blob_base_fee =
-            state::compute_blob_gas_price(blob_params, parent_excess_blob_gas);
+            state::compute_blob_gas_price(blob_params, *parent_excess_blob_gas);
         excess_blob_gas = state::calc_excess_blob_gas(rev, blob_params, parent_blob_gas_used,
-            parent_excess_blob_gas, parent_base_fee, parent_blob_base_fee);
+            *parent_excess_blob_gas, parent_base_fee, parent_blob_base_fee);
     }
-    else if (const auto it2 = j.find("currentExcessBlobGas"); it2 != j.end())
-    {
-        excess_blob_gas = from_json<uint64_t>(*it2);
-    }
+    else
+        excess_blob_gas = load_or<uint64_t>(j, "currentExcessBlobGas", 0);
 
     return state::BlockInfo{
         .number = from_json<int64_t>(j.at("currentNumber")),
         .timestamp = from_json<int64_t>(j.at("currentTimestamp")),
-        .parent_timestamp = parent_timestamp,
+        .parent_timestamp = load_or<int64_t>(j, "parentTimestamp", 0),
         .gas_limit = from_json<int64_t>(j.at("currentGasLimit")),
         .coinbase = from_json<evmc::address>(j.at("currentCoinbase")),
-        .difficulty = current_difficulty,
-        .parent_difficulty = parent_difficulty,
-        .parent_ommers_hash = parent_uncle_hash,
+        .difficulty = load_or<int64_t>(j, "currentDifficulty", 0),
+        .parent_difficulty = load_or<int64_t>(j, "parentDifficulty", 0),
+        .parent_ommers_hash = load_or<hash256>(j, "parentUncleHash", {}),
         .prev_randao = prev_randao,
-        .parent_beacon_block_root = load_if_exists<hash256>(j, "parentBeaconBlockRoot"),
+        .parent_beacon_block_root = load_or<hash256>(j, "parentBeaconBlockRoot", {}),
         .base_fee = base_fee,
-        .blob_gas_used = load_if_exists<uint64_t>(j, "blobGasUsed"),
+        .blob_gas_used = load_optional<uint64_t>(j, "blobGasUsed"),
         .excess_blob_gas = excess_blob_gas,
         .blob_base_fee = state::compute_blob_gas_price(blob_params, excess_blob_gas),
-        .slot_number = load_if_exists<uint64_t>(j, "slotNumber"),
+        .slot_number = load_or<uint64_t>(j, "slotNumber", 0),
         .ommers = std::move(ommers),
         .withdrawals = std::move(withdrawals),
     };
@@ -369,13 +335,9 @@ TestState from_json<TestState>(const json::json& j)
 static void from_json_tx_common(const json::json& j, state::Transaction& o)
 {
     // `sender` is not provided for transactions in invalid blocks.
-    o.sender = load_if_exists<evmc::address>(j, "sender");
+    o.sender = load_or<address>(j, "sender", {});
     o.nonce = from_json<uint64_t>(j.at("nonce"));
-
-    if (const auto chain_id_it = j.find("chainId"); chain_id_it != j.end())
-        o.chain_id = from_json<uint64_t>(*chain_id_it);
-    else
-        o.chain_id = 1;
+    o.chain_id = load_or<uint64_t>(j, "chainId", 1);
 
     if (const auto to_it = j.find("to"); to_it != j.end())
     {
@@ -480,7 +442,7 @@ static void from_json(const json::json& j, TestMultiTransaction& o)
     for (const auto& j_value : j.at("value"))
         o.values.emplace_back(from_json<intx::uint256>(j_value));
 
-    o.v = load_if_exists<uint64_t>(j, "v");
+    o.v = load_or<uint64_t>(j, "v", 0);
 }
 
 static void from_json(const json::json& j, TestMultiTransaction::Indexes& o)
@@ -496,9 +458,7 @@ static void from_json(const json::json& j, StateTransitionTest::Case::Expectatio
     o.state_hash = from_json<hash256>(j.at("hash"));
     o.logs_hash = from_json<hash256>(j.at("logs"));
     o.exception = j.contains("expectException");
-    // Not load_if_exists(): it maps an absent key to bytes{}, which engages the optional.
-    if (const auto it = j.find("txbytes"); it != j.end())
-        o.txbytes = from_json<bytes>(*it);
+    o.txbytes = load_optional<bytes>(j, "txbytes");
 }
 
 static void from_json(const json::json& j_t, StateTransitionTest& o)
@@ -526,10 +486,8 @@ static void from_json(const json::json& j_t, StateTransitionTest& o)
     uint64_t chain_id = 1;
     if (const auto config_it = j_t.find("config"); config_it != j_t.end())
     {
-        if (const auto bs_it = config_it->find("blobSchedule"); bs_it != config_it->end())
-            o.blob_schedule = from_json<BlobSchedule>(*bs_it);
-        if (const auto cid_it = config_it->find("chainid"); cid_it != config_it->end())
-            chain_id = from_json<uint64_t>(*cid_it);
+        o.blob_schedule = load_or<BlobSchedule>(*config_it, "blobSchedule", {});
+        chain_id = load_or<uint64_t>(*config_it, "chainid", chain_id);
     }
 
     for (const auto& [rev_name, expectations] : j_t.at("post").items())

--- a/test/utils/t8n.cpp
+++ b/test/utils/t8n.cpp
@@ -102,18 +102,13 @@ void t8n(evmc::VM& vm, const T8NArgs& args)
                 auto tx = from_json<state::Transaction>(j_tx);
                 tx.chain_id = args.chain_id;
 
-                if (j_tx.contains("hash"))
+                if (const auto loaded_tx_hash = load_optional<hash256>(j_tx, "hash"))
                 {
                     const auto computed_tx_hash = keccak256(rlp::encode(tx));
-                    const auto loaded_tx_hash_opt =
-                        evmc::from_hex<bytes32>(j_tx["hash"].get<std::string>());
-                    if (!loaded_tx_hash_opt)
-                        throw std::logic_error("transaction hash hex is malformed: " +
-                                               j_tx["hash"].get<std::string>());
-                    if (*loaded_tx_hash_opt != computed_tx_hash)
+                    if (*loaded_tx_hash != computed_tx_hash)
                         throw std::logic_error("transaction hash mismatched: computed " +
                                                hex0x(computed_tx_hash) + ", expected " +
-                                               hex0x(*loaded_tx_hash_opt));
+                                               hex0x(*loaded_tx_hash));
                 }
 
                 txs.emplace_back(std::move(tx));


### PR DESCRIPTION
The state test and blockchain test loaders each carried their own `load_if_exists()`, which returned a default-constructed value for an absent key and so conflated "absent" with "zero": `BlockInfo::blob_gas_used` is a `std::optional<uint64_t>`, so an env without `blobGasUsed` ended up with an engaged optional holding 0. Both copies are replaced by a shared `load_optional()` in `statetest.hpp` for the genuinely optional fields and `load_or(j, key, default)` where the default belongs at the call site (`{}` for hashes and addresses, `0`/`1` for numbers). Single-value keys previously read through a `find()`/`end()` pair go through them as well, which drops the `contains()`+`at()` double lookups and the hand-rolled hex decoding of the t8n transaction hash.