### PR TITLE
crypto: Drop the runtime-modulus Montgomery arithmetic

### DIFF
--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -29,12 +29,12 @@ concept FieldSpec = requires { T::ORDER; };
 template <FieldSpec Spec>
 class FieldElement
 {
-    using uint_type = std::remove_const_t<decltype(Spec::ORDER)>;
-    static constexpr ModArith<uint_type> Fp{Spec::ORDER};
+    using Arith = MontgomeryArith<Spec::ORDER>;
+    using uint_type = Arith::uint_type;
 
     uint_type value_;
 
-    /// Wraps a value into the Element type assuming it is already in the internal ModArith form.
+    /// Wraps a value into the Element type assuming it is already in the internal Arith form.
     [[gnu::always_inline]] static constexpr FieldElement wrap(const uint_type& v) noexcept
     {
         FieldElement element;
@@ -48,9 +48,9 @@ public:
 
     FieldElement() = default;
 
-    constexpr explicit FieldElement(uint_type v) : value_{Fp.to_mont(v)} {}
+    constexpr explicit FieldElement(uint_type v) : value_{Arith::to_internal(v)} {}
 
-    constexpr uint_type value() const noexcept { return Fp.from_mont(value_); }
+    constexpr uint_type value() const noexcept { return Arith::from_internal(value_); }
 
     /// The valid range for from_bytes().
     enum class Range : bool
@@ -85,45 +85,45 @@ public:
 
     friend constexpr auto operator*(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.mul(a.value_, b.value_));
+        return wrap(Arith::mul(a.value_, b.value_));
     }
 
     friend constexpr auto operator+(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.add(a.value_, b.value_));
+        return wrap(Arith::add(a.value_, b.value_));
     }
 
     FieldElement& operator+=(const FieldElement& b) noexcept
     {
-        value_ = Fp.add(value_, b.value_);
+        value_ = Arith::add(value_, b.value_);
         return *this;
     }
 
     friend constexpr auto operator-(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.sub(a.value_, b.value_));
+        return wrap(Arith::sub(a.value_, b.value_));
     }
 
     friend constexpr auto operator-(const FieldElement& a) noexcept
     {
-        return wrap(Fp.sub(0, a.value_));
+        return wrap(Arith::sub(0, a.value_));
     }
 
-    /// Division returns 0 when the divisor is 0. See ModArith::inv().
+    /// Division returns 0 when the divisor is 0. See MontgomeryArith::inv().
     friend constexpr auto operator/(one_t, const FieldElement& a) noexcept
     {
-        return wrap(Fp.inv(a.value_));
+        return wrap(Arith::inv(a.value_));
     }
 
-    /// Division returns 0 when the divisor is 0. See ModArith::inv().
+    /// Division returns 0 when the divisor is 0. See MontgomeryArith::inv().
     friend constexpr auto operator/(const FieldElement& a, const FieldElement& b) noexcept
     {
-        return wrap(Fp.mul(a.value_, Fp.inv(b.value_)));
+        return wrap(Arith::mul(a.value_, Arith::inv(b.value_)));
     }
 
     /// Named 1/x inversion method. Needed in the pairing templates.
-    /// Returns 0 when this element is 0. See ModArith::inv().
-    constexpr auto inv() const noexcept { return wrap(Fp.inv(value_)); }
+    /// Returns 0 when this element is 0. See MontgomeryArith::inv().
+    constexpr auto inv() const noexcept { return wrap(Arith::inv(value_)); }
 
     /// Named one element. Needed in the pairing templates.
     static constexpr auto one() noexcept { return FieldElement{1}; }
