### PR TITLE
crypto: Pseudo-Mersenne field multiplication for secp256k1

### DIFF
--- a/include/evmmax/evmmax.hpp
+++ b/include/evmmax/evmmax.hpp
@@ -158,9 +158,9 @@ public:
         return (d.carry) ? s : d.value;
     }
 
-    /// Computes modular inverse of x in Montgomery form. Result is in Montgomery form.
+    /// Computes u⋅x⁻¹ % mod for the given initial value of the Bézout coefficient u.
     /// Returns 0 for non-invertible x (including x == 0).
-    constexpr UintT inv(const UintT& x) const noexcept
+    constexpr UintT inv_scaled(const UintT& x, UintT u) const noexcept
     {
         assert((mod_ & 1) == 1);
         assert(mod_ >= 3);
@@ -179,12 +179,6 @@ public:
         // TODO: The same paper has additional optimizations that could be applied.
         UintT a = x;
         UintT b = mod_;
-
-        // Bézout's coefficients are originally initialized to 1 and 0. But because the input x
-        // is in Montgomery form XR the algorithm would compute X⁻¹R⁻¹. To get the expected X⁻¹R,
-        // we need to multiply the result by R². We can achieve the same effect "for free"
-        // by initializing u to R² instead of 1.
-        UintT u = r_squared_;
         UintT v = 0;
 
         while (a != 0)
@@ -222,6 +216,17 @@ public:
         if (b != 1) [[unlikely]]
             v = 0;  // not invertible
         return v;
+    }
+
+    /// Computes modular inverse of x in Montgomery form. Result is in Montgomery form.
+    /// Returns 0 for non-invertible x (including x == 0).
+    constexpr UintT inv(const UintT& x) const noexcept
+    {
+        // Bézout's coefficient u is originally initialized to 1. But because the input x is in
+        // Montgomery form XR the algorithm would compute X⁻¹R⁻¹. To get the expected X⁻¹R, we
+        // need to multiply the result by R². We can achieve the same effect "for free"
+        // by initializing u to R² instead of 1.
+        return inv_scaled(x, r_squared_);
     }
 };
 }  // namespace evmmax

--- a/include/evmmax/evmmax.hpp
+++ b/include/evmmax/evmmax.hpp
@@ -316,7 +316,49 @@ private:
     static constexpr ModArith<uint_type> M{Mod};
 };
 
-/// Selects the arithmetic backend for the given modulus.
+/// The pseudo-Mersenne backend for a modulus 2ⁿ-c with a single-word c.
+/// Values are kept plain, so the conversions to and from the internal form are free.
 template <const auto& Mod>
-using ArithFor = MontgomeryArith<Mod>;
+struct PseudoMersenneArith
+{
+    using uint_type = std::remove_cvref_t<decltype(Mod)>;
+
+    static constexpr uint_type to_internal(const uint_type& v) noexcept
+    {
+        // Unlike the conversion to the Montgomery form, this does not reduce the input.
+        assert(v < Mod);
+        return v;
+    }
+    static constexpr uint_type from_internal(const uint_type& v) noexcept { return v; }
+
+    static constexpr uint_type mul(const uint_type& x, const uint_type& y) noexcept
+    {
+        return pseudo_mersenne_reduce<Mod>(intx::umul(x, y));
+    }
+    static constexpr uint_type add(const uint_type& x, const uint_type& y) noexcept
+    {
+        return M.add(x, y);
+    }
+    static constexpr uint_type sub(const uint_type& x, const uint_type& y) noexcept
+    {
+        return M.sub(x, y);
+    }
+
+    /// The plain representation needs no R² factor folded in, unlike the Montgomery one.
+    static constexpr uint_type inv(const uint_type& x) noexcept
+    {
+        return M.inv_scaled(x, uint_type{1});
+    }
+
+private:
+    /// Reused for the operations not affected by the representation and for the binary GCD.
+    static constexpr ModArith<uint_type> M{Mod};
+};
+
+/// Selects the arithmetic backend from the structure of the modulus.
+/// Both alternatives are named for any modulus, but only the selected one is instantiated,
+/// so a backend must not place its precondition in the class scope.
+template <const auto& Mod>
+using ArithFor =
+    std::conditional_t<pseudo_mersenne_c(Mod) != 0, PseudoMersenneArith<Mod>, MontgomeryArith<Mod>>;
 }  // namespace evmmax

--- a/include/evmmax/evmmax.hpp
+++ b/include/evmmax/evmmax.hpp
@@ -59,6 +59,48 @@ constexpr std::pair<uint64_t, uint64_t> addmul(
     return {p[1], p[0]};
 }
 
