### PR TITLE
build: Fetch google/benchmark instead of using Hunter

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -2,8 +2,6 @@
 # Copyright 2018 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-include(hunter_cmake_args)
-
 hunter_config(
     intx
     VERSION 0.15.0
@@ -30,16 +28,4 @@ hunter_config(
     VERSION 3.12.0
     URL https://github.com/nlohmann/json/archive/v3.12.0.tar.gz
     SHA1 815212d8acbddc87009667c52ba98a8404efec18
-)
-
-# Propagate BENCHMARK_ENABLE_LIBPFM to google/benchmark.
-# https://github.com/google/benchmark/blob/v1.9.4/CMakeLists.txt#L42
-option(BENCHMARK_ENABLE_LIBPFM "Enable performance counters provided by libpfm" OFF)
-
-hunter_config(
-    benchmark
-    VERSION 1.9.5
-    CMAKE_ARGS BENCHMARK_ENABLE_LIBPFM=${BENCHMARK_ENABLE_LIBPFM}
-    URL https://github.com/google/benchmark/archive/v1.9.5.tar.gz
-    SHA1 1923d665fc134fca137fea0951403d043b5b7732
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright 2019-2020 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+include(FetchContent)
 include(GoogleTest)
 
 set(evmone_private_include_dir ${PROJECT_SOURCE_DIR}/lib)
@@ -12,8 +13,23 @@ find_package(CLI11 CONFIG REQUIRED)
 hunter_add_package(GTest)
 find_package(GTest CONFIG REQUIRED)
 
-hunter_add_package(benchmark)
-find_package(benchmark CONFIG REQUIRED)
+FetchContent_Declare(
+    benchmark
+    URL https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz
+    URL_HASH SHA256=9631341c82bac4a288bef951f8b26b41f69021794184ece969f8473977eaa340
+)
+block()
+    set(BUILD_SHARED_LIBS OFF)
+    set(BENCHMARK_ENABLE_TESTING OFF)
+    set(BENCHMARK_ENABLE_INSTALL OFF)
+    FetchContent_MakeAvailable(benchmark)
+endblock()
+set_target_properties(
+    benchmark benchmark_main PROPERTIES
+    COMPILE_OPTIONS $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-w>
+    CXX_CLANG_TIDY ""
+    SYSTEM TRUE  # TODO(cmake-3.26): Use the SYSTEM option of FetchContent_Declare().
+)
 
 include(CableBuildInfo)
 cable_add_buildinfo_library(PROJECT_NAME evmone)


### PR DESCRIPTION
Moves google/benchmark from Hunter to `FetchContent`, pulling the very same v1.9.5 tarball (the SHA-256 recorded here is of the archive the Hunter entry pinned by SHA-1). Because `FetchContent_MakeAvailable()` adds it as a subdirectory, it is now compiled with the project's own settings rather than as an external package, so its targets get warnings and clang-tidy turned off — `-Wsign-conversion` alone breaks it in three places — and `BUILD_SHARED_LIBS` is forced off to keep the library static as Hunter had it. The `SYSTEM` target property keeps its headers out of the warning set of the code including them, matching what an imported target used to provide. It is set there rather than passed to `FetchContent_Declare()`, whose `SYSTEM` keyword is not stripped before being forwarded to `ExternalProject_Add()` in CMake 3.25.1, the version Debian 12 and therefore the `gcc-min` image ships.

`BENCHMARK_ENABLE_LIBPFM` is now the cache option declared by google/benchmark itself, so `-DBENCHMARK_ENABLE_LIBPFM=ON` reaches it directly and the `option()` plus `CMAKE_ARGS` forwarding is gone, together with the `include(hunter_cmake_args)` it was the last apparent user of. Verified with a clean build of every target under `CMAKE_COMPILE_WARNING_AS_ERROR=TRUE` (no warnings), an install and a `ctest` run, on both CMake 3.25.1 and 4.2.