@@ -518,17 +518,17 @@ template <typename Curve>
 {
     // Verify k ≡ k₁ + k₂·λ (mod N).
     {
-        static constexpr ModArith N{Curve::ORDER};
-        auto r_k1 = N.to_mont(k1.value);
+        using N = MontgomeryArith<Curve::ORDER>;
+        auto r_k1 = N::to_internal(k1.value);
         if (k1.sign)
-            r_k1 = N.sub(0, r_k1);
-        auto r_k2 = N.to_mont(k2.value);
+            r_k1 = N::sub(0, r_k1);
+        auto r_k2 = N::to_internal(k2.value);
         if (k2.sign)
-            r_k2 = N.sub(0, r_k2);
+            r_k2 = N::sub(0, r_k2);
 
-        const auto r_k = N.to_mont(k);
+        const auto r_k = N::to_internal(k);
 
-        const auto right = N.add(r_k1, N.mul(r_k2, N.to_mont(Curve::LAMBDA)));
+        const auto right = N::add(r_k1, N::mul(r_k2, N::to_internal(Curve::LAMBDA)));
         if (r_k != right)
             return false;
     }

--- a/lib/evmone_precompiles/expmod.tmpl
+++ b/lib/evmone_precompiles/expmod.tmpl
@@ -1,7 +1,7 @@
 {{- $exponent := "" -}}
 {{- range $exponent = $.Chain }}{{ end -}}
 
-uint256 expmod_(const ModArith<uint256>& m, const uint256& x) noexcept
+Curve::Fp expmod_(const Curve::Fp& x) noexcept
 {
     // Computes modular exponentiation
     // x^{{ printf "%#x" $exponent }}
@@ -15,29 +15,29 @@ uint256 expmod_(const ModArith<uint256>& m, const uint256& x) noexcept
     {{- end }}
 
     // Allocate Temporaries.
-    uint256 z;
+    Curve::Fp z;
     {{- range .Program.Temporaries }}
-    uint256 {{ . }};
+    Curve::Fp {{ . }};
     {{- end }}
 
     {{ range $i := .Program.Instructions }}
     // {{ printf "Step %d: %s = x^%#x" $i.Output.Index $i.Output (index $.Chain $i.Output.Index) }}
     {{- with add $i.Op }}
-    {{ $i.Output }} = m.mul({{ .X }}, {{ .Y }});
+    {{ $i.Output }} = {{ .X }} * {{ .Y }};
     {{ end -}}
 
     {{- with double $i.Op }}
-    {{ $i.Output }} = m.mul({{ .X }}, {{ .X }});
+    {{ $i.Output }} = {{ .X }} * {{ .X }};
     {{ end -}}
 
     {{- with shift $i.Op -}}
     {{- $first := 0 -}}
     {{- if ne $i.Output.Identifier .X.Identifier }}
-    {{ $i.Output }} = m.mul({{ .X }}, {{ .X }});
+    {{ $i.Output }} = {{ .X }} * {{ .X }};
     {{- $first = 1 -}}
     {{- end }}
     for (int i = {{ $first }}; i < {{ .S }}; ++i)
-        {{ $i.Output }} = m.mul({{ $i.Output }}, {{ $i.Output }});
+        {{ $i.Output }} = {{ $i.Output }} * {{ $i.Output }};
     {{ end -}}
     {{- end }}
     return z;

--- a/lib/evmone_precompiles/modarith.hpp
+++ b/lib/evmone_precompiles/modarith.hpp
@@ -152,60 +152,45 @@ constexpr UintT modinv_scaled(const UintT& x, const UintT& scale, const UintT& m
 }
 
 /// The modular arithmetic operations using the Montgomery form of the values.
-template <typename UintT>
-class ModArith
+/// The modulus is a compile-time constant, given as a reference to it.
+template <const auto& Mod>
+struct MontgomeryArith
 {
-    const UintT mod_;  ///< The modulus.
+    using uint_type = std::remove_cvref_t<decltype(Mod)>;
 
-    const UintT r_squared_;  ///< R² % mod.
+    /// The alias to the modulus.
+    static constexpr auto& MOD = Mod;
 
-    /// The modulus inversion, i.e. the number N' such that mod⋅N' = 2⁶⁴-1.
-    const uint64_t mod_inv_;
-
-    /// Compute R² % mod.
-    static constexpr UintT compute_r_squared(const UintT& mod) noexcept
-    {
-        // R is 2^num_bits, R² is 2^(2*num_bits) and needs 2*num_bits+1 bits to represent,
-        // rounded to 2*num_bits+64 for intx requirements.
-        constexpr auto RR = intx::uint<UintT::num_bits * 2 + 64>{1} << (UintT::num_bits * 2);
-        return intx::udivrem(RR, mod).rem;
-    }
-
-public:
-    constexpr explicit ModArith(const UintT& mod) noexcept
-      : mod_{mod}, r_squared_{compute_r_squared(mod)}, mod_inv_{compute_mont_mod_inv(mod)}
-    {}
-
-    /// Returns the modulus.
-    constexpr const UintT& mod() const noexcept { return mod_; }
-
-    /// Converts a value to Montgomery form.
+    /// Converts a value to the internal (Montgomery) form.
     ///
     /// This is done by using Montgomery multiplication mul(x, R²)
     /// what gives aR²R⁻¹ % mod = aR % mod.
-    constexpr UintT to_mont(const UintT& x) const noexcept { return mul(x, r_squared_); }
+    static constexpr uint_type to_internal(const uint_type& x) noexcept
+    {
+        return mul(x, R_SQUARED);
+    }
 
-    /// Converts a value in Montgomery form back to normal value.
+    /// Converts a value in the internal (Montgomery) form back to normal value.
     ///
     /// Given the x is the Montgomery form x = aR, the conversion is done by using
     /// Montgomery multiplication mul(x, 1) what gives aRR⁻¹ % mod = a % mod.
-    constexpr UintT from_mont(const UintT& x) const noexcept { return mul(x, 1); }
+    static constexpr uint_type from_internal(const uint_type& x) noexcept { return mul(x, 1); }
 
     /// Performs a Montgomery modular multiplication.
     ///
     /// Inputs must be in Montgomery form: x = aR, y = bR.
     /// This computes Montgomery multiplication xyR⁻¹ % mod what gives aRbRR⁻¹ % mod = abR % mod.
     /// The result (abR) is in Montgomery form.
-    constexpr UintT mul(const UintT& x, const UintT& y) const noexcept
+    static constexpr uint_type mul(const uint_type& x, const uint_type& y) noexcept
     {
         // Coarsely Integrated Operand Scanning (CIOS) Method
         // Based on 2.3.2 from
         // High-Speed Algorithms & Architectures For Number-Theoretic Cryptosystems
         // https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf
 
-        constexpr auto S = UintT::num_words;  // TODO(C++23): Make it static
+        constexpr auto S = uint_type::num_words;  // TODO(C++23): Make it static
 
-        intx::uint<UintT::num_bits + 64> t;
+        intx::uint<uint_type::num_bits + 64> t;
         for (size_t i = 0; i != S; ++i)
         {
             uint64_t c = 0;
@@ -216,43 +201,53 @@ public:
             t[S] = tmp.value;
             const auto d = tmp.carry;  // TODO: Carry is 0 for sparse modulus.
 
-            const auto m = t[0] * mod_inv_;
-            std::tie(c, std::ignore) = addmul(t[0], m, mod_[0], 0);
+            const auto m = t[0] * MOD_INV;
+            std::tie(c, std::ignore) = addmul(t[0], m, MOD[0], 0);
 #pragma GCC unroll 8
             for (size_t j = 1; j != S; ++j)
-                std::tie(c, t[j - 1]) = addmul(t[j], m, mod_[j], c);
+                std::tie(c, t[j - 1]) = addmul(t[j], m, MOD[j], c);
             tmp = intx::addc(t[S], c);
             t[S - 1] = tmp.value;
             t[S] = d + tmp.carry;  // TODO: Carry is 0 for sparse modulus.
         }
 
-        if (t >= mod_)
-            t -= mod_;
+        if (t >= MOD)
+            t -= MOD;
 
-        return static_cast<UintT>(t);
+        return static_cast<uint_type>(t);
     }
 
     /// Performs a modular addition.
-    constexpr UintT add(const UintT& x, const UintT& y) const noexcept
+    static constexpr uint_type add(const uint_type& x, const uint_type& y) noexcept
     {
         // Using generic procedure is fine for Montgomery forms.
-        return modadd(x, y, mod_);
+        return modadd(x, y, MOD);
     }
 
     /// Performs a modular subtraction.
-    constexpr UintT sub(const UintT& x, const UintT& y) const noexcept
+    static constexpr uint_type sub(const uint_type& x, const uint_type& y) noexcept
     {
         // Using generic procedure is fine for Montgomery forms.
-        return modsub(x, y, mod_);
+        return modsub(x, y, MOD);
     }
 
     /// Computes modular inverse of x in Montgomery form. Result is in Montgomery form.
     /// Returns 0 for non-invertible x (including x == 0).
-    constexpr UintT inv(const UintT& x) const noexcept
+    static constexpr uint_type inv(const uint_type& x) noexcept
     {
         // The input XR would invert to X⁻¹R⁻¹, so scaling by R² gives the expected Montgomery
         // form X⁻¹R at no extra cost.
-        return modinv_scaled(x, r_squared_, mod_);
+        return modinv_scaled(x, R_SQUARED, MOD);
     }
+
+private:
+    /// The modulus inversion, i.e. the number N' such that MOD⋅N' = 2⁶⁴-1.
+    static constexpr uint64_t MOD_INV = compute_mont_mod_inv(Mod);
+
+    /// R² % MOD, where R is 2^num_bits. R² is 2^(2*num_bits) and needs 2*num_bits+1 bits to
+    /// represent, rounded to 2*num_bits+64 for intx requirements.
+    static constexpr uint_type R_SQUARED =
+        intx::udivrem(intx::uint<uint_type::num_bits * 2 + 64>{1} << (uint_type::num_bits * 2), Mod)
+            .rem;
 };
 }  // namespace evmone::crypto

--- a/lib/evmone_precompiles/secp256r1.cpp
+++ b/lib/evmone_precompiles/secp256r1.cpp
@@ -38,16 +38,16 @@ bool verify(const ethash::hash256& h, const uint256& r, const uint256& s, const 
     if (!is_on_curve(Q))
         return false;
 
-    const ModArith n{Curve::ORDER};
+    using N = MontgomeryArith<Curve::ORDER>;
 
     // 3. Let z be the Lₙ leftmost bits of e = HASH(m).
     static_assert(Curve::ORDER > 1_u256 << 255);
     const auto z = intx::be::load<uint256>(h.bytes);
 
     // 4. Calculate u₁ = zs⁻¹ mod n and u₂ = rs⁻¹ mod n.
-    const auto s_inv = n.inv(n.to_mont(s));
-    const auto u1 = n.from_mont(n.mul(n.to_mont(z), s_inv));
-    const auto u2 = n.from_mont(n.mul(n.to_mont(r), s_inv));
+    const auto s_inv = N::inv(N::to_internal(s));
+    const auto u1 = N::from_internal(N::mul(N::to_internal(z), s_inv));
+    const auto u2 = N::from_internal(N::mul(N::to_internal(r), s_inv));
 
     // 5. Calculate the curve point R = (x₁, y₁) = u₁×G + u₂×Q.
     const auto R = ecc::to_affine(msm(u1, G, u2, Q));

--- a/test/internal_benchmarks/modarith_bench.cpp
+++ b/test/internal_benchmarks/modarith_bench.cpp
@@ -6,6 +6,7 @@
 #include <evmone_precompiles/modarith.hpp>
 
 using namespace intx;
+using evmone::crypto::MontgomeryArith;
 
 namespace
 {
@@ -14,58 +15,58 @@ constexpr auto secp256k1 = 0xfffffffffffffffffffffffffffffffffffffffffffffffffff
 
 // Each pair of operations forms a single dependency chain, so the reported time is the latency.
 
-template <typename UintT, const UintT& Mod>
+template <const auto& Mod>
 void modarith_add(benchmark::State& state)
 {
-    const evmone::crypto::ModArith<UintT> m{Mod};
+    using M = MontgomeryArith<Mod>;
     auto a = Mod / 2;
     auto b = Mod / 3;
 
     while (state.KeepRunningBatch(2))
     {
-        a = m.add(a, b);
-        b = m.add(b, a);
+        a = M::add(a, b);
+        b = M::add(b, a);
     }
     benchmark::DoNotOptimize(a);
     benchmark::DoNotOptimize(b);
 }
 
-template <typename UintT, const UintT& Mod>
+template <const auto& Mod>
 void modarith_sub(benchmark::State& state)
 {
-    const evmone::crypto::ModArith<UintT> m{Mod};
+    using M = MontgomeryArith<Mod>;
     auto a = Mod / 2;
     auto b = Mod / 3;
 
     while (state.KeepRunningBatch(2))
     {
-        a = m.sub(a, b);
-        b = m.sub(b, a);
+        a = M::sub(a, b);
+        b = M::sub(b, a);
     }
     benchmark::DoNotOptimize(a);
     benchmark::DoNotOptimize(b);
 }
 
-template <typename UintT, const UintT& Mod>
+template <const auto& Mod>
 void modarith_mul(benchmark::State& state)
 {
-    const evmone::crypto::ModArith<UintT> m{Mod};
-    auto a = m.to_mont(Mod / 2);
-    auto b = m.to_mont(Mod / 3);
+    using M = MontgomeryArith<Mod>;
+    auto a = M::to_internal(Mod / 2);
+    auto b = M::to_internal(Mod / 3);
 
     while (state.KeepRunningBatch(2))
     {
-        a = m.mul(a, b);
-        b = m.mul(b, a);
+        a = M::mul(a, b);
+        b = M::mul(b, a);
     }
     benchmark::DoNotOptimize(a);
     benchmark::DoNotOptimize(b);
 }
 }  // namespace
 
-BENCHMARK_TEMPLATE(modarith_add, uint256, bn254);
-BENCHMARK_TEMPLATE(modarith_add, uint256, secp256k1);
-BENCHMARK_TEMPLATE(modarith_sub, uint256, bn254);
-BENCHMARK_TEMPLATE(modarith_sub, uint256, secp256k1);
-BENCHMARK_TEMPLATE(modarith_mul, uint256, bn254);
-BENCHMARK_TEMPLATE(modarith_mul, uint256, secp256k1);
+BENCHMARK_TEMPLATE(modarith_add, bn254);
+BENCHMARK_TEMPLATE(modarith_add, secp256k1);
+BENCHMARK_TEMPLATE(modarith_sub, bn254);
+BENCHMARK_TEMPLATE(modarith_sub, secp256k1);
+BENCHMARK_TEMPLATE(modarith_mul, bn254);
+BENCHMARK_TEMPLATE(modarith_mul, secp256k1);

--- a/test/unittests/modarith_test.cpp
+++ b/test/unittests/modarith_test.cpp
@@ -18,47 +18,39 @@ constexpr auto BLS12384Mod =
     0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab_u384;
 
 
-template <typename UintT, const UintT& Mod>
-struct ModA : ModArith<UintT>
-{
-    using uint = UintT;
-    ModA() : ModArith<UintT>{Mod} {}
-};
-
 template <typename>
 class modarith_test : public testing::Test
 {};
 
-using test_types = testing::Types<ModA<uint256, P23>, ModA<uint256, BN254Mod>,
-    ModA<uint256, Secp256k1Mod>, ModA<uint256, M256>, ModA<uint384, BLS12384Mod>>;
+using test_types = testing::Types<MontgomeryArith<P23>, MontgomeryArith<BN254Mod>,
+    MontgomeryArith<Secp256k1Mod>, MontgomeryArith<M256>, MontgomeryArith<BLS12384Mod>>;
 TYPED_TEST_SUITE(modarith_test, test_types);
 
-TYPED_TEST(modarith_test, to_from_mont)
+TYPED_TEST(modarith_test, to_from_internal)
 {
-    const typename TypeParam::uint v = 1;
+    const typename TypeParam::uint_type v = 1;
 
-    const TypeParam s;
-    const auto x = s.to_mont(v);
-    EXPECT_EQ(s.from_mont(x), v);
+    const auto x = TypeParam::to_internal(v);
+    EXPECT_EQ(TypeParam::from_internal(x), v);
 }
 
-TYPED_TEST(modarith_test, to_from_mont_0)
+TYPED_TEST(modarith_test, to_from_internal_0)
 {
-    const TypeParam s;
-    EXPECT_EQ(s.to_mont(0), 0);
-    EXPECT_EQ(s.from_mont(0), 0);
+    EXPECT_EQ(TypeParam::to_internal(0), 0);
+    EXPECT_EQ(TypeParam::from_internal(0), 0);
 }
 
-template <typename Mod>
-static auto get_test_values(const Mod& m) noexcept
+template <typename Arith>
+static auto get_test_values() noexcept
 {
-    using Uint = Mod::uint;
+    using Uint = Arith::uint_type;
+    static constexpr auto& MOD = Arith::MOD;
     return std::array{
-        m.mod() - 1,
-        m.mod() - 2,
-        m.mod() / 2 + 1,
-        m.mod() / 2,
-        m.mod() / 2 - 1,
+        MOD - 1,
+        MOD - 2,
+        MOD / 2 + 1,
+        MOD / 2,
+        MOD / 2 - 1,
         Uint{2},
         Uint{1},
         Uint{0},
@@ -67,37 +59,37 @@ static auto get_test_values(const Mod& m) noexcept
 
 [[maybe_unused]] static void constexpr_test()
 {
-    // Make sure ModArith works in constexpr.
-    static constexpr ModArith m{BN254Mod};
-    static_assert(m.mod() == BN254Mod);
+    // Make sure MontgomeryArith works in constexpr.
+    using M = MontgomeryArith<BN254Mod>;
+    static_assert(M::MOD == BN254Mod);
 
-    static constexpr auto a = m.to_mont(3);
-    static constexpr auto b = m.to_mont(11);
-    static_assert(m.add(a, b) == m.to_mont(14));
-    static_assert(m.sub(a, b) == m.to_mont(BN254Mod - 8));
-    static_assert(m.mul(a, b) == m.to_mont(33));
+    static constexpr auto a = M::to_internal(3);
+    static constexpr auto b = M::to_internal(11);
+    static_assert(M::add(a, b) == M::to_internal(14));
+    static_assert(M::sub(a, b) == M::to_internal(BN254Mod - 8));
+    static_assert(M::mul(a, b) == M::to_internal(33));
 }
 
 TYPED_TEST(modarith_test, add)
 {
-    const TypeParam m;
-    const auto values = get_test_values(m);
+    using M = TypeParam;
+    const auto values = get_test_values<M>();
 
     for (const auto& x : values)
     {
-        const auto xm = m.to_mont(x);
+        const auto xm = M::to_internal(x);
         for (const auto& y : values)
         {
             const auto expected =
-                udivrem(intx::uint<TypeParam::uint::num_bits + 64>{x} + y, m.mod()).rem;
+                udivrem(intx::uint<M::uint_type::num_bits + 64>{x} + y, M::MOD).rem;
 
-            const auto ym = m.to_mont(y);
-            const auto s1m = m.add(xm, ym);
-            const auto s1 = m.from_mont(s1m);
+            const auto ym = M::to_internal(y);
+            const auto s1m = M::add(xm, ym);
+            const auto s1 = M::from_internal(s1m);
             EXPECT_EQ(s1, expected);
 
             // Conversion to Montgomery form is not necessary for addition to work.
-            const auto s2 = m.add(x, y);
+            const auto s2 = M::add(x, y);
             EXPECT_EQ(s2, expected);
         }
     }
@@ -105,24 +97,24 @@ TYPED_TEST(modarith_test, add)
 
 TYPED_TEST(modarith_test, sub)
 {
-    const TypeParam m;
-    const auto values = get_test_values(m);
+    using M = TypeParam;
+    const auto values = get_test_values<M>();
 
     for (const auto& x : values)
     {
-        const auto xm = m.to_mont(x);
+        const auto xm = M::to_internal(x);
         for (const auto& y : values)
         {
             const auto expected =
-                udivrem(intx::uint<TypeParam::uint::num_bits + 64>{x} + m.mod() - y, m.mod()).rem;
+                udivrem(intx::uint<M::uint_type::num_bits + 64>{x} + M::MOD - y, M::MOD).rem;
 
-            const auto ym = m.to_mont(y);
-            const auto d1m = m.sub(xm, ym);
-            const auto d1 = m.from_mont(d1m);
+            const auto ym = M::to_internal(y);
+            const auto d1m = M::sub(xm, ym);
+            const auto d1 = M::from_internal(d1m);
             EXPECT_EQ(d1, expected);
 
             // Conversion to Montgomery form is not necessary for subtraction to work.
-            const auto d2 = m.sub(x, y);
+            const auto d2 = M::sub(x, y);
             EXPECT_EQ(d2, expected);
         }
     }
@@ -130,19 +122,19 @@ TYPED_TEST(modarith_test, sub)
 
 TYPED_TEST(modarith_test, mul)
 {
-    const TypeParam m;
-    const auto values = get_test_values(m);
+    using M = TypeParam;
+    const auto values = get_test_values<M>();
 
     for (const auto& x : values)
     {
-        const auto xm = m.to_mont(x);
+        const auto xm = M::to_internal(x);
         for (const auto& y : values)
         {
-            const auto expected = udivrem(umul(x, y), m.mod()).rem;
+            const auto expected = udivrem(umul(x, y), M::MOD).rem;
 
-            const auto ym = m.to_mont(y);
-            const auto pm = m.mul(xm, ym);
-            const auto p = m.from_mont(pm);
+            const auto ym = M::to_internal(y);
+            const auto pm = M::mul(xm, ym);
+            const auto p = M::from_internal(pm);
             EXPECT_EQ(p, expected);
         }
     }
@@ -150,20 +142,20 @@ TYPED_TEST(modarith_test, mul)
 
 TYPED_TEST(modarith_test, inv)
 {
-    const TypeParam m;
-    for (const auto& x : get_test_values(m))
+    using M = TypeParam;
+    for (const auto& x : get_test_values<M>())
     {
-        const auto xm = m.to_mont(x);
-        const auto xm_inv = m.inv(xm);
+        const auto xm = M::to_internal(x);
+        const auto xm_inv = M::inv(xm);
         if (xm_inv == 0)  // not invertible
         {
-            if (m.mod() != M256)  // mod is prime
+            if (M::MOD != M256)  // mod is prime
             {
                 EXPECT_EQ(x, 0);
             }
             continue;
         }
-        const auto pm = m.mul(xm, xm_inv);
-        EXPECT_EQ(m.from_mont(pm), 1);
+        const auto pm = M::mul(xm, xm_inv);
+        EXPECT_EQ(M::from_internal(pm), 1);
     }
 }

--- a/test/unittests/secp256k1_test.cpp
+++ b/test/unittests/secp256k1_test.cpp
@@ -58,7 +58,7 @@ TEST(secp256k1, field_sqrt_invalid)
 
 TEST(secp256k1, scalar_inv)
 {
-    const evmone::crypto::ModArith n{Curve::ORDER};
+    using N = evmone::crypto::MontgomeryArith<Curve::ORDER>;
 
     for (const auto& t : {
              1_u256,
@@ -67,10 +67,10 @@ TEST(secp256k1, scalar_inv)
          })
     {
         ASSERT_LT(t, Curve::ORDER);
-        const auto a = n.to_mont(t);
-        const auto a_inv = n.inv(a);
-        const auto p = n.mul(a, a_inv);
-        EXPECT_EQ(n.from_mont(p), 1) << hex(t);
+        const auto a = N::to_internal(t);
+        const auto a_inv = N::inv(a);
+        const auto p = N::mul(a, a_inv);
+        EXPECT_EQ(N::from_internal(p), 1) << hex(t);
     }
 }
 


### PR DESCRIPTION
Every modulus in the codebase is a compile-time constant. Accepting one at runtime was needed only
for EVMMAX, which is gone. `ModArith` becomes `MontgomeryArith<Mod>` with the modulus as a template
parameter, so the modulus, R² and N′ are compile-time constants instead of members, and the
operations become static. The multiplication keeps its body — nothing is extracted, because nothing
outside the class would call it yet.

`to_mont()`/`from_mont()` become `to_internal()`/`from_internal()` in the same commit: they touch the
same call sites, and the Montgomery form is an implementation detail of this one arithmetic rather
than something its users need to name. The next arithmetic in the series keeps values in the plain
representation, where the conversions are identity.

## Effect on generated code

The curve code already used a `static constexpr ModArith`, so the compiler had the modulus as a
constant there already and the field arithmetic itself is unchanged. Two things move: `p256verify`
stops computing R² by a 576-by-256-bit division on every call (the `intx::udivrem` instantiation,
`udivrem_knuth` and the reciprocal table are now absent from `secp256r1.o`), and in the inner pairing
function `multiply_by_lin_func_value()` GCC stops inlining one of the multiplications.

Instructions per call, hardware counters with two-point subtraction to cancel process startup
(GCC 15.2, `-O3`, `x86-64-v2`):

| | master | this PR | |
| --- | --- | --- | --- |
| p256verify | 1,595,954 | 1,563,289 | −2.05% |
| ecadd | 21,993 | 21,780 | −0.97% |
| ecrecover | 1,588,150 | 1,575,664 | −0.79% |
| ecmul | 787,626 | 789,380 | +0.22% |
| ecpairing | 20,877,721 | 20,931,957 | +0.26% |

The micro-benchmark also constructed the arithmetic at runtime, so its multiplication gets up to
~30% faster now that the modulus is a constant (secp256k1's all-ones limbs turn multiplies into
shifts). That does not carry over to the library, for the reason above.

## On the CodSpeed report

CodSpeed reports the opposite for four of these — ecrecover −10.3%, p256verify −5.3%, ecpairing
−3.9%, ecmul −3.7%, ecadd +3.2% — and warns that those comparisons crossed runtime environments. The
disagreement is in sign, not just size, for ecrecover and p256verify. An interleaved wall-clock A/B on
ecrecover put the two builds within ~1% of each other, spread ±4% by machine load, so a 10%
regression is not there on this hardware. Their simulation mode cannot be reproduced locally
(Valgrind does not run in my environment), and the toolchain differs (GCC 15 here, GCC 14 in CI).

Re-running the benchmark workflow on master would refresh the baseline and settle whether anything
survives.

## Notes

- `MOD_INV` is computed during constant evaluation, so an even modulus is now a compile-time error
  instead of a failed assert at runtime.
- The typed test suite drops its `ModA` wrapper: `MontgomeryArith<Mod>` is directly the test type.
- `expmod.tmpl` still generated `ModArith`-based code, while the checked-in generated code has been
  `Curve::Fp`-based for a while. Updated, so regenerating produces what is committed.
