### PR TITLE
test: Register the precompile benchmarks uniformly

### DIFF
--- a/test/precompiles_bench/precompiles_bench.cpp
+++ b/test/precompiles_bench/precompiles_bench.cpp
@@ -23,6 +23,7 @@ namespace
 {
 using namespace evmone::state;
 using namespace evmone::test;
+using enum PrecompileId;
 
 /// The revision used for the precompile benchmarks.
 constexpr auto REV = EVMC_OSAKA;
@@ -324,58 +325,21 @@ BENCHMARK(modexp<expmod_execute_gmp>) MODEXP_ARGS;
 #endif
 #undef MODEXP_ARGS
 
-BENCHMARK_TEMPLATE(precompile, PrecompileId::identity, identity_execute);
-
-namespace bench_ecrecovery
-{
-constexpr auto evmone = ecrecover_execute_evmone;
-BENCHMARK_TEMPLATE(precompile, PrecompileId::ecrecover, evmone);
+BENCHMARK(precompile<identity, identity_execute>);
+BENCHMARK(precompile<ecrecover, ecrecover_execute_evmone>);
 #ifdef EVMONE_PRECOMPILES_LIBSECP256K1
-constexpr auto libsecp256k1 = ecrecover_execute_libsecp256k1;
-BENCHMARK_TEMPLATE(precompile, PrecompileId::ecrecover, libsecp256k1);
+BENCHMARK(precompile<ecrecover, ecrecover_execute_libsecp256k1>);
 #endif
-}  // namespace bench_ecrecovery
-
-namespace bench_expmod
-{
-constexpr auto evmone = expmod_execute_evmone;
-BENCHMARK(precompile<PrecompileId::expmod, evmone>);
+BENCHMARK(precompile<expmod, expmod_execute_evmone>);
 #ifdef EVMONE_PRECOMPILES_GMP
-constexpr auto gmp = expmod_execute_gmp;
-BENCHMARK(precompile<PrecompileId::expmod, gmp>);
+BENCHMARK(precompile<expmod, expmod_execute_gmp>);
 #endif
-}  // namespace bench_expmod
-
-namespace bench_ecadd
-{
-constexpr auto evmone_cpp = ecadd_execute;
-BENCHMARK_TEMPLATE(precompile, PrecompileId::ecadd, evmone_cpp);
-}  // namespace bench_ecadd
-
-namespace bench_ecmul
-{
-constexpr auto evmone_cpp = ecmul_execute;
-BENCHMARK_TEMPLATE(precompile, PrecompileId::ecmul, evmone_cpp);
-}  // namespace bench_ecmul
-
-namespace bench_ecpairing
-{
-constexpr auto evmone_cpp = ecpairing_execute;
-BENCHMARK_TEMPLATE(precompile, PrecompileId::ecpairing, evmone_cpp);
-}  // namespace bench_ecpairing
-
-namespace bench_kzg
-{
-constexpr auto evmone_blst = point_evaluation_execute;
-BENCHMARK_TEMPLATE(precompile, PrecompileId::point_evaluation, evmone_blst);
-}  // namespace bench_kzg
+BENCHMARK(precompile<ecadd, ecadd_execute>);
+BENCHMARK(precompile<ecmul, ecmul_execute>);
+BENCHMARK(precompile<ecpairing, ecpairing_execute>);
+BENCHMARK(precompile<point_evaluation, point_evaluation_execute>);
+BENCHMARK(precompile<p256verify, p256verify_execute>);
 
 }  // namespace
-
-namespace bench_p256verify
-{
-constexpr auto evmone_cpp = p256verify_execute;
-BENCHMARK_TEMPLATE(precompile, PrecompileId::p256verify, evmone_cpp);
-}  // namespace bench_p256verify
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
The implementation functions are passed to `BENCHMARK()` directly instead of through aliases, which makes the seven namespaces that only existed to keep those aliases apart unnecessary, replaces the legacy `BENCHMARK_TEMPLATE()` with the form the modexp benchmarks in the same file already use, and a `using enum` declaration drops the redundant qualification from the generated names — `precompile<ecadd, ecadd_execute>` instead of `precompile<PrecompileId::ecadd, evmmax_cpp>`, now naming the measured implementation exactly. The benchmarks themselves are unchanged; this only removes 36 lines and makes the registrations uniform, which also keeps the names free of the `::` that CodSpeed reserves for its `file::name` URI separator (#1653).