+/// Returns the c of a "pseudo-Mersenne" modulus 2ⁿ-c, where n is the bit width of the type.
+/// Returns 0 if c does not fit in a single word, i.e. if the modulus is not pseudo-Mersenne
+/// for the purpose of pseudo_mersenne_reduce().
+template <typename UintT>
+consteval uint64_t pseudo_mersenne_c(const UintT& mod) noexcept
+{
+    const UintT c = -mod;  // 2ⁿ - mod, because the negation is modulo 2ⁿ.
+    return (c == UintT{c[0]}) ? c[0] : 0;
+}
+
+/// Reduces a double-width value modulo the pseudo-Mersenne modulus Mod = 2ⁿ-c.
+/// Accepts any value of the double width and returns the fully reduced result.
+template <const auto& Mod>
+constexpr auto pseudo_mersenne_reduce(
+    const intx::uint<2 * std::remove_cvref_t<decltype(Mod)>::num_bits>& p) noexcept
+{
+    using UintT = std::remove_cvref_t<decltype(Mod)>;
+    constexpr auto S = UintT::num_words;
+    constexpr auto C = pseudo_mersenne_c(Mod);
+    static_assert(C != 0, "the modulus is not pseudo-Mersenne");
+
+    // Fold the high half into the low one: h⋅2ⁿ + l ≡ l + h⋅c (mod 2ⁿ-c).
+    UintT t;
+    uint64_t c = 0;
+#pragma GCC unroll 8
+    for (size_t i = 0; i != S; ++i)
+        std::tie(c, t[i]) = addmul(p[i], p[S + i], C, c);
+
+    // Fold the leftover word the same way. It is not greater than c, so the product spans
+    // two words at most and the addition below overflows by at most 1.
+    auto [r, overflow] = addc(t, UintT{intx::umul(c, C)});
+
+    // Fold the overflow again. This cannot overflow, because the addition above only overflows
+    // when the low part of its result is as small as the two-word product.
+    if (overflow) [[unlikely]]
+        r += C;
+
+    if (r >= Mod) [[unlikely]]  // The result may exceed the modulus, but by less than c.
+        r -= Mod;
+    return r;
+}
+
 /// The modular arithmetic operations for EVMMAX (EVM Modular Arithmetic Extensions).
 template <typename UintT>
 class ModArith

--- a/include/evmmax/evmmax.hpp
+++ b/include/evmmax/evmmax.hpp
@@ -271,4 +271,52 @@ public:
         return inv_scaled(x, r_squared_);
     }
 };
