### PR TITLE
crypto: Rename modinv to modinv_pow2

### DIFF
--- a/lib/evmone_precompiles/modarith.hpp
+++ b/lib/evmone_precompiles/modarith.hpp
@@ -8,8 +8,9 @@
 
 namespace evmone::crypto
 {
-/// Compute the modular inverse of the number modulo 2³²: inv⋅a = 1 mod 2³².
-constexpr uint32_t modinv(uint32_t a) noexcept
+/// Computes the modular inverse of a modulo 2³², satisfying a⋅inv = 1 mod 2³².
+/// Only odd arguments are invertible modulo a power of two.
+constexpr uint32_t modinv_pow2(uint32_t a) noexcept
 {
     assert(a % 2 == 1);  // The argument must be odd, otherwise the inverse does not exist.
 
@@ -33,11 +34,12 @@ constexpr uint32_t modinv(uint32_t a) noexcept
     return inv;
 }
 
-/// Compute the modular inverse of the number modulo 2⁶⁴: inv⋅a = 1 mod 2⁶⁴.
-constexpr uint64_t modinv(uint64_t a) noexcept
+/// Computes the modular inverse of a modulo 2⁶⁴, satisfying a⋅inv = 1 mod 2⁶⁴.
+/// Only odd arguments are invertible modulo a power of two.
+constexpr uint64_t modinv_pow2(uint64_t a) noexcept
 {
     assert(a % 2 == 1);  // The argument must be odd, otherwise the inverse does not exist.
-    uint64_t inv = modinv(static_cast<uint32_t>(a));  // Start with inversion mod 2³².
+    uint64_t inv = modinv_pow2(static_cast<uint32_t>(a));  // Start with inversion mod 2³².
     inv *= 2 - a * inv;    // One Newton-Raphson iteration: 64 bits correct.
     assert(inv * a == 1);  // Verify the result.
     return inv;
@@ -49,7 +51,7 @@ constexpr uint64_t compute_mont_mod_inv(const UintT& mod) noexcept
 {
     // Compute the inversion mod[0]⁻¹ mod 2⁶⁴, then the final result is N' = -mod[0]⁻¹
     // because this gives mod⋅N' = -1 mod 2⁶⁴ = 2⁶⁴-1.
-    return -modinv(mod[0]);
+    return -modinv_pow2(mod[0]);
 }
 
 constexpr std::pair<uint64_t, uint64_t> addmul(

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -414,7 +414,7 @@ void modexp_odd(std::span<uint64_t> result, std::span<const uint64_t> base, Expo
     assert(!exp.empty());
 
     const auto n = mod.size();
-    const auto mod_inv = -modinv(mod[0]);
+    const auto mod_inv = -modinv_pow2(mod[0]);
     const auto exp_bits = exp.bit_width();
 
     const auto w = window_width(exp_bits);
@@ -572,13 +572,13 @@ void modinv_pow2(
     assert(!r.empty());
     assert(scratch.size() >= 2 * r.size());
 
-    r[0] = modinv(x[0]);                           // Good start: 64 correct bits.
+    r[0] = crypto::modinv_pow2(x[0]);              // Good start: 64 correct bits.
     std::ranges::fill(r.subspan(1), uint64_t{0});  // Zero the rest for correct final subtraction.
 
     // Newton-Raphson iteration for modular inverse: inv' = inv * (2 - x * inv).
     // Rearranged as: inv' = 2 * inv - x * inv^2, which avoids the (2 - x) negation helper
     // and computes the result directly into r (no copy needed).
-    // Each iteration doubles the number of correct bits. See modinv().
+    // Each iteration doubles the number of correct bits. See modinv_pow2().
     for (size_t i = 1; i < r.size(); i *= 2)
     {
         // We have i-word correct inverse in r[0..i). Double the precision to n = min(2i, r.size()).


### PR DESCRIPTION
`modinv()` computes the inverse modulo a power of two, not a modular inverse, so the name claims
the general operation while implementing the narrower one. Rename it after the modulus it actually
uses. This also frees `modinv` for the modular inversion, which a follow-up adds.

## The overload

`modexp.cpp` already had `modinv_pow2()` for the multi-word case, so the two now form one overload
set: the multi-word version seeds its Newton-Raphson iteration with the single-word result.

That one call has to be qualified:

```cpp
// Qualified because this function hides the single-word overload it needs.
r[0] = crypto::modinv_pow2(x[0]);
```

It sits *inside* the multi-word `modinv_pow2()`, whose own declaration in the unnamed namespace
hides the name, so unqualified lookup stops there and never reaches the overload in
`evmone::crypto`. Without the qualification it fails to compile — the note is in the code so the
qualification does not get tidied away and the error rediscovered.

## Docstrings

Reworded for the renamed pair to name the modulus explicitly and to state the precondition, which
previously lived only in an assert comment:

```cpp
/// Computes the modular inverse of a modulo 2³²: the inv satisfying a⋅inv = 1 mod 2³².
/// Only odd arguments are invertible modulo a power of two.
```

`compute_mont_mod_inv()` keeps its name: it computes the Montgomery constant N′, not an inverse of
the modulus, and it pairs with `compute_r_squared()`.

## Verification

No functional change. 1219 tests pass, including the modexp ones that exercise both overloads.
