### PR TITLE
crypto: Spell out the BN254 ate loop schedule digits

### DIFF
--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -36,40 +36,39 @@ constexpr void multiply_by_lin_func_value(
         f.coeffs[1].coeffs[2] * t0y + f.coeffs[0].coeffs[2] * t1x + f.coeffs[0].coeffs[1] * t[2];
 }
 
-// 0000000100010010000010000000010000100010000000010010000000001000000100100000010000000000100000100001001000000010001000000001000101
-// NAF rep 00 -> 0, 01 -> 1, 10 -> -1
-// miller loop goes from L-2 to 0 inclusively. NAF rep of 29793968203157093288 (6x+2) is two bits
-// longer, but we omit lowest 2 bits.
-inline constexpr auto ATE_LOOP_COUNT_NAF = 0x1120804220120081204008212022011_u128;
-inline constexpr int LOG_ATE_LOOP_COUNT = 63;
+/// The signed digits of the ate loop count 6x+2 = 29793968203157093288, most significant first,
+/// with the leading 1 omitted. This is a semi-NAF: adjacent non-zeros occur only at the leading
+/// 1, 1, which the non-adjacent form spells as 1, 0, -1. Both have 22 non-zero digits, but this
+/// one is a digit shorter, i.e. one loop iteration less.
+// clang-format off
+inline constexpr int8_t ATE_LOOP_COUNT_DIGITS[] = {
+     1,  0,  1,  0,  0,  0, -1,  0, -1,  0,  0,  0, -1,  0,  1,  0,
+    -1,  0,  0, -1,  0,  0,  0,  0,  0,  1,  0,  0, -1,  0,  1,  0,
+     0, -1,  0,  0,  0,  0, -1,  0,  1,  0,  0,  0, -1,  0, -1,  0,
+     0,  1,  0,  0,  0, -1,  0,  0, -1,  0,  1,  0,  1,  0,  0,  0,
+};
+// clang-format on
 
 /// Miller loop according to https://eprint.iacr.org/2010/354.pdf Algorithm 1.
 Fq12 miller_loop(const ecc::AffinePoint<E2>& Q, const ecc::AffinePoint<Curve>& P) noexcept
 {
-    auto T = ecc::ProjPoint{Q};
+    auto T = ecc::ProjPoint{Q};  // Applies the omitted leading digit 1 of the loop count.
     const auto nQ = -Q;
     auto f = Fq12::one();
     std::array<Fq2, 3> t;
-    auto naf = ATE_LOOP_COUNT_NAF;
     const auto ny = -P.y;
 
-    for (int i = 0; i <= LOG_ATE_LOOP_COUNT; ++i)
+    for (const auto digit : ATE_LOOP_COUNT_DIGITS)
     {
         T = lin_func_and_dbl(T, t);
         f = square(f);
         multiply_by_lin_func_value(f, t, P.x, ny);
 
-        if (naf & 1)
+        if (digit != 0)
         {
-            T = lin_func_and_add(T, Q, t);
+            T = lin_func_and_add(T, digit > 0 ? Q : nQ, t);
             multiply_by_lin_func_value(f, t, P.x, P.y);
         }
-        else if (naf & 2)
-        {
-            T = lin_func_and_add(T, nQ, t);
-            multiply_by_lin_func_value(f, t, P.x, P.y);
-        }
-        naf >>= 2;
     }
 
     // Frobenius endomorphism for point Q from twisted curve over Fq2 field.


### PR DESCRIPTION
The Miller loop schedule was a uint128 of 2-bit groups, unpacked with a shift and two bit tests per iteration and paired with a separate length constant. Storing the digits as -1, 0 and 1 lets the loop range over them, so the shift, the length constant and one of the two add branches go away.

The digits are not the non-adjacent form of 6x+2, which is worth knowing before anyone regenerates them: the NAF has 66 digits and leads with 1, 0, -1, while this schedule has 65 and leads with 1, 1. Same value, same 22 non-zero digits, one loop iteration less, so a plain NAF routine would add that iteration back. gnark-crypto's `LoopCounter [66]int8` is the canonical NAF and pays it. Hence the rename to `_DIGITS` and the "semi-NAF" note in the comment.

Within digits {-1, 0, 1} this schedule is optimal on both axes: 65 digits is the minimum length, since 64 digits reach only 2^64-1 < 6x+2, and 22 non-zero digits is the minimum weight, which is the NAF's. Wider digit sets do not help either: from w=3 up, every digit above 1 needs an extra full Fq12 multiplication by a precomputed f_d(P), because Miller's addition rule is f_{i+j} = f_i * f_j * l / v and f_1 is the only constant one. Measured against a deliberately wrong table with 5-NAF's shape, that ceiling is -9% instructions, while the Fq12 factors, the seven affine odd multiples and the seven per-pair f_d(P) constants cost about 2.7 times more than the ceiling saves.

Instructions and branches are unchanged, -0.01% and -0.18% on the ECPAIRING benchmark. Cycles could not resolve a difference on this machine under load: four runs gave -4.3%, -1.3%, -3.2% and +1.1%.

The digits were checked by reconstructing 6x+2 from them, and every single-digit mutation of the table, as well as a change of its length, is caught by the existing pairing tests.

This touches the same function as #1544, so whichever lands second needs a rebase.
