### PR TITLE
Name the CALL stipend constant

### DIFF
--- a/lib/evmone/constants.hpp
+++ b/lib/evmone/constants.hpp
@@ -17,4 +17,7 @@ constexpr auto MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
 /// Transactions and create instructions with nonce equal or above this value are invalid.
 /// Defined by [EIP-2681](https://eips.ethereum.org/EIPS/eip-2681).
 constexpr auto MAX_NONCE = 0xffff'ffff'ffff'ffff;
+
+/// The gas given back to a value-transferring CALL, the Yellow Paper's G_callstipend.
+constexpr auto CALL_STIPEND = 2300;
 }  // namespace evmone

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -163,8 +163,8 @@ Result call_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexce
     {
         if (has_value)
         {
-            msg.gas += 2300;  // Add stipend.
-            gas_left += 2300;
+            msg.gas += CALL_STIPEND;
+            gas_left += CALL_STIPEND;
             if (intx::be::load<uint256>(state.host.get_balance(state.msg->recipient)) < value)
                 return {EVMC_SUCCESS, gas_left};  // "Light" failure.
         }

--- a/lib/evmone/instructions_storage.cpp
+++ b/lib/evmone/instructions_storage.cpp
@@ -2,6 +2,7 @@
 // Copyright 2019 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "constants.hpp"
 #include "instructions.hpp"
 
 namespace evmone::instr::core
@@ -120,7 +121,7 @@ Result sstore(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
     if (state.in_static_mode())
         return {EVMC_STATIC_MODE_VIOLATION, gas_left};
 
-    if (state.rev >= EVMC_ISTANBUL && gas_left <= 2300)
+    if (state.rev >= EVMC_ISTANBUL && gas_left <= CALL_STIPEND)
         return {EVMC_OUT_OF_GAS, gas_left};
 
     const auto key = intx::be::store<evmc::bytes32>(stack.pop());


### PR DESCRIPTION
The 2300 gas given back to a value-transferring CALL (the Yellow Paper's G_callstipend) appeared as a bare literal at both of its use sites, right next to the named `CALL_VALUE_COST` it is paired with. The same quantity is the gas SSTORE must have left to run at all (EIP-2200), a bare literal there too.