### PR TITLE
test: Pin storage-only account and create-rollback slot warmth

### DIFF
--- a/test/unittests/state_transition_create_test.cpp
+++ b/test/unittests/state_transition_create_test.cpp
@@ -394,3 +394,33 @@ TEST_F(state_transition, created_code_hash)
     expect.post[created].code = runtime_code;
     expect.post[To].storage[0x00_bytes32] = keccak256(runtime_code);
 }
+
+TEST_F(state_transition, create2_rollback_preserves_access_list_slot_warmth)
+{
+    // Rolling back the first CREATE2 must not cool the slots its address had warmed via the tx
+    // access list, so the SSTORE in the second attempt still pays the warm price.
+    rev = EVMC_CANCUN;
+
+    // Initcode reverts on zero CALLVALUE, otherwise stores and deploys nothing.
+    const auto revert_path = revert(0, 0);
+    const auto dest = 4 + revert_path.size();  // CALLVALUE + PUSH1 dest + JUMPI
+    const auto initcode = bytecode{OP_CALLVALUE} + push(dest) + OP_JUMPI + revert_path +
+                          OP_JUMPDEST + sstore(1, 1) + ret(0, 0);
+
+    const auto off = 32 - initcode.size();
+    tx.to = To;
+    pre[To] = {.nonce = 1,
+        .balance = 1,
+        .code = mstore(0, push(initcode)) + create2().input(off, initcode.size()) + OP_POP +
+                create2().value(1).input(off, initcode.size()) + OP_POP};
+
+    const auto created = compute_create2_address(To, {}, initcode);
+    tx.access_list = {{created, {0x01_bytes32}}};
+
+    expect.post[To].nonce = pre[To].nonce + 2;
+    expect.post[To].balance = 0;  // the endowment left the creator
+    expect.post[created].nonce = 1;
+    expect.post[created].balance = 1;
+    expect.post[created].storage[0x01_bytes32] = 0x01_bytes32;
+    expect.gas_used = 109405;  // Cooling the slot would add the 2100 cold surcharge.
+}

--- a/test/unittests/state_transition_touch_test.cpp
+++ b/test/unittests/state_transition_touch_test.cpp
@@ -254,3 +254,56 @@ TEST_F(state_transition, touch_revert_ripemd_london)
     expect.post[*tx.to].exists = true;
     expect.post[0x03_address].exists = false;  // deleted by the retained touch
 }
+
+// A storage-only account (nonce 0, balance 0, no code) is empty per EIP-158, so it is eligible for
+// the end-of-tx sweep, but only a genuine touch may trigger it. Constructing one in the pre-state
+// needs a fork before EIP-7523.
+
+TEST_F(state_transition, touch_access_list_storage_only)
+{
+    // Warming via the access list is not a touch.
+    rev = EVMC_LONDON;
+    static constexpr auto STORAGE_ONLY = 0x5a_address;
+
+    tx.to = To;
+    tx.access_list = {{STORAGE_ONLY, {}}};
+    pre[*tx.to] = {.code = bytecode{OP_STOP}};
+    pre[STORAGE_ONLY] = {.storage = {{0x01_bytes32, 0x01_bytes32}}};
+
+    expect.post[*tx.to].exists = true;
+    expect.post[STORAGE_ONLY].exists = true;
+    expect.post[STORAGE_ONLY].storage[0x01_bytes32] = 0x01_bytes32;
+}
+
+TEST_F(state_transition, touch_balance_storage_only)
+{
+    // BALANCE loads the account, where the access list above only warms it.
+    rev = EVMC_LONDON;
+    static constexpr auto STORAGE_ONLY = 0x5a_address;
+
+    tx.to = To;
+    pre[*tx.to] = {.code = push(STORAGE_ONLY) + OP_BALANCE + OP_POP};
+    pre[STORAGE_ONLY] = {.storage = {{0x01_bytes32, 0x01_bytes32}}};
+
+    expect.post[*tx.to].exists = true;
+    expect.post[STORAGE_ONLY].exists = true;
+    expect.post[STORAGE_ONLY].storage[0x01_bytes32] = 0x01_bytes32;
+}
+
+TEST_F(state_transition, touch_revert_storage_only)
+{
+    // The rollback must undo the touched flag, or the account is swept despite the revert.
+    rev = EVMC_ISTANBUL;  // Berlin's account access would journal the flag on its own.
+    block.base_fee = 0;
+    static constexpr auto STORAGE_ONLY = 0x5a_address;
+
+    tx.type = Transaction::Type::legacy;
+    tx.to = To;
+    pre[*tx.to] = {.code = call(STORAGE_ONLY) + revert(0, 0)};
+    pre[STORAGE_ONLY] = {.storage = {{0x01_bytes32, 0x01_bytes32}}};
+
+    expect.status = EVMC_REVERT;
+    expect.post[*tx.to].exists = true;
+    expect.post[STORAGE_ONLY].exists = true;
+    expect.post[STORAGE_ONLY].storage[0x01_bytes32] = 0x01_bytes32;
+}


### PR DESCRIPTION
Regression tests for behavior no fixture reaches:

- A storage-only account is empty per EIP-158, so warming it, loading it, or touching it in a frame that reverts must not get it swept at end of tx. The pre-state needs an empty-with-storage account, which EIP-7523 forbids from Paris onward, so these run before it.

- Rolling back a failed CREATE2 must not cool the storage slots its address had warmed via the tx access list, so a second CREATE2 at the same address pays the warm SSTORE price.

`touch_revert_storage_only` runs on Istanbul on purpose: from Berlin the account access journals the flag on its own, which masks the rollback under test. Mutation-checked by dropping `journal_account_flags()` from `State::touch()` — the test then fails alongside the existing `touch_revert_empty`.