### PR TITLE
crypto: Declare the pairing arithmetic noexcept

### DIFF
--- a/lib/evmone_precompiles/pairing/bn254/fields.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/fields.hpp
@@ -42,7 +42,7 @@ struct Fq12Config
 using Fq12 = ecc::ExtFieldElem<Fq12Config>;
 
 /// Multiplies two Fq^2 field elements
-constexpr Fq2 multiply(const Fq2& a, const Fq2& b)
+constexpr Fq2 multiply(const Fq2& a, const Fq2& b) noexcept
 {
     const auto& [a0, a1] = a.coeffs;
     const auto& [b0, b1] = b.coeffs;
@@ -50,7 +50,7 @@ constexpr Fq2 multiply(const Fq2& a, const Fq2& b)
 }
 
 /// Squares an Fq^2 field element.
-constexpr Fq2 sqr(const Fq2& a)
+constexpr Fq2 sqr(const Fq2& a) noexcept
 {
     const auto& [a0, a1] = a.coeffs;
 
@@ -60,7 +60,7 @@ constexpr Fq2 sqr(const Fq2& a)
 }
 
 /// Multiplies two Fq^6 field elements
-constexpr Fq6 multiply(const Fq6& a, const Fq6& b)
+constexpr Fq6 multiply(const Fq6& a, const Fq6& b) noexcept
 {
     const auto& [a0, a1, a2] = a.coeffs;
     const auto& [b0, b1, b2] = b.coeffs;
@@ -79,7 +79,7 @@ constexpr Fq6 multiply(const Fq6& a, const Fq6& b)
 }
 
 /// Multiplies two Fq^12 field elements
-constexpr Fq12 multiply(const Fq12& a, const Fq12& b)
+constexpr Fq12 multiply(const Fq12& a, const Fq12& b) noexcept
 {
     const auto& [a0, a1] = a.coeffs;
     const auto& [b0, b1] = b.coeffs;
@@ -96,7 +96,7 @@ constexpr Fq12 multiply(const Fq12& a, const Fq12& b)
 }
 
 /// Inverses the Fq^2 field element
-inline Fq2 inverse(const Fq2& f)
+inline Fq2 inverse(const Fq2& f) noexcept
 {
     const auto& [a0, a1] = f.coeffs;
 
@@ -113,7 +113,7 @@ inline Fq2 inverse(const Fq2& f)
 }
 
 /// Inverses the Fq^6 field element
-inline Fq6 inverse(const Fq6& f)
+inline Fq6 inverse(const Fq6& f) noexcept
 {
     const auto& [a0, a1, a2] = f.coeffs;
 
@@ -138,7 +138,7 @@ inline Fq6 inverse(const Fq6& f)
 }
 
 /// Inverses the Fq^12 field element
-inline Fq12 inverse(const Fq12& f)
+inline Fq12 inverse(const Fq12& f) noexcept
 {
     const auto& [a0, a1] = f.coeffs;
 

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -44,7 +44,7 @@ inline constexpr std::array<std::array<Fq2, 5>, 3> FROBENIUS_COEFFS = {{
 }};
 
 /// Verifies that affine point over Fq^2 field is on the twisted curve.
-constexpr bool is_on_twisted_curve(const ecc::AffinePoint<E2>& p)
+constexpr bool is_on_twisted_curve(const ecc::AffinePoint<E2>& p) noexcept
 {
     const auto x3 = p.x * p.x * p.x;
     const auto y2 = p.y * p.y;
@@ -243,7 +243,7 @@ constexpr ecc::ProjPoint<E2> mul_by_X(const ecc::ProjPoint<E2>& a) noexcept
 
 /// Checks that point `p_aff` is in proper subgroup of points from twisted curve over Fq2 field.
 /// For more details see https://eprint.iacr.org/2022/348.pdf Example 1 from 3.1.2 Examples
-constexpr bool g2_subgroup_check(const ecc::AffinePoint<E2>& p_aff)
+constexpr bool g2_subgroup_check(const ecc::AffinePoint<E2>& p_aff) noexcept
 {
     const auto p = ecc::ProjPoint<E2>{p_aff};
 
@@ -377,7 +377,7 @@ constexpr void lin_func(
 
 /// Computes `a^2` for `a` from `Fq^4 = Fq^2[V](V^2 - ksi)` where `V` is from Fq^2 extended field.
 /// For more reference see https://eprint.iacr.org/2010/354.pdf Algorithm 9
-constexpr std::pair<Fq2, Fq2> fq4_square(const std::pair<Fq2, Fq2>& a)
+constexpr std::pair<Fq2, Fq2> fq4_square(const std::pair<Fq2, Fq2>& a) noexcept
 {
     const auto& a0 = a.first;
     const auto& a1 = a.second;
@@ -394,7 +394,7 @@ constexpr std::pair<Fq2, Fq2> fq4_square(const std::pair<Fq2, Fq2>& a)
 
 /// Computes `c^2` for `x` from Fq^12 where `x^(FieldPrime^6 - 1) == 1`.
 /// This is Fq^12 subgroup called cyclotomic polynomials or group of `r` roots of unity.
-constexpr Fq12 cyclotomic_square(const Fq12& c)
+constexpr Fq12 cyclotomic_square(const Fq12& c) noexcept
 {
     const auto& g = c.coeffs[0];
     const auto& h = c.coeffs[1];
@@ -426,7 +426,7 @@ constexpr Fq12 cyclotomic_square(const Fq12& c)
 
 /// Computes `cyclotomic_square` N times.
 template <int N>
-constexpr Fq12 n_cyclotomic_square(const Fq12& c)
+constexpr Fq12 n_cyclotomic_square(const Fq12& c) noexcept
 {
     auto r = c;
     for (int i = 0; i < N; ++i)
@@ -437,7 +437,7 @@ constexpr Fq12 n_cyclotomic_square(const Fq12& c)
 
 /// Computes `a^X` where `X` is the curve seed parameter
 /// and `a` is from cyclotomic subgroup of Fq^12.
-constexpr Fq12 cyclotomic_pow_to_X(const Fq12& a)
+constexpr Fq12 cyclotomic_pow_to_X(const Fq12& a) noexcept
 {
     auto t0 = cyclotomic_square(a);
     auto t2 = cyclotomic_square(t0);


### PR DESCRIPTION
Thirteen definitions in the bn254 field and curve helpers omitted `noexcept` while
their neighbours carried it — six in `pairing/bn254/utils.hpp`
(`is_on_twisted_curve`, `g2_subgroup_check`, `fq4_square`, `cyclotomic_square`,
`n_cyclotomic_square`, `cyclotomic_pow_to_X`) and all seven `multiply`/`sqr`/`inverse`
overloads in `pairing/bn254/fields.hpp`.

None of them can throw, and the boundary above them already asserted as much:
`ExtFieldElem::operator*` and `ExtFieldElem::inv()` are `noexcept` and call
`multiply()`, `sqr()` and `inverse()`, which were not. This removes that mismatch.

**The compiled binary is byte-identical** to master (`cmp` reports no difference), so
there is nothing to measure. 1172/1172 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)