### PR TITLE
crypto: Reduce the exponent for the power-of-two modulus part

### DIFF
--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -541,10 +541,44 @@ void modexp_pow2(std::span<uint64_t> r, std::span<const uint64_t> base, Exponent
 
     const auto base_k = base.subspan(0, std::min(base.size(), num_pow2_words));
 
+    // The full exponent is not needed: base^exp % 2^k collapses to 0 for an even base
+    // and depends only on a bounded number of the low exponent bits for an odd one.
+    auto num_bits = exp.bit_width();
+    if ((base[0] & 1) == 0)  // base[0] is the least significant word, i.e. the base parity.
+    {
+        // For an even base the result is 0 once exp >= k. The bit width comparison is a
+        // sufficient condition: exp >= 2^(num_bits - 1) >= 2^bit_width(k) > k.
+        if (num_bits > static_cast<unsigned>(std::bit_width(k)))
+        {
+            std::ranges::fill(r_k, uint64_t{0});
+            return;
+        }
+    }
+    else
+    {
+        // An odd base satisfies base^λ ≡ 1 (mod 2^k), so base^exp ≡ base^(exp mod λ), which
+        // is the low period_bits of the exponent.
+        // λ is the Carmichael function: λ(2ᵏ) = 2ᵏ⁻² if k > 2 else 2ᵏ⁻¹.
+        if (const auto period_bits = k > 2 ? k - 2 : k - 1; num_bits > period_bits)
+        {
+            // Trim the leading zero bits of the reduced exponent.
+            num_bits = period_bits;
+            while (num_bits != 0 && !exp[num_bits - 1])
+                --num_bits;
+
+            if (num_bits == 0)  // The exponent is reduced to 0 and base^0 % 2^k == 1.
+            {
+                std::ranges::fill(r_k, uint64_t{0});
+                r_k[0] = 1;
+                return;
+            }
+        }
+    }
+
     const auto [_, pad] = std::ranges::copy(base_k, r_k.begin());
     std::ranges::fill(std::span{pad, r_k.end()}, uint64_t{0});
 
-    for (auto i = exp.bit_width() - 1; i != 0; --i)
+    for (auto i = num_bits - 1; i != 0; --i)
     {
         mul(tmp, r_k, r_k);
         std::swap(r_k, tmp);

--- a/test/precompiles_bench/precompiles_bench.cpp
+++ b/test/precompiles_bench/precompiles_bench.cpp
@@ -252,6 +252,7 @@ void modexp(benchmark::State& state)
     intx::be::unsafe::store(&input[32], intx::uint256{exp_len});
     intx::be::unsafe::store(&input[64], intx::uint256{base_mod_len});
     const std::span payload{&input[3 * 32], payload_len};
+    // TODO: The base is always odd, so the even base path of the power-of-two part is not covered.
     std::fill_n(&payload[0], base_mod_len, 0xff);
     std::fill_n(&payload[base_mod_len + 1], exp_len - 1, 0xff);
     payload[base_mod_len] = 0xff >> exp_clz;

--- a/test/unittests/precompiles_expmod_test.cpp
+++ b/test/unittests/precompiles_expmod_test.cpp
@@ -358,6 +358,35 @@ TEST_P(expmod, inputs)
         {"03", "08f83d563ebc382e09e4b8245edebc817af708",
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
             "8016137e4c542dd66f4ab5f668fc0ac76d43353a675f3d4616a56f23757e463ca1093164385ef006"},
+        // Exponent reduction for the power-of-two part of the modulus.
+        // Odd base, k=1: the exponent reduces to nothing, the power-of-two part is 1.
+        {"05", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "06", "05"},
+        // Odd base, k=8: the exponent 64 == 2^6 reduces to 0, the power-of-two part is 1.
+        {"03", "40", "ff00", "aa01"},
+        // Odd base, k=8: the exponent reduces to its low 6 bits.
+        {"ab", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "7fffffffffffffffffffffffffffff00", "47548b40b49c4c051dfb86e2c2c5fc03"},
+        // Odd base, k=8: the reduced exponent has leading zero bits to skip.
+        {"ab", "44", "ff00", "f9b1"},
+        // Even base with exp >= k: the power-of-two part is 0.
+        {"02", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "7fffffffffffffffffffffffffffff00", "00000000002000000000000000000000"},
+        // Even base with exp < k: the power-of-two part is 2^32.
+        {"02", "20", "ffffffffffffffff0000000000000000", "00000000000000000000000100000000"},
+        // Even base with exp < k of the same bit width: the comparison must be strict.
+        {"02", "09", "5000", "0200"},
+        // Modulus 2^64 (trivial odd part) with odd base.
+        {"ab", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "010000000000000000", "0080bfa02fe80bfa03"},
+        // Modulus 2^64 with even base and exp >= k.
+        {"06", "0100", "010000000000000000", "000000000000000000"},
+        // Even modulus with k=2: the exponent reduces to a single bit.
+        {"07", "010000000000000001", "0300000000000000000000000000000004",
+            "00746574c451e5b990a792326fa8db4c8b"},
+        // Odd base, k=3: the smallest k reduced with λ(2^k) = 2^(k-2).
+        {"05", "03", "18", "05"},
+        // Even base with the low word of zero: the parity comes from the low word, not the top.
+        {"010000000000000000", "02", "06", "04"},
     };
 
     for (const auto& [base_hex, exp_hex, mod_hex, expected_result_hex] : test_cases)


### PR DESCRIPTION
modexp_pow2 iterated over every exponent bit although base^exp % 2ᵏ is periodic in exp. For an odd base the multiplicative order divides λ(2ᵏ) = 2ᵏ⁻², so only that many low bits of the exponent matter. For an even base the result is 0 once exp >= k, which the bit widths of exp and k are enough to decide. Either way the loop is now bounded by k instead of the exponent width: for a modulus with 8 trailing zero bits and an 8192-bit exponent it processes 6 exponent bits instead of 8192.

Gives up to ~30% fewer cycles for even moduli with wide exponents.
