### PR TITLE
test: Recover the blockchain test transaction senders

### DIFF
--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -346,22 +346,15 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 const auto names_spec_exception =
                     test_block.expected_exception.find("Exception.") != std::string::npos;
 
-                // TODO: The transaction senders come from the fixture instead of being recovered
-                //   from the signatures, so evmone never sees the signature the test broke. Such a
-                //   transaction executes as the sender the fixture names and the block is rejected
-                //   by whatever rule that sender happens to break, or by its state root alone.
-                const auto sender_not_recovered = contains_any(
-                    test_block.expected_exception, "TransactionException.INVALID_SIGNATURE_VRS");
-
-                const auto res =
-                    apply_block(pre_state, vm, bi, block_hashes, test_block.transactions, rev,
-                        blob_gas_limit, {.block_reward = mining_reward(rev)});
+                const auto res = apply_block(pre_state, vm, bi, block_hashes,
+                    test_block.transactions, rev, blob_gas_limit,
+                    {.block_reward = mining_reward(rev), .recover_senders = true});
                 if (!res.rejected.empty())
                 {
                     // A transaction was rejected: the fixture must name that reason, not merely
                     // some rejection.
                     const auto& rejected = res.rejected.front();
-                    if (names_spec_exception && !sender_not_recovered)
+                    if (names_spec_exception)
                     {
                         EXPECT_TRUE(
                             is_expected_tx_exception(rejected.error, test_block.expected_exception))
@@ -373,14 +366,10 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 }
                 if (res.requests_error)
                 {
-                    if (!sender_not_recovered)
-                    {
-                        EXPECT_TRUE(is_expected_block_exception(
-                            res.requests_error, test_block.expected_exception))
-                            << "Block invalidity reason mismatch: got "
-                            << res.requests_error.message() << ", expected "
-                            << test_block.expected_exception;
-                    }
+                    EXPECT_TRUE(is_expected_block_exception(
+                        res.requests_error, test_block.expected_exception))
+                        << "Block invalidity reason mismatch: got " << res.requests_error.message()
+                        << ", expected " << test_block.expected_exception;
                     continue;
                 }
                 // The block executed, so it is invalid only if it computes something other than
@@ -395,7 +384,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 // Asserts the fixture names one of @p names, the exceptions the check that just
                 // fired is the symptom of. Silent where the reason cannot be compared.
                 const auto expect_fixture_names = [&](std::string_view names) {
-                    if (!names_spec_exception || ommers_not_validated || sender_not_recovered)
+                    if (!names_spec_exception || ommers_not_validated)
                         return;
                     EXPECT_TRUE(contains_any(test_block.expected_exception, names))
                         << "Block invalidity reason mismatch: the block failed the check for "

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -164,6 +164,8 @@ std::optional<address> recover_sender(const Transaction& tx, bytes_view txbytes)
 
     // A typed v is {0, 1}. A legacy v is 27 + y_parity, or 35 + 2 * chain_id + y_parity (EIP-155):
     // both bases are odd, so an even v means y_parity 1.
+    if (typed ? tx.v > 1 : (tx.v < 27 || (tx.v > 28 && tx.v < 35)))
+        return std::nullopt;
     const auto y_parity = typed ? tx.v != 0 : tx.v % 2 == 0;
 
     const auto h = keccak256((typed ? bytes{stdx::to_underlying(tx.type)} : bytes{}) +

--- a/test/utils/block_transition.cpp
+++ b/test/utils/block_transition.cpp
@@ -55,8 +55,24 @@ TransitionResult apply_block(const TestState& state, evmc::VM& vm, const state::
 
     for (size_t i = 0; i < txs.size(); ++i)
     {
-        const auto& tx = txs[i];
-        const auto computed_tx_hash = keccak256(rlp::encode(tx));
+        const auto& input_tx = txs[i];
+        const auto tx_bytes = rlp::encode(input_tx);
+        const auto computed_tx_hash = keccak256(tx_bytes);
+
+        std::optional<state::Transaction> recovered_tx;
+        if (opts.recover_senders)
+        {
+            const auto sender = state::recover_sender(input_tx, tx_bytes);
+            if (!sender.has_value())
+            {
+                rejected_txs.push_back(
+                    {computed_tx_hash, i, make_error_code(state::INVALID_SIGNATURE)});
+                continue;
+            }
+            recovered_tx = input_tx;
+            recovered_tx->sender = *sender;
+        }
+        const auto& tx = recovered_tx.has_value() ? *recovered_tx : input_tx;
 
         std::optional<StreamRedirect> trace_guard;
         if (trace_enabled)

--- a/test/utils/block_transition.hpp
+++ b/test/utils/block_transition.hpp
@@ -39,6 +39,10 @@ struct BlockTransitionOptions
     /// (t8n pre-state-only mode). The transaction loop and finalization still run.
     bool skip_system_calls = false;
 
+    /// Recover each transaction's sender from its signature instead of using the one supplied,
+    /// rejecting the transaction if the signature does not recover.
+    bool recover_senders = false;
+
     /// Called once per transaction (just before execution) to obtain a per-tx
     /// trace sink; std::clog is redirected to the returned stream for the
     /// duration of that transaction. Unset = tracing disabled.


### PR DESCRIPTION
The runner trusted the sender the fixture supplies, so a transaction whose signature the test broke executed as that sender and the block was rejected by whatever rule it happened to break. Recover from the transaction's own encoding instead, and reject it when the signature does not recover. This removes the exemption added in #1632 and the TODO from #1623; the two fixtures added there now exercise the recovery.

`recover_sender()` also had to reject a `v` outside its domain, a rule only `decode_transaction()` enforced and the JSON path never runs. Without it the `v=34` cases of `frontier/validation/bad_v_r_s` recover a stranger's address and fail on its empty balance instead of on the signature — 13 blockchain fixtures.

Recovery is opt-in via `BlockTransitionOptions`, so t8n keeps using the sender it is given.