+
+/// The modular arithmetic backend of a prime field.
+///
+/// An implementation keeps values in an internal representation of its choice. Every operation
+/// takes and returns fully reduced values, i.e. less than the modulus. Additionally,
+/// to_internal() requires its argument to be already reduced, because a plain representation
+/// cannot reduce it. inv() returns 0 for non-invertible input, including 0.
+template <typename T>
+concept FieldArith = requires(const typename T::uint_type& x, const typename T::uint_type& y) {
+    { T::to_internal(x) } -> std::same_as<typename T::uint_type>;
+    { T::from_internal(x) } -> std::same_as<typename T::uint_type>;
+    { T::mul(x, y) } -> std::same_as<typename T::uint_type>;
+    { T::add(x, y) } -> std::same_as<typename T::uint_type>;
+    { T::sub(x, y) } -> std::same_as<typename T::uint_type>;
+    { T::inv(x) } -> std::same_as<typename T::uint_type>;
+};
+
+/// The Montgomery multiplication backend, usable with any odd modulus.
+/// Values are kept in the Montgomery form.
+template <const auto& Mod>
+struct MontgomeryArith
+{
+    using uint_type = std::remove_cvref_t<decltype(Mod)>;
+
+    static constexpr uint_type to_internal(const uint_type& v) noexcept { return M.to_mont(v); }
+    static constexpr uint_type from_internal(const uint_type& v) noexcept { return M.from_mont(v); }
+
+    static constexpr uint_type mul(const uint_type& x, const uint_type& y) noexcept
+    {
+        return M.mul(x, y);
+    }
+    static constexpr uint_type add(const uint_type& x, const uint_type& y) noexcept
+    {
+        return M.add(x, y);
+    }
+    static constexpr uint_type sub(const uint_type& x, const uint_type& y) noexcept
+    {
+        return M.sub(x, y);
+    }
+    static constexpr uint_type inv(const uint_type& x) noexcept { return M.inv(x); }
+
+private:
+    static constexpr ModArith<uint_type> M{Mod};
+};
+
+/// Selects the arithmetic backend for the given modulus.
+template <const auto& Mod>
+using ArithFor = MontgomeryArith<Mod>;
 }  // namespace evmmax

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -30,11 +30,15 @@ template <FieldSpec Spec>
 class FieldElement
 {
     using uint_type = std::remove_const_t<decltype(Spec::ORDER)>;
-    static constexpr ModArith<uint_type> Fp{Spec::ORDER};
+
+    /// The arithmetic backend, selected by the modulus. It also decides the internal
+    /// representation of the value, so this class must not assume any.
+    using Arith = ArithFor<Spec::ORDER>;
+    static_assert(FieldArith<Arith>);
 
     uint_type value_;
 
-    /// Wraps a value into the Element type assuming it is already in the internal ModArith form.
+    /// Wraps a value into the Element type assuming it is already in the internal form.
     [[gnu::always_inline]] static constexpr FieldElement wrap(const uint_type& v) noexcept
     {
         FieldElement element;
@@ -48,9 +52,9 @@ public:
 
     FieldElement() = default;
 
-    constexpr explicit FieldElement(uint_type v) : value_{Fp.to_mont(v)} {}
+    constexpr explicit FieldElement(uint_type v) : value_{Arith::to_internal(v)} {}
 
-    constexpr uint_type value() const noexcept { return Fp.from_mont(value_); }
+    constexpr uint_type value() const noexcept { return Arith::from_internal(value_); }
 
     /// The valid range for from_bytes().
     enum class Range : bool
@@ -85,45 +89,45 @@ public:
 
     friend constexpr auto operator*(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.mul(a.value_, b.value_));
+        return wrap(Arith::mul(a.value_, b.value_));
     }
 
     friend constexpr auto operator+(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.add(a.value_, b.value_));
+        return wrap(Arith::add(a.value_, b.value_));
     }
 
     FieldElement& operator+=(const FieldElement& b) noexcept
     {
-        value_ = Fp.add(value_, b.value_);
+        value_ = Arith::add(value_, b.value_);
         return *this;
     }
 
     friend constexpr auto operator-(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.sub(a.value_, b.value_));
+        return wrap(Arith::sub(a.value_, b.value_));
     }
 
     friend constexpr auto operator-(const FieldElement& a) noexcept
     {
-        return wrap(Fp.sub(0, a.value_));
+        return wrap(Arith::sub(0, a.value_));
     }
 
-    /// Division returns 0 when the divisor is 0. See ModArith::inv().
+    /// Division returns 0 when the divisor is 0. See the FieldArith concept.
     friend constexpr auto operator/(one_t, const FieldElement& a) noexcept
     {
-        return wrap(Fp.inv(a.value_));
+        return wrap(Arith::inv(a.value_));
     }
 
-    /// Division returns 0 when the divisor is 0. See ModArith::inv().
+    /// Division returns 0 when the divisor is 0. See the FieldArith concept.
     friend constexpr auto operator/(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.mul(a.value_, Fp.inv(b.value_)));
+        return wrap(Arith::mul(a.value_, Arith::inv(b.value_)));
     }
 
     /// Named 1/x inversion method. Needed in the pairing templates.
-    /// Returns 0 when this element is 0. See ModArith::inv().
-    constexpr auto inv() const noexcept { return wrap(Fp.inv(value_)); }
+    /// Returns 0 when this element is 0. See the FieldArith concept.
+    constexpr auto inv() const noexcept { return wrap(Arith::inv(value_)); }
 
     /// Named one element. Needed in the pairing templates.
     static constexpr auto one() noexcept { return FieldElement{1}; }

--- a/test/unittests/evmmax_test.cpp
+++ b/test/unittests/evmmax_test.cpp
@@ -5,6 +5,7 @@
 #include <evmmax/evmmax.hpp>
 #include <gtest/gtest.h>
 #include <array>
+#include <vector>
 
 using namespace intx;
 using namespace evmmax;
@@ -17,6 +18,13 @@ constexpr auto M256 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 constexpr auto BLS12384Mod =
     0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab_u384;
 
+
+// Only the secp256k1 field prime (2²⁵⁶-2³²-977) and 2²⁵⁶-1 are pseudo-Mersenne.
+static_assert(pseudo_mersenne_c(Secp256k1Mod) == 0x1000003d1);
+static_assert(pseudo_mersenne_c(M256) == 1);
+static_assert(pseudo_mersenne_c(P23) == 0);
+static_assert(pseudo_mersenne_c(BN254Mod) == 0);
+static_assert(pseudo_mersenne_c(BLS12384Mod) == 0);
 
 template <typename UintT, const UintT& Mod>
 struct ModA : ModArith<UintT>
