### PR TITLE
state: Extract the block body's transaction slices

### DIFF
--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -7,7 +7,6 @@
 #include <test/state/errors.hpp>
 #include <test/state/ethash_difficulty.hpp>
 #include <test/state/requests.hpp>
-#include <test/state/rlp_decode.hpp>
 #include <test/utils/block_transition.hpp>
 #include <test/utils/error_matching.hpp>
 #include <test/utils/mpt_hash.hpp>
@@ -135,27 +134,11 @@ std::error_code validate_block(evmc_revision rev, state::BlobParams blob_params,
 /// decode, and encode back to the very same bytes.
 void expect_transactions_round_trip(bytes_view block_rlp)
 {
-    bytes_view body;  // A block is [header, transactions, ...].
-    ASSERT_TRUE(rlp::take_list_payload(block_rlp, body));
-    ASSERT_TRUE(block_rlp.empty()) << "trailing bytes after the block";
-    bytes_view block_header;
-    ASSERT_TRUE(rlp::take_list_payload(body, block_header));  // Skipped over.
-    bytes_view txs;
-    ASSERT_TRUE(rlp::take_list_payload(body, txs));
+    const auto txs = state::split_block_transactions(block_rlp);
+    ASSERT_TRUE(txs.has_value()) << "malformed block";
 
-    while (!txs.empty())
+    for (const auto tx_bytes : *txs)
     {
-        const auto item = txs;
-        rlp::Header h;
-        ASSERT_TRUE(rlp::decode_header(txs, h));  // Advances txs to the item's payload.
-        const auto header_size = item.size() - txs.size();
-        txs.remove_prefix(h.payload_length);
-
-        // A legacy transaction is an RLP list here, a typed one an RLP string wrapping the
-        // EIP-2718 envelope; the envelope alone is the transaction.
-        const auto tx_bytes = h.is_list ? item.substr(0, header_size + h.payload_length) :
-                                          item.substr(header_size, h.payload_length);
-
         const auto tx = state::decode_transaction(tx_bytes);
         ASSERT_TRUE(tx.has_value()) << hex(tx_bytes);
         EXPECT_EQ(rlp::encode(*tx), tx_bytes);

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -141,6 +141,33 @@ std::optional<Transaction> decode_transaction(bytes_view data) noexcept
     return tx;
 }
 
+std::optional<std::vector<bytes_view>> split_block_transactions(bytes_view block_rlp) noexcept
+{
+    bytes_view body;
+    if (!rlp::take_list_payload(block_rlp, body) || !block_rlp.empty())
+        return std::nullopt;
+
+    bytes_view block_header;
+    bytes_view txs;
+    if (!rlp::take_list_payload(body, block_header) || !rlp::take_list_payload(body, txs))
+        return std::nullopt;
+
+    std::vector<bytes_view> transactions;
+    while (!txs.empty())
+    {
+        const auto item = txs;
+        rlp::Header h;
+        if (!rlp::decode_header(txs, h))  // Advances txs to the item's payload.
+            return std::nullopt;
+        const auto header_size = item.size() - txs.size();
+        txs.remove_prefix(h.payload_length);
+
+        transactions.push_back(h.is_list ? item.substr(0, header_size + h.payload_length) :
+                                           item.substr(header_size, h.payload_length));
+    }
+    return transactions;
+}
+
 std::optional<address> recover_sender(const Transaction& tx, bytes_view txbytes) noexcept
 {
     // The signing preimage is the transaction's encoding without the trailing (v, r, s).

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -88,6 +88,17 @@ struct Transaction
 /// Handles the legacy RLP list and the EIP-2718 typed envelope (type byte followed by an RLP list).
 [[nodiscard]] std::optional<Transaction> decode_transaction(bytes_view data) noexcept;
 
+/// Returns the serialization of each transaction of the block @p block_rlp, delimited but not
+/// decoded, or std::nullopt if the block's structure is malformed.
+///
+/// A block is [header, transactions, ...]; only these two are read, whatever follows them is not
+/// validated. Inside the transaction list a legacy transaction is an RLP list and a typed one an
+/// RLP string wrapping the EIP-2718 envelope; the envelope alone is the transaction.
+///
+/// The returned views point into @p block_rlp, which must outlive them.
+[[nodiscard]] std::optional<std::vector<bytes_view>> split_block_transactions(
+    bytes_view block_rlp) noexcept;
+
 /// Recovers the sender (the signer) of the transaction @p tx decoded from @p txbytes,
 /// or std::nullopt if the signature is invalid.
 ///

--- a/test/unittests/state_rlp_decode_test.cpp
+++ b/test/unittests/state_rlp_decode_test.cpp
@@ -38,6 +38,16 @@ state::Transaction round_trip(const state::Transaction& tx)
     return decoded.value_or(state::Transaction{});
 }
 
+/// Builds a block serialization carrying @p txs, each as it appears in a block body: a legacy
+/// transaction verbatim, a typed one wrapped in an RLP string. The header is an empty list.
+bytes make_block(std::initializer_list<bytes> txs)
+{
+    bytes list;
+    for (const auto& tx : txs)
+        list += (!tx.empty() && tx[0] >= rlp::SHORT_LIST_BASE) ? tx : rlp::encode(tx);
+    return rlp::internal::wrap_list(rlp::internal::wrap_list({}) + rlp::internal::wrap_list(list));
+}
+
 /// Decodes @p txbytes and recovers the sender of the transaction; it must decode.
 std::optional<address> recover(const bytes& txbytes)
 {
@@ -681,4 +691,50 @@ TEST(state_rlp_decode, recover_sender_rejects_high_s)
 
     tx.s += 1;
     EXPECT_FALSE(recover(rlp::encode(tx)).has_value());
+}
+
+TEST(state_rlp_decode, split_block_transactions)
+{
+    const auto legacy = rlp::encode(MINIMAL_LEGACY_TX);
+    auto tx = MINIMAL_LEGACY_TX;
+    tx.type = state::Transaction::Type::eip1559;
+    tx.chain_id = 1;
+    tx.v = 1;
+    const auto typed = rlp::encode(tx);
+    ASSERT_EQ(typed[0], 0x02);  // The EIP-2718 envelope, wrapped in an RLP string by make_block().
+
+    const auto block = make_block({legacy, typed, legacy});
+    const auto txs = state::split_block_transactions(block);
+    ASSERT_TRUE(txs.has_value());
+    ASSERT_EQ(txs->size(), 3);
+    EXPECT_EQ((*txs)[0], bytes_view{legacy});
+    EXPECT_EQ((*txs)[1], bytes_view{typed});
+    EXPECT_EQ((*txs)[2], bytes_view{legacy});
+
+    const auto empty = make_block({});
+    const auto no_txs = state::split_block_transactions(empty);
+    ASSERT_TRUE(no_txs.has_value());
+    EXPECT_TRUE(no_txs->empty());
+}
+
+TEST(state_rlp_decode, split_block_transactions_rejects_malformed)
+{
+    EXPECT_FALSE(state::split_block_transactions({}).has_value());          // Empty input.
+    EXPECT_FALSE(state::split_block_transactions("0x80"_hex).has_value());  // Not a list.
+
+    // A block header alone: the transaction list is missing.
+    const auto header_only = rlp::internal::wrap_list(rlp::internal::wrap_list({}));
+    EXPECT_FALSE(state::split_block_transactions(header_only).has_value());
+
+    // The transaction list is not a list.
+    const auto not_a_list = rlp::internal::wrap_list(rlp::internal::wrap_list({}) + "0x80"_hex);
+    EXPECT_FALSE(state::split_block_transactions(not_a_list).has_value());
+
+    // A truncated item: 0xf8 begins a long list whose length byte is not there.
+    const auto truncated = rlp::internal::wrap_list(
+        rlp::internal::wrap_list({}) + rlp::internal::wrap_list("0xf8"_hex));
+    EXPECT_FALSE(state::split_block_transactions(truncated).has_value());
+
+    // Trailing bytes after the block.
+    EXPECT_FALSE(state::split_block_transactions(make_block({}) + "0x00"_hex).has_value());
 }


### PR DESCRIPTION
The blockchain test runner walked a block's serialization itself to check the transaction codec against it, so it carried two pieces of protocol knowledge inside a gtest assertion: where a block keeps its transactions, and that a typed transaction is wrapped in an RLP string there while a legacy one is a bare list.

`split_block_transactions()` takes over that walk. It delimits the transactions without decoding them, which is what the upcoming sender recovery in blockchain tests needs: a caller has to tell a transaction that does not decode from one whose signature does not recover, because the fixtures name those as different exceptions. `expect_transactions_round_trip()` becomes a decode-and-compare loop.

No behavior change. The malformed-block cases the runner used to assert on are now the `std::nullopt` result, with the same conditions in the same order, and the new unit tests cover the typed-vs-legacy wrapping and six rejection cases directly instead of only through fixtures.