### PR TITLE
build: Require CMake 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.22...4.2)
+cmake_minimum_required(VERSION 3.25...4.2)
 
 option(BUILD_SHARED_LIBS "Build evmone as a shared library" ON)
 option(COVERAGE "Build with coverage instrumentation" OFF)
@@ -36,15 +36,11 @@ if(PROJECT_VERSION_MAJOR EQUAL 0)
     set(PROJECT_SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
 endif()
 
-if(COMMAND block) # TODO(cmake-3.25)
-    block()
-        set(CMAKE_C_CLANG_TIDY "")
-        set(CMAKE_CXX_CLANG_TIDY "")
-        add_subdirectory(evmc)
-    endblock()
-else()
+block()
+    set(CMAKE_C_CLANG_TIDY "")
+    set(CMAKE_CXX_CLANG_TIDY "")
     add_subdirectory(evmc)
-endif()
+endblock()
 
 cable_configure_compiler(NO_STACK_PROTECTION)
 if(CABLE_COMPILER_GNULIKE)

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 16
   linux-gcc-min:
     docker:
-      - image: ethereum/cpp-build-env:17-gcc-11
+      - image: ethereum/cpp-build-env:20-gcc-11
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/circle.yml
+++ b/circle.yml
@@ -638,7 +638,7 @@ jobs:
     executor: linux-base
     steps:
       - install_cmake:
-          version: 3.22.6
+          version: 3.25.3
       - build
       - test
 

--- a/lib/evmone/create_address.cpp
+++ b/lib/evmone/create_address.cpp
@@ -28,7 +28,10 @@ address compute_create_address(const address& sender, uint64_t sender_nonce) noe
     }
     else  // Prefixed integer encoding.
     {
-        const auto num_nonzero_bytes = (std::bit_width(sender_nonce) + 7) / 8;
+        // TODO(gcc-13): bit_width returns int after
+        // [LWG 3656](https://cplusplus.github.io/LWG/issue3656).
+        // NOLINTNEXTLINE(readability-redundant-casting)
+        const auto num_nonzero_bytes = static_cast<int>((std::bit_width(sender_nonce) + 7) / 8);
         *p++ = static_cast<uint8_t>(RLP_STR_BASE + num_nonzero_bytes);
         intx::be::unsafe::store(p, sender_nonce);
         p = std::shift_left(p, p + MAX_NONCE_SIZE, MAX_NONCE_SIZE - num_nonzero_bytes);

--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -50,28 +50,28 @@ if(EVMONE_PRECOMPILES_LIBSECP256K1)
         URL https://github.com/bitcoin-core/secp256k1/archive/refs/tags/v0.8.0.tar.gz
         URL_HASH SHA256=eb52b0e9239dff7dc26be5f9623567141b8720ec47da29eb3c1e0a660d17c8bb
     )
