### PR TITLE
test: Use the range-based loop in all benchmarks

### DIFF
--- a/test/internal_benchmarks/evmmax_bench.cpp
+++ b/test/internal_benchmarks/evmmax_bench.cpp
@@ -19,11 +19,14 @@ void evmmax_add(benchmark::State& state)
     auto a = Mod / 2;
     auto b = Mod / 3;
 
-    while (state.KeepRunningBatch(2))
+    for ([[maybe_unused]] auto _ : state)
     {
         a = m.add(a, b);
         b = m.add(b, a);
     }
+    state.counters["avg_time_per_item"] =
+        benchmark::Counter(2.0 * static_cast<double>(state.iterations()),
+            benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 
 template <typename UintT, const UintT& Mod>
@@ -33,11 +36,14 @@ void evmmax_sub(benchmark::State& state)
     auto a = Mod / 2;
     auto b = Mod / 3;
 
-    while (state.KeepRunningBatch(2))
+    for ([[maybe_unused]] auto _ : state)
     {
         a = m.sub(a, b);
         b = m.sub(b, a);
     }
+    state.counters["avg_time_per_item"] =
+        benchmark::Counter(2.0 * static_cast<double>(state.iterations()),
+            benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 
 template <typename UintT, const UintT& Mod>
@@ -47,11 +53,14 @@ void evmmax_mul(benchmark::State& state)
     auto a = m.to_mont(Mod / 2);
     auto b = m.to_mont(Mod / 3);
 
-    while (state.KeepRunningBatch(2))
+    for ([[maybe_unused]] auto _ : state)
     {
         a = m.mul(a, b);
         b = m.mul(b, a);
     }
+    state.counters["avg_time_per_item"] =
+        benchmark::Counter(2.0 * static_cast<double>(state.iterations()),
+            benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 }  // namespace
 

--- a/test/internal_benchmarks/find_jumpdest_bench.cpp
+++ b/test/internal_benchmarks/find_jumpdest_bench.cpp
@@ -159,7 +159,7 @@ void find_jumpdest_random(benchmark::State& state)
     const auto begin = map.data();
     benchmark::ClobberMemory();
 
-    while (state.KeepRunningBatch(indexes.size()))
+    for ([[maybe_unused]] auto _ : state)
     {
         for (auto i : indexes)
         {
@@ -167,6 +167,9 @@ void find_jumpdest_random(benchmark::State& state)
             benchmark::DoNotOptimize(x);
         }
     }
+    state.counters["avg_time_per_item"] = benchmark::Counter(
+        static_cast<double>(indexes.size()) * static_cast<double>(state.iterations()),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 
 BENCHMARK_TEMPLATE(find_jumpdest_random, int, linear);
@@ -269,7 +272,7 @@ void find_jumpdest_split_random(benchmark::State& state)
     const auto value = map.value.data();
     benchmark::ClobberMemory();
 
-    while (state.KeepRunningBatch(indexes.size()))
+    for ([[maybe_unused]] auto _ : state)
     {
         for (auto i : indexes)
         {
@@ -277,6 +280,9 @@ void find_jumpdest_split_random(benchmark::State& state)
             benchmark::DoNotOptimize(x);
         }
     }
+    state.counters["avg_time_per_item"] = benchmark::Counter(
+        static_cast<double>(indexes.size()) * static_cast<double>(state.iterations()),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 
 BENCHMARK_TEMPLATE(find_jumpdest_split, uint16_t, lower_bound) ARGS;
@@ -294,7 +300,7 @@ void find_jumpdest_hashmap_random(benchmark::State& state)
     const auto hashmap = std::unordered_map<T, T>{map.begin(), map.end()};
     benchmark::ClobberMemory();
 
-    while (state.KeepRunningBatch(indexes.size()))
+    for ([[maybe_unused]] auto _ : state)
     {
         for (auto i : indexes)
         {
@@ -303,6 +309,9 @@ void find_jumpdest_hashmap_random(benchmark::State& state)
             benchmark::DoNotOptimize(x);
         }
     }
+    state.counters["avg_time_per_item"] = benchmark::Counter(
+        static_cast<double>(indexes.size()) * static_cast<double>(state.iterations()),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 
 BENCHMARK_TEMPLATE(find_jumpdest_hashmap_random, int);

--- a/test/internal_benchmarks/lru_cache_bench.cpp
+++ b/test/internal_benchmarks/lru_cache_bench.cpp
@@ -108,7 +108,7 @@ void lru_cache_put_empty(benchmark::State& state)
         data[i] = static_cast<Key>(i);
     benchmark::ClobberMemory();
 
-    while (state.KeepRunningBatch(static_cast<benchmark::IterationCount>(capacity)))
+    for ([[maybe_unused]] auto _ : state)
     {
         for (const auto& key : data)
         {
@@ -118,6 +118,9 @@ void lru_cache_put_empty(benchmark::State& state)
         cache.clear();
         state.ResumeTiming();
     }
+    state.counters["avg_time_per_item"] =
+        benchmark::Counter(static_cast<double>(capacity) * static_cast<double>(state.iterations()),
+            benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 BENCHMARK(lru_cache_put_empty<int, int>)->Arg(5000);
 BENCHMARK(lru_cache_put_empty<hash256, std::shared_ptr<char>>)->Arg(5000);

--- a/test/precompiles_bench/precompiles_bench.cpp
+++ b/test/precompiles_bench/precompiles_bench.cpp
@@ -213,7 +213,7 @@ void precompile(benchmark::State& state)
 
 
     int64_t total_gas_used = 0;
-    while (state.KeepRunningBatch(inputs<Id>.size()))
+    for ([[maybe_unused]] auto _ : state)
     {
         for (const auto& input : inputs<Id>)
         {
@@ -228,7 +228,10 @@ void precompile(benchmark::State& state)
     }
 
     using benchmark::Counter;
-    state.counters["gas_used"] = Counter(static_cast<double>(batch_gas_cost));
+    const auto num_inputs = static_cast<double>(inputs<Id>.size());
+    state.counters["avg_time_per_input"] = Counter(
+        num_inputs * static_cast<double>(state.iterations()), Counter::kIsRate | Counter::kInvert);
+    state.counters["avg_gas_used"] = Counter(static_cast<double>(batch_gas_cost) / num_inputs);
     state.counters["gas_rate"] = Counter(static_cast<double>(total_gas_used), Counter::kIsRate);
 }
 


### PR DESCRIPTION
Replaces the 8 `state.KeepRunningBatch(N)` loops with the range-based `for (auto _ : state)` one.

`KeepRunningBatch()` never drove the loop body — the body already iterated over all the items itself. The batch size only told google/benchmark to divide the measured time by it, so this changes the reporting, not the executed work:

- **Time** changes from per item to per loop iteration, i.e. it grows by the batch size.
- **avg_time_per_item** (`avg_time_per_input` in `precompiles_bench`) is added and reports what the Time column reported before.
- **gas_used** becomes **avg_gas_used**, the average gas of a single input instead of the whole batch, so that it matches the per-input time: `avg_gas_used / avg_time_per_input` is exactly `gas_rate`.
- **gas_rate** is unchanged, it never depended on the batch size.

Before and after with the same compiler, `precompile<PrecompileId::ecrecover, evmone>`:

```
master   227733 ns    gas_used=30k     gas_rate=13.1736M/s
this PR 2304700 ns    avg_gas_used=3k  gas_rate=13.0173M/s  avg_time_per_input=230.462us
```

The per-item counter matters most for `find_jumpdest` and `lru_cache`, where the batch size is derived from the benchmark argument (`indexes.size()`, `capacity`): without it a larger argument would simply look slower per iteration.

Uniform loops also keep every benchmark measurable by tools instrumenting the range-based loop only, which is the case for the CodSpeed compatibility layer: #1653 currently needs a dedicated macro to swap the loop in its builds, and that macro can be dropped once this lands.