### PR TITLE
crypto: Specialize the Fq2 multiplication by ksi

### DIFF
--- a/lib/evmone_precompiles/pairing/bn254/fields.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/fields.hpp
@@ -37,6 +37,18 @@ struct Fq12Config
 };
 using Fq12 = ecc::ExtFieldElem<Fq12Config>;
 
+/// Multiplies an Fq^2 field element by ksi, the non-residue defining the Fq^6 extension.
+constexpr Fq2 mul_by_ksi(const Fq2& a) noexcept
+{
+    // ksi = 9 + u, so (a0 + a1·u)·ksi = (9a0 − a1) + (a0 + 9a1)·u.
+    // TODO: The multiplications by 9 can be done with additions only, but that was not faster.
+    static_assert(Fq6Config::ksi == Fq2{9, 1});
+    const auto& nine = Fq6Config::ksi.coeffs[0];
+
+    const auto& [a0, a1] = a.coeffs;
+    return Fq2({a0 * nine - a1, a1 * nine + a0});
+}
+
 /// Multiplies two Fq^2 field elements
 constexpr Fq2 multiply(const Fq2& a, const Fq2& b) noexcept
 {
@@ -61,14 +73,12 @@ constexpr Fq6 multiply(const Fq6& a, const Fq6& b) noexcept
     const auto& [a0, a1, a2] = a.coeffs;
     const auto& [b0, b1, b2] = b.coeffs;
 
-    const Fq2& ksi = Fq6Config::ksi;
-
     const auto t0 = a0 * b0;
     const auto t1 = a1 * b1;
     const auto t2 = a2 * b2;
 
-    const auto c0 = ((a1 + a2) * (b1 + b2) - t1 - t2) * ksi + t0;
-    const auto c1 = (a0 + a1) * (b0 + b1) - t0 - t1 + ksi * t2;
+    const auto c0 = mul_by_ksi((a1 + a2) * (b1 + b2) - t1 - t2) + t0;
+    const auto c1 = (a0 + a1) * (b0 + b1) - t0 - t1 + mul_by_ksi(t2);
     const auto c2 = (a0 + a2) * (b0 + b2) - t0 - t2 + t1;
 
     return Fq6({c0, c1, c2});
@@ -83,9 +93,8 @@ constexpr Fq12 multiply(const Fq12& a, const Fq12& b) noexcept
     const auto t0 = a0 * b0;
     const auto t1 = a1 * b1;
 
-    const Fq2& ksi = Fq6Config::ksi;
-
-    const auto c0 = t0 + Fq6({ksi * t1.coeffs[2], t1.coeffs[0], t1.coeffs[1]});  // gamma is sparse.
+    const auto c0 =
+        t0 + Fq6({mul_by_ksi(t1.coeffs[2]), t1.coeffs[0], t1.coeffs[1]});  // gamma is sparse.
     const auto c1 = (a0 + a1) * (b0 + b1) - t0 - t1;
 
     return Fq12({c0, c1});
@@ -113,8 +122,6 @@ inline Fq6 inverse(const Fq6& f) noexcept
 {
     const auto& [a0, a1, a2] = f.coeffs;
 
-    const Fq2& ksi = Fq6Config::ksi;
-
     const auto t0 = a0 * a0;
     const auto t1 = a1 * a1;
     const auto t2 = a2 * a2;
@@ -123,11 +130,11 @@ inline Fq6 inverse(const Fq6& f) noexcept
     const auto t4 = a0 * a2;
     const auto t5 = a2 * a1;
 
-    const auto c0 = t0 - ksi * t5;
-    const auto c1 = ksi * t2 - t3;
+    const auto c0 = t0 - mul_by_ksi(t5);
+    const auto c1 = mul_by_ksi(t2) - t3;
     const auto c2 = t1 - t4;
 
-    const auto t = a0 * c0 + (a2 * c1 + a1 * c2) * ksi;
+    const auto t = a0 * c0 + mul_by_ksi(a2 * c1 + a1 * c2);
     const auto t6 = t.inv();
 
     return Fq6({c0 * t6, c1 * t6, c2 * t6});
@@ -141,9 +148,7 @@ inline Fq12 inverse(const Fq12& f) noexcept
     auto t0 = a0 * a0;
     auto t1 = a1 * a1;
 
-    const Fq2& ksi = Fq6Config::ksi;
-
-    t0 = t0 - Fq6({ksi * t1.coeffs[2], t1.coeffs[0], t1.coeffs[1]});  // gamma is sparse.
+    t0 = t0 - Fq6({mul_by_ksi(t1.coeffs[2]), t1.coeffs[0], t1.coeffs[1]});  // gamma is sparse.
     t1 = t0.inv();
 
     const auto c0 = a0 * t1;

--- a/lib/evmone_precompiles/pairing/bn254/pairing.cpp
+++ b/lib/evmone_precompiles/pairing/bn254/pairing.cpp
@@ -16,13 +16,12 @@ constexpr void multiply_by_lin_func_value(
     Fq12& fr, const std::array<Fq2, 3>& t, const Fq& x, const Fq& y) noexcept
 {
     const Fq12 f = fr;
-    const auto& ksi = Fq6Config::ksi;
 
     const auto t0y = t[0] * y;
     const auto t1x = t[1] * x;
-    const auto t2ksi = t[2] * ksi;
+    const auto t2ksi = mul_by_ksi(t[2]);
 
-    fr.coeffs[0].coeffs[0] = f.coeffs[0].coeffs[0] * t0y + f.coeffs[1].coeffs[2] * t1x * ksi +
+    fr.coeffs[0].coeffs[0] = f.coeffs[0].coeffs[0] * t0y + mul_by_ksi(f.coeffs[1].coeffs[2] * t1x) +
                              f.coeffs[1].coeffs[1] * t2ksi;
     fr.coeffs[0].coeffs[1] =
         f.coeffs[0].coeffs[1] * t0y + f.coeffs[1].coeffs[0] * t1x + f.coeffs[1].coeffs[2] * t2ksi;

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -359,16 +359,14 @@ constexpr void lin_func(
 /// Computes f^2 for f in Fq12. For more ref https://eprint.iacr.org/2010/354.pdf Algorithm 22
 [[nodiscard]] constexpr Fq12 square(const Fq12& f) noexcept
 {
-    const Fq2& ksi = Fq6Config::ksi;
-
     const auto& a0 = f.coeffs[0];
     const auto& a1 = f.coeffs[1];
     auto c0 = a0 - a1;
-    auto c3 = a0 - Fq6({ksi * a1.coeffs[2], a1.coeffs[0], a1.coeffs[1]});
+    auto c3 = a0 - Fq6({mul_by_ksi(a1.coeffs[2]), a1.coeffs[0], a1.coeffs[1]});
     auto c2 = a0 * a1;
     c0 = c0 * c3 + c2;
     const auto c1 = c2 + c2;
-    c2 = Fq6({ksi * c2.coeffs[2], c2.coeffs[0], c2.coeffs[1]});
+    c2 = Fq6({mul_by_ksi(c2.coeffs[2]), c2.coeffs[0], c2.coeffs[1]});
     c0 = c0 + c2;
 
     return Fq12({c0, c1});
@@ -384,7 +382,7 @@ constexpr std::pair<Fq2, Fq2> fq4_square(const std::pair<Fq2, Fq2>& a) noexcept
     const auto t0 = a0 * a0;
     const auto t1 = a1 * a1;
 
-    const auto c0 = t1 * Fq6Config::ksi + t0;
+    const auto c0 = mul_by_ksi(t1) + t0;
     auto c1 = a0 + a1;
     c1 = c1 * c1 - t0 - t1;
 
@@ -410,7 +408,7 @@ constexpr Fq12 cyclotomic_square(const Fq12& c) noexcept
     const auto [t01, t12] = fq4_square({h0, g2});  // Typo in paper t01 <-> t12
     const auto [t02, aux] = fq4_square({g1, h2});
 
-    const auto t10 = aux * Fq6Config::ksi;
+    const auto t10 = mul_by_ksi(aux);
 
     const auto c00 = (t00 + t00 + t00) - (g0 + g0);
     const auto c01 = (t01 + t01 + t01) - (g1 + g1);


### PR DESCRIPTION
Multiplication by ksi = 9 + u, the non-residue defining the Fq6 extension, went through the generic Fq2 multiplication. That costs 4 field multiplications where 2 suffice: the u coefficient of ksi is 1, so `a1 * 1` and `a0 * 1` were computed for nothing. `mul_by_ksi()` computes `(a0 + a1*u)*(9 + u) = (9a0 - a1) + (a0 + 9a1)*u` directly and is used at the 13 sites, spread over the Fq6 and Fq12 multiplication, squaring and inversion, the cyclotomic squaring and the Miller loop's line multiplication.

The dependency depth is unchanged (multiplication then addition, exactly as before), so this is a strict removal of work rather than a trade-off.

ecpairing benchmark, interleaved A/B with two-point subtraction: instructions -6.6% (0.02% spread), cycles -2.6% by minimum and -4.6% by median over 7 repetitions, faster in 7/7. Only the cycles range is soft, the box was at load 50-64 throughout.

The obvious stronger version, computing 9a with additions only so that no multiplication is left at all, is a regression and the TODO in the code records it: -9.3% instructions but +5.2% cycles, IPC 1.78 to 1.54. The chain v, 2v, 4v, 8v, 9v is 4 dependent modular additions, each with its own carry chain and conditional subtraction, replacing multiplications that were independent and pipelined well. Fewer instructions, longer critical path.

Correctness: `mul_by_ksi` was differentially tested against the generic `multiply(a, ksi)` over 200,100 inputs, the field edge cases (0, 1, 2, 8, 9, p-1, p-2, p/2, p/2+1, (p-1)/9 in both coordinates) and 200k random Fq2 values, with no mismatch. The `static_assert` pins the coefficient that licenses dropping the two multiplications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
