### PR TITLE
crypto: Drop unused ecc declarations

### DIFF
--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -130,16 +130,6 @@ public:
 };
 
 /// The affine (two coordinates) point on an Elliptic Curve over a prime field.
-template <typename ValueT>
-struct Point
-{
-    ValueT x = {};
-    ValueT y = {};
-
-    friend constexpr Point operator-(const Point& p) noexcept { return {p.x, -p.y}; }
-};
-
-/// The affine (two coordinates) point on an Elliptic Curve over a prime field.
 template <typename Curve>
 struct AffinePoint
 {
@@ -216,9 +206,6 @@ struct ProjPoint
 
     friend constexpr ProjPoint operator-(const ProjPoint& p) noexcept { return {p.x, -p.y, p.z}; }
 };
-
-template <typename IntT>
-using InvFn = IntT (*)(const ModArith<IntT>&, const IntT& x) noexcept;
 
 /// Converts a projected point to an affine point.
 template <typename Curve>

--- a/lib/evmone_precompiles/pairing/field_template.hpp
+++ b/lib/evmone_precompiles/pairing/field_template.hpp
@@ -50,8 +50,6 @@ struct ExtFieldElem
         return res;
     }
 
-    static constexpr ExtFieldElem zero() noexcept { return ExtFieldElem{}; }
-
     constexpr ExtFieldElem inv() const noexcept { return inverse(*this); }
 
     friend constexpr ExtFieldElem operator+(const ExtFieldElem& e1, const ExtFieldElem& e2) noexcept


### PR DESCRIPTION
Three declarations in the elliptic-curve headers have no users anywhere in the
repository, tests and tools included:

- `ecc::Point`, the `ValueT`-templated affine point — curve points are represented
  by `AffinePoint`/`ProjPoint`. It even carried the same doc comment as
  `AffinePoint`, which is the tell that it is a leftover.
- `ecc::InvFn`, a function-pointer alias for an inversion callback.
- `ExtFieldElem::zero()` — the zero value is spelled as default-initialization
  everywhere. `one()` is used and stays.

Deletion only, no behaviour change.