### PR TITLE
crypto: Move the twisted curve's b coefficient onto E2

### DIFF
--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -73,6 +73,9 @@ struct E2
 {
     using Fp = Fq2;
     static constexpr auto A = 0;
+    /// b/ξ, i.e. Curve::B divided by the Fq⁶ non-residue ξ.
+    static constexpr Fp B{0x2b149d40ceb8aaae81be18991be06ac3b5b4c5e559dbefa33267e6dc24a138e5_u256,
+        0x9713b03af0fed4cd2cafadeed8fdf4a74fa084e52d1852e4a2bd0685c315d2_u256};
 };
 
 using ExtPoint = ecc::AffinePoint<E2>;

--- a/lib/evmone_precompiles/pairing/bn254/fields.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/fields.hpp
@@ -22,10 +22,6 @@ struct Fq6Config
     using ValueT = Fq2;
     static constexpr uint8_t DEGREE = 3;
     static constexpr auto ksi = Fq2({Fq(9_u256), Fq(1_u256)});
-    static constexpr auto _3_ksi_inv = Fq2({
-        Fq(0x2b149d40ceb8aaae81be18991be06ac3b5b4c5e559dbefa33267e6dc24a138e5_u256),
-        Fq(0x9713b03af0fed4cd2cafadeed8fdf4a74fa084e52d1852e4a2bd0685c315d2_u256),
-    });
 };
 using Fq6 = ecc::ExtFieldElem<Fq6Config>;
 

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -49,7 +49,7 @@ constexpr bool is_on_twisted_curve(const ecc::AffinePoint<E2>& p)
     const auto x3 = p.x * p.x * p.x;
     const auto y2 = p.y * p.y;
 
-    return y2 == x3 + Fq6Config::_3_ksi_inv;
+    return y2 == x3 + E2::B;
 }
 
 // Frobenius endomorphism related functions are implemented based on


### PR DESCRIPTION
The twisted curve's `b = 3/ξ` lived in `Fq6Config` as `_3_ksi_inv` — a *field* config
holding a *curve* constant, named after how it is derived rather than what it is —
while `E2` carried no `B` at all, even though `Curve` has `B = Fp{3}`. Its single use
now reads `y2 == x3 + E2::B` instead of `y2 == x3 + Fq6Config::_3_ksi_inv`, and the
twist is described the same way as G1.

The value is moved verbatim (extracted programmatically, not retyped). I also
confirmed it really is `3/ξ`: it equals `(27/82, −3/82)` mod p, which is
`3(9−u)/((9+u)(9−u))`, and `ξ · B == (3, 0)`.

**The compiled binary is byte-identical** — `cmp` reports no difference against
master, which is the expected outcome for relocating a compile-time constant, and
makes this a zero-risk change on the performance side. 1172/1172 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)