-    # TODO(cmake-3.25): Use block().
-    set(BUILD_SHARED_LIBS_ORIG ${BUILD_SHARED_LIBS})
-    set(BUILD_SHARED_LIBS OFF)
-    set(SECP256K1_ENABLE_MODULE_ELLSWIFT OFF)
-    set(SECP256K1_ENABLE_MODULE_MUSIG OFF)
-    set(SECP256K1_ENABLE_MODULE_SILENTPAYMENTS OFF)
-    set(SECP256K1_ENABLE_MODULE_SCHNORRSIG OFF)
-    set(SECP256K1_ENABLE_MODULE_EXTRAKEYS OFF)
-    set(SECP256K1_ENABLE_MODULE_RECOVERY ON)
-    set(SECP256K1_ENABLE_MODULE_ECDH OFF)
-    # On x86_64 using asm is ~1% worse. Untested on ARM.
-    set(SECP256K1_ASM OFF)
-    set(SECP256K1_BUILD_BENCHMARK OFF)
-    set(SECP256K1_BUILD_TESTS OFF)
-    set(SECP256K1_BUILD_EXHAUSTIVE_TESTS OFF)
-    set(SECP256K1_BUILD_CTIME_TESTS OFF)
-    set(SECP256K1_INSTALL OFF)
-    set(SECP256K1_BUILD_EXAMPLES OFF)
-    # Not needed for static library.
-    set(SECP256K1_ENABLE_API_VISIBILITY_ATTRIBUTES OFF)
-    set(SECP256K1_VALGRIND OFF)
-    FetchContent_MakeAvailable(libsecp256k1)
+    block()
+        set(BUILD_SHARED_LIBS OFF)
+        set(SECP256K1_ENABLE_MODULE_ELLSWIFT OFF)
+        set(SECP256K1_ENABLE_MODULE_MUSIG OFF)
+        set(SECP256K1_ENABLE_MODULE_SILENTPAYMENTS OFF)
+        set(SECP256K1_ENABLE_MODULE_SCHNORRSIG OFF)
+        set(SECP256K1_ENABLE_MODULE_EXTRAKEYS OFF)
+        set(SECP256K1_ENABLE_MODULE_RECOVERY ON)
+        set(SECP256K1_ENABLE_MODULE_ECDH OFF)
+        # On x86_64 using asm is ~1% worse. Untested on ARM.
+        set(SECP256K1_ASM OFF)
+        set(SECP256K1_BUILD_BENCHMARK OFF)
+        set(SECP256K1_BUILD_TESTS OFF)
+        set(SECP256K1_BUILD_EXHAUSTIVE_TESTS OFF)
+        set(SECP256K1_BUILD_CTIME_TESTS OFF)
+        set(SECP256K1_INSTALL OFF)
+        set(SECP256K1_BUILD_EXAMPLES OFF)
+        # Not needed for static library.
+        set(SECP256K1_ENABLE_API_VISIBILITY_ATTRIBUTES OFF)
+        set(SECP256K1_VALGRIND OFF)
+        FetchContent_MakeAvailable(libsecp256k1)
+    endblock()
     foreach(TARGET secp256k1 secp256k1_precomputed)
         set_target_properties(
             ${TARGET}
@@ -89,7 +89,6 @@ if(EVMONE_PRECOMPILES_LIBSECP256K1)
         precompiles_libsecp256k1.hpp
         precompiles_libsecp256k1.cpp
     )
-    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_ORIG})
 endif()
 
 option(EVMONE_PRECOMPILES_GMP "Enable precompiles implementations via the GMP/MPIR library" OFF)


### PR DESCRIPTION
Bumps the required CMake to 3.25, which is the version providing `block()`. This resolves the two `TODO(cmake-3.25)`s: the `if(COMMAND block)` fallback around the evmc clang-tidy suppression, and the libsecp256k1 option overrides, which no longer need `BUILD_SHARED_LIBS` to be saved and restored by hand. Of the current LTS distributions only Ubuntu 22.04 (3.22.1) falls below the new minimum — Debian 12 has 3.25.1, RHEL 9 has 3.26.5, Ubuntu 24.04 has 3.28.3 and Debian 13 has 3.31.6 — and 3.25 is the largest bump that leaves all of the others in place.

Two CI jobs need to come along. `gcc-min` runs the Ubuntu 22.04 based `cpp-build-env:17-gcc-11` image, which is limited to CMake 3.22, so it moves to `20-gcc-11`: the newest image still offering GCC 11, Debian 12 based and therefore on CMake 3.25.1. `cmake-min` moves to 3.25.3 and thereby starts honoring the `CMAKE_COMPILE_WARNING_AS_ERROR` it has always been passed, that variable having been added in CMake 3.24. Both of those jobs use GCC 11 and neither ever had warnings as errors in effect, which is why the `std::bit_width()` cast dropped in #1590 has to come back: libstdc++ returns the argument's unsigned type until GCC 13, making the `std::shift_left()` distance unsigned.