### PR TITLE
test: Drop the duplicate transaction nonce load

### DIFF
--- a/test/utils/statetest_loader.cpp
+++ b/test/utils/statetest_loader.cpp
@@ -413,7 +413,6 @@ state::Transaction from_json<state::Transaction>(const json::json& j)
                                         ", expected: " + std::to_string(inferred_type));
     }
 
-    o.nonce = from_json<uint64_t>(j.at("nonce"));
     o.r = from_json<intx::uint256>(j.at("r"));
     o.s = from_json<intx::uint256>(j.at("s"));
     o.v = from_json<uint64_t>(j.at("v"));


### PR DESCRIPTION
`from_json<state::Transaction>` loaded `nonce` again at the end, after `from_json_tx_common()` had already loaded it from the same key at the start. The second assignment stored the identical value.