@@ -166,4 +174,48 @@ TYPED_TEST(evmmax_test, inv)
         const auto pm = m.mul(xm, xm_inv);
         EXPECT_EQ(m.from_mont(pm), 1);
     }
+}
+
+/// Reduces by generic division, as the reference for pseudo_mersenne_reduce().
+template <const auto& Mod>
+static auto reduce_ref(
+    const intx::uint<2 * std::remove_cvref_t<decltype(Mod)>::num_bits>& p) noexcept
+{
+    using UintT = std::remove_cvref_t<decltype(Mod)>;
+    return static_cast<UintT>(udivrem(p, decltype(p){Mod}).rem);
+}
+
+/// Checks pseudo_mersenne_reduce() against the reference for the whole input range, including
+/// the two carry foldings that no product of two canonical operands can reach.
+template <const auto& Mod>
+static void test_reduce()
+{
+    using UintT = std::remove_cvref_t<decltype(Mod)>;
+    using WideT = intx::uint<2 * UintT::num_bits>;
+    static constexpr auto C = pseudo_mersenne_c(Mod);
+
+    std::vector<WideT> inputs{0, 1, WideT{Mod} - 1, WideT{Mod} + 1, ~WideT{},
+        umul(Mod - 1, Mod - 1), WideT{~UintT{}}, WideT{~UintT{}} - C, WideT{C}};
+
+    // Reaches the final subtraction: a zero high half makes the folding an identity, so any
+    // value in [Mod, 2ⁿ) needs the subtraction. Mod itself must reduce to 0.
+    inputs.push_back(WideT{Mod});
+
+    // Reaches the folding of the leftover word's overflow: solving l + h⋅C = 2ⁿ + (2ⁿ-1) leaves
+    // the first folding at 2ⁿ-1 with a leftover word of 1, so adding 1⋅C overflows.
+    const auto target = (WideT{1} << (UintT::num_bits + 1)) - 1;
+    inputs.push_back(((target / C) << UintT::num_bits) | (target % C));
+
+    for (const auto& p : inputs)
+        EXPECT_EQ(pseudo_mersenne_reduce<Mod>(p), reduce_ref<Mod>(p)) << to_string(p, 16);
+}
+
+TEST(evmmax, pseudo_mersenne_reduce_secp256k1)
+{
+    test_reduce<Secp256k1Mod>();
+}
+
+TEST(evmmax, pseudo_mersenne_reduce_m256)
+{
+    test_reduce<M256>();
 }


### PR DESCRIPTION
Proof of concept: specialize the modular multiplication for the secp256k1 field prime,
which is the pseudo-Mersenne prime 2²⁵⁶-2³²-977, instead of running the generic Montgomery
CIOS loop on it.

**The verdict up front: this is a wash on ecrecover cycles today.** It is roughly 2x faster
where there is instruction-level parallelism to exploit, and exactly break-even where there
is not — and ecrecover turns out to be latency-bound. Opening it as a draft because the
mechanism is worth reviewing on its own terms and it is the prerequisite for the follow-ups
below.

## What it does

For a modulus 2ⁿ-c with a single-word c, the product is reduced by folding the high half
instead of by Montgomery reduction, with values kept in the plain representation:

1. `t, carry = l + h⋅c` — one addmul pass over the high half
2. `r, overflow = t + carry⋅c` — `carry ≤ c`, so this product spans two words at most
3. `if (overflow) r += c` — cannot overflow again
4. `if (r >= Mod) r -= Mod` — the excess is less than c

Because the representation is plain rather than Montgomery, the conversions to and from the
internal form become the identity, so constructing a field element and reading its value are
free.

The backend, and with it the representation, is selected from the *value* of the modulus,
never from a declaration:

| field | 2ⁿ - mod | selected |
|---|---|---|
| secp256k1 p | `0x1000003d1` (33 bits) | pseudo-Mersenne |
| secp256k1 n | ~2¹²⁹ | Montgomery |
| secp256r1 p | 2²²⁴-2¹⁹²-2⁹⁶+1 | Montgomery |
| bn254 q | ~2²⁵⁴ | Montgomery |

A hand-written tag would be redundant with the modulus and could be set inconsistently,
silently producing wrong arithmetic; deriving it cannot desync, and adding a curve needs no
knowledge of which backend to pick.

