### PR TITLE
crypto: Use the generic ecc::dbl for G2 point doubling

### DIFF
--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -371,7 +371,7 @@ ProjPoint<Curve> add(const ProjPoint<Curve>& p, const AffinePoint<Curve>& q) noe
 }
 
 template <typename Curve>
-ProjPoint<Curve> dbl(const ProjPoint<Curve>& p) noexcept
+constexpr ProjPoint<Curve> dbl(const ProjPoint<Curve>& p) noexcept
 {
     const auto& [x1, y1, z1] = p;
 

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -192,33 +192,6 @@ constexpr ecc::ProjPoint<E2> add(
     return {X3, Y3, Z3};
 }
 
-/// Computes `Q + Q` in Jacobian coordinates.
-constexpr ecc::ProjPoint<E2> dbl(const ecc::ProjPoint<E2>& Q) noexcept
-{
-    const auto& x = Q.x;
-    const auto& y = Q.y;
-    const auto& z = Q.z;
-
-    const auto y_squared = y * y;
-    const auto x_squared = x * x;
-    const auto z_squared = z * z;
-    const auto y_4 = y_squared * y_squared;
-    const auto _4y_4 = y_4 + y_4 + y_4 + y_4;
-
-    const auto R = y_squared + y_squared;
-    const auto A = (x + R);
-    const auto S = A * A - x_squared - _4y_4;  // 2xR = (x+R)^2 - x^2 - R^2
-    const auto M = x_squared + x_squared + x_squared;
-
-    const auto N = y + z;
-
-    const auto Xp = M * M - (S + S);
-    const auto Yp = M * (S - Xp) - (_4y_4 + _4y_4);
-    const auto Zp = N * N - y_squared - z_squared;  // 2yz = (y+z)^2 - y^2 - z^2
-
-    return {Xp, Yp, Zp};
-}
-
 /// Computes `N` doubles of the point `a` in Jacobian coordinates.
 template <int N>
 constexpr ecc::ProjPoint<E2> n_dbl(const ecc::ProjPoint<E2>& a) noexcept


### PR DESCRIPTION
`bn254::dbl` repeated the generic a=0 Jacobian doubling that `ecc::dbl` already
implements. The x and y steps are the same formula under different names; only z
differed, computed as `(y+z)² − y² − z²` and so needing a `z²` with no other use
there, where `ecc::dbl` takes `2yz` directly.

Both cost **18 Fq multiplications** — an Fq² squaring is 2 Fq muls against 4 for a
multiplication, so the z coordinate is 4 Fq muls either way. The saving is in
additions: 7 sqr + 1 mul + 18 Fq² add/sub becomes 5 sqr + 2 mul + 14, about a dozen
fewer modular additions per doubling, and a G2 subgroup check does 63 doublings per
pair (57 through the `n_dbl<k>` chain, 5 explicit in `mul_by_X`, 1 for `_2px`).

`lin_func_and_dbl` keeps its own copy of the formula — it needs `z²` for the line
coefficients anyway, so the `(y+z)²` form is the right one there.

Worth about 0.3% of the ECPAIRING instruction count.

### Notes for review

- **Equivalence.** The two are the same polynomial identity, so this is not
  input-dependent: `S ≡ d = 4xy²`, `M ≡ e = 3x²`, and the rest follows. Checked
  against the deleted formula over 2000 random Fq² triples plus the edge cases
  `z = 0` (infinity), `y = 0`, `x = 0`, all-zero, `z = 1`, and purely imaginary
  coordinates — identical output in every case, including the same Jacobian
  representative rather than merely the same affine point.
- **The `constexpr` is hygiene, not a requirement.** It builds without it. The bn254
  callers (`n_dbl`, `mul_by_X`, `g2_subgroup_check`) are declared `constexpr` and
  nothing constant-evaluates them, so leaving `ecc::dbl` non-constexpr is IFNDR that
  compilers accept. Adding it is the smaller of the two honest fixes; dropping
  `constexpr` from those three callers instead would also be defensible.
- **`bn254::add` deliberately stays**, and `dbl` is not symmetric with it. `ecc::add<E2>`
  does not compile: its infinity and doubling guards (`ecc.hpp:194` `p == 0`,
  `:300` `assert(r != 0 || h == 0)`, `:301` `if (h == 0 && r == 0)`) all compare a field
  element against zero, and `Fq²` has no such comparison — `ExtFieldElem` has only the
  defaulted `ExtFieldElem == ExtFieldElem`, and `0` cannot convert to it because the
  consteval constructor wants `DEGREE == 2` coefficients. The a=0 `dbl` branch, by
  contrast, is entirely branch-free, which is why it substitutes cleanly.

  That is one line from being fixable (`operator==(const ExtFieldElem&, zero_t)`), but it
  should not be: `bn254::add` documents that its inputs are never infinity, equal, or
  negations of each other, and `mul_by_X`'s addchain guarantees it — so unifying would
  import an assert plus three dead branches onto a path taken ~20 times per pair.

  Unqualified `add(...)` in bn254 keeps resolving to `bn254::add` regardless, since a
  non-template beats a template in overload resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