## Numbers

Per-mul cost on the secp256k1 field, min of 5 reps, perf two-point subtraction:

| regime | instructions | cycles |
|---|---|---|
| serial chain (latency-bound) | -38.7% | **-0.5%** |
| 4 independent chains (throughput-bound) | -52.9% | **-48.5%** |

ecrecover: **-33.4% instructions, cycles unchanged** (median 906k → 909k, IPC 1.88 → 1.18).
bn254 moves by -0.01% instructions, confirming the Montgomery path is untouched.

Multiply counts from the generated code: 21 for the pseudo-Mersenne reduction against 36 for
CIOS in general — but only 28 for *this* modulus, because three of its four words are all-ones
and the compiler strength-reduces `m⋅(2⁶⁴-1)` to a shift and a subtract. So the baseline was
already better than generic CIOS here.

## Why ecrecover does not move

Per-mul latency is identical (~118 cycles, measured directly), and ecrecover's critical path is
a chain of dependent field multiplications — ~5000 of them, of which `field_sqrt` alone is 253
*sequential* squarings.

I first suspected generic `mulq` was serializing the parallel partial products through the fixed
`rdx:rax` pair. Rebuilding both sides with `-march=native`, so `mulx`/`adcx`/`adox` are
available, leaves ecrecover at -33.4% instructions / -0.3% cycles. **Refuted** — neither the
multiply count nor its encoding is what bounds ecrecover.

The most promising lever for ecrecover is therefore not arithmetic at all: `ecc::decompose()`
and the 4-way MSM already exist and are used by bn254, but `secp256k1::Curve` defines no
`LAMBDA`/`BETA`/`X1`…, so ecrecover runs a full 256-doubling ladder. GLV would roughly halve
the critical path. After that, redundant limbs (5×52, how libsecp256k1 wins on latency too) and
a dedicated squaring for `FieldElement`, which it lacks unlike `ExtFieldElem`.

## Correctness

- 1221 unit and integration tests pass, and 1176 in a Debug build with asserts enabled.
- 22.8M-vector differential of the reduction against a `udivrem` reference: zero mismatches,
  every result canonical. Corners, random canonical operands, operands near p, random raw
  512-bit inputs, and crafted inputs for the rare branches.
- Steps 3 and 4 above cannot be reached by any product of canonical operands (~2⁻¹⁹⁰ and
  ~2⁻²²³), so neither ctest nor EEST will ever exercise them. The added unit test *constructs*
  inputs for both, and it is mutation-tested: deleting either branch makes it fail on exactly
  the intended input.
- The plain representation cannot reduce an out-of-range input the way the conversion to the
  Montgomery form does, so `assert(v < Mod)` now enforces the precondition. Note that
  `secp256k1.cpp` deliberately relies on the Montgomery conversion to reduce the message hash
  mod n — that still holds only because n is not pseudo-Mersenne.

## Structure

Four commits, each independently reviewable and landable in order; the last is the optimization:

1. `crypto: Let the binary GCD inversion start from a given coefficient` — exposes the inversion
   loop as `inv_scaled()` so a non-Montgomery representation can seed it with 1 instead of R².
2. `crypto: Add the pseudo-Mersenne modular reduction` — the primitive and its tests, unused.
3. `crypto: Introduce the field arithmetic backend` — the `FieldArith` concept, `MontArith`
   implementing it, and the per-modulus selection. **No functional change**: every field still
   selects Montgomery, and the instruction counts of ecrecover and ecmul move by ≤0.02%.
4. `crypto: Use the pseudo-Mersenne reduction for the secp256k1 field` — adds `PMArith` and lets
   the selection pick it.

`FieldElement` delegates to the backend and contains no algorithm dispatch of its own, so it no
longer knows the internal representation. Two abstractions: the backend family and the element.
`ModArith` keeps its name for now and becomes the runtime-modulus Montgomery backend later.

Scope stops deliberately at two backends. An interface is validated by implementations that
differ along its axes, and these two differ on the representation axis — the one that produced
every constraint here (`inv_scaled`, the `to_internal` precondition). secp256r1 comes along free
as another `MontArith` user: a third user, not a third shape. Left for follow-ups, in order: the
`ModArith` rename, mandatory `sqr` (dead code without a real implementation), the sparse-modulus
refinement (which needs the CIOS loop extracted from `ModArith`, touching every curve's
multiply), asm kernels with cpuid dispatch, and `SolinasArith`.

`FpSpec` is left exactly as it was; folding it away is a separate change.
