### PR TITLE
crypto: Rename ModArith to MontgomeryArith

### DIFF
--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -30,11 +30,11 @@ template <FieldSpec Spec>
 class FieldElement
 {
     using uint_type = std::remove_const_t<decltype(Spec::ORDER)>;
-    static constexpr ModArith<uint_type> Fp{Spec::ORDER};
+    static constexpr MontgomeryArith<uint_type> Fp{Spec::ORDER};
 
     uint_type value_;
 
-    /// Wraps a value into the Element type assuming it is already in the internal ModArith form.
+    /// Wraps a value into the Element type assuming it is already in the internal form.
     [[gnu::always_inline]] static constexpr FieldElement wrap(const uint_type& v) noexcept
     {
         FieldElement element;
@@ -48,9 +48,9 @@ public:
 
     FieldElement() = default;
 
-    constexpr explicit FieldElement(uint_type v) : value_{Fp.to_mont(v)} {}
+    constexpr explicit FieldElement(uint_type v) : value_{Fp.to_internal(v)} {}
 
-    constexpr uint_type value() const noexcept { return Fp.from_mont(value_); }
+    constexpr uint_type value() const noexcept { return Fp.from_internal(value_); }
 
     /// The valid range for from_bytes().
     enum class Range : bool
@@ -109,20 +109,20 @@ public:
         return wrap(Fp.sub(0, a.value_));
     }
 
-    /// Division returns 0 when the divisor is 0. See ModArith::inv().
+    /// Division returns 0 when the divisor is 0. See MontgomeryArith::inv().
     friend constexpr auto operator/(one_t, const FieldElement& a) noexcept
     {
         return wrap(Fp.inv(a.value_));
     }
 
-    /// Division returns 0 when the divisor is 0. See ModArith::inv().
+    /// Division returns 0 when the divisor is 0. See MontgomeryArith::inv().
     friend constexpr auto operator/(const FieldElement& a, const FieldElement& b) noexcept
     {
         return wrap(Fp.mul(a.value_, Fp.inv(b.value_)));
     }
 
     /// Named 1/x inversion method. Needed in the pairing templates.
-    /// Returns 0 when this element is 0. See ModArith::inv().
+    /// Returns 0 when this element is 0. See MontgomeryArith::inv().
     constexpr auto inv() const noexcept { return wrap(Fp.inv(value_)); }
 
     /// Named one element. Needed in the pairing templates.
@@ -518,17 +518,17 @@ template <typename Curve>
 {
     // Verify k ≡ k₁ + k₂·λ (mod N).
     {
-        static constexpr ModArith N{Curve::ORDER};
-        auto r_k1 = N.to_mont(k1.value);
+        static constexpr MontgomeryArith N{Curve::ORDER};
+        auto r_k1 = N.to_internal(k1.value);
         if (k1.sign)
             r_k1 = N.sub(0, r_k1);
-        auto r_k2 = N.to_mont(k2.value);
+        auto r_k2 = N.to_internal(k2.value);
         if (k2.sign)
             r_k2 = N.sub(0, r_k2);
 
-        const auto r_k = N.to_mont(k);
+        const auto r_k = N.to_internal(k);
 
-        const auto right = N.add(r_k1, N.mul(r_k2, N.to_mont(Curve::LAMBDA)));
+        const auto right = N.add(r_k1, N.mul(r_k2, N.to_internal(Curve::LAMBDA)));
         if (r_k != right)
             return false;
     }

--- a/lib/evmone_precompiles/expmod.tmpl
+++ b/lib/evmone_precompiles/expmod.tmpl
@@ -1,7 +1,7 @@
 {{- $exponent := "" -}}
 {{- range $exponent = $.Chain }}{{ end -}}
 
-uint256 expmod_(const ModArith<uint256>& m, const uint256& x) noexcept
+uint256 expmod_(const MontgomeryArith<uint256>& m, const uint256& x) noexcept
 {
     // Computes modular exponentiation
     // x^{{ printf "%#x" $exponent }}

--- a/lib/evmone_precompiles/modarith.hpp
+++ b/lib/evmone_precompiles/modarith.hpp
@@ -153,7 +153,7 @@ constexpr UintT modinv_scaled(const UintT& x, const UintT& scale, const UintT& m
 
 /// The modular arithmetic operations using the Montgomery form of the values.
 template <typename UintT>
-class ModArith
+class MontgomeryArith
 {
     const UintT mod_;  ///< The modulus.
 
@@ -172,24 +172,24 @@ class ModArith
     }
 
 public:
-    constexpr explicit ModArith(const UintT& mod) noexcept
+    constexpr explicit MontgomeryArith(const UintT& mod) noexcept
       : mod_{mod}, r_squared_{compute_r_squared(mod)}, mod_inv_{compute_mont_mod_inv(mod)}
     {}
 
     /// Returns the modulus.
     constexpr const UintT& mod() const noexcept { return mod_; }
 
-    /// Converts a value to Montgomery form.
+    /// Converts a value to the internal (Montgomery) form.
     ///
     /// This is done by using Montgomery multiplication mul(x, R²)
     /// what gives aR²R⁻¹ % mod = aR % mod.
-    constexpr UintT to_mont(const UintT& x) const noexcept { return mul(x, r_squared_); }
+    constexpr UintT to_internal(const UintT& x) const noexcept { return mul(x, r_squared_); }
 
-    /// Converts a value in Montgomery form back to normal value.
+    /// Converts a value in the internal (Montgomery) form back to normal value.
     ///
     /// Given the x is the Montgomery form x = aR, the conversion is done by using
     /// Montgomery multiplication mul(x, 1) what gives aRR⁻¹ % mod = a % mod.
-    constexpr UintT from_mont(const UintT& x) const noexcept { return mul(x, 1); }
+    constexpr UintT from_internal(const UintT& x) const noexcept { return mul(x, 1); }
 
     /// Performs a Montgomery modular multiplication.
     ///

--- a/lib/evmone_precompiles/secp256r1.cpp
+++ b/lib/evmone_precompiles/secp256r1.cpp
@@ -38,16 +38,16 @@ bool verify(const ethash::hash256& h, const uint256& r, const uint256& s, const 
     if (!is_on_curve(Q))
         return false;
 
-    const ModArith n{Curve::ORDER};
+    const MontgomeryArith n{Curve::ORDER};
 
     // 3. Let z be the Lₙ leftmost bits of e = HASH(m).
     static_assert(Curve::ORDER > 1_u256 << 255);
     const auto z = intx::be::load<uint256>(h.bytes);
 
     // 4. Calculate u₁ = zs⁻¹ mod n and u₂ = rs⁻¹ mod n.
-    const auto s_inv = n.inv(n.to_mont(s));
-    const auto u1 = n.from_mont(n.mul(n.to_mont(z), s_inv));
-    const auto u2 = n.from_mont(n.mul(n.to_mont(r), s_inv));
+    const auto s_inv = n.inv(n.to_internal(s));
+    const auto u1 = n.from_internal(n.mul(n.to_internal(z), s_inv));
+    const auto u2 = n.from_internal(n.mul(n.to_internal(r), s_inv));
 
     // 5. Calculate the curve point R = (x₁, y₁) = u₁×G + u₂×Q.
     const auto R = ecc::to_affine(msm(u1, G, u2, Q));

--- a/test/internal_benchmarks/modarith_bench.cpp
+++ b/test/internal_benchmarks/modarith_bench.cpp
@@ -17,7 +17,7 @@ constexpr auto secp256k1 = 0xfffffffffffffffffffffffffffffffffffffffffffffffffff
 template <typename UintT, const UintT& Mod>
 void modarith_add(benchmark::State& state)
 {
-    const evmone::crypto::ModArith<UintT> m{Mod};
+    const evmone::crypto::MontgomeryArith<UintT> m{Mod};
     auto a = Mod / 2;
     auto b = Mod / 3;
 
@@ -33,7 +33,7 @@ void modarith_add(benchmark::State& state)
 template <typename UintT, const UintT& Mod>
 void modarith_sub(benchmark::State& state)
 {
-    const evmone::crypto::ModArith<UintT> m{Mod};
+    const evmone::crypto::MontgomeryArith<UintT> m{Mod};
     auto a = Mod / 2;
     auto b = Mod / 3;
 
@@ -49,9 +49,9 @@ void modarith_sub(benchmark::State& state)
 template <typename UintT, const UintT& Mod>
 void modarith_mul(benchmark::State& state)
 {
-    const evmone::crypto::ModArith<UintT> m{Mod};
-    auto a = m.to_mont(Mod / 2);
-    auto b = m.to_mont(Mod / 3);
+    const evmone::crypto::MontgomeryArith<UintT> m{Mod};
+    auto a = m.to_internal(Mod / 2);
+    auto b = m.to_internal(Mod / 3);
 
     while (state.KeepRunningBatch(2))
     {

--- a/test/unittests/modarith_test.cpp
+++ b/test/unittests/modarith_test.cpp
@@ -19,10 +19,10 @@ constexpr auto BLS12384Mod =
 
 
 template <typename UintT, const UintT& Mod>
-struct ModA : ModArith<UintT>
+struct ModA : MontgomeryArith<UintT>
 {
     using uint = UintT;
-    ModA() : ModArith<UintT>{Mod} {}
+    ModA() : MontgomeryArith<UintT>{Mod} {}
 };
 
 template <typename>
@@ -33,20 +33,20 @@ using test_types = testing::Types<ModA<uint256, P23>, ModA<uint256, BN254Mod>,
     ModA<uint256, Secp256k1Mod>, ModA<uint256, M256>, ModA<uint384, BLS12384Mod>>;
 TYPED_TEST_SUITE(modarith_test, test_types);
 
-TYPED_TEST(modarith_test, to_from_mont)
+TYPED_TEST(modarith_test, to_from_internal)
 {
     const typename TypeParam::uint v = 1;
 
     const TypeParam s;
-    const auto x = s.to_mont(v);
-    EXPECT_EQ(s.from_mont(x), v);
+    const auto x = s.to_internal(v);
+    EXPECT_EQ(s.from_internal(x), v);
 }
 
-TYPED_TEST(modarith_test, to_from_mont_0)
+TYPED_TEST(modarith_test, to_from_internal_0)
 {
     const TypeParam s;
-    EXPECT_EQ(s.to_mont(0), 0);
-    EXPECT_EQ(s.from_mont(0), 0);
+    EXPECT_EQ(s.to_internal(0), 0);
+    EXPECT_EQ(s.from_internal(0), 0);
 }
 
 template <typename Mod>
@@ -67,15 +67,15 @@ static auto get_test_values(const Mod& m) noexcept
 
 [[maybe_unused]] static void constexpr_test()
 {
-    // Make sure ModArith works in constexpr.
-    static constexpr ModArith m{BN254Mod};
+    // Make sure MontgomeryArith works in constexpr.
+    static constexpr MontgomeryArith m{BN254Mod};
     static_assert(m.mod() == BN254Mod);
 
-    static constexpr auto a = m.to_mont(3);
-    static constexpr auto b = m.to_mont(11);
-    static_assert(m.add(a, b) == m.to_mont(14));
-    static_assert(m.sub(a, b) == m.to_mont(BN254Mod - 8));
-    static_assert(m.mul(a, b) == m.to_mont(33));
+    static constexpr auto a = m.to_internal(3);
+    static constexpr auto b = m.to_internal(11);
+    static_assert(m.add(a, b) == m.to_internal(14));
+    static_assert(m.sub(a, b) == m.to_internal(BN254Mod - 8));
+    static_assert(m.mul(a, b) == m.to_internal(33));
 }
 
 TYPED_TEST(modarith_test, add)
@@ -85,15 +85,15 @@ TYPED_TEST(modarith_test, add)
 
     for (const auto& x : values)
     {
-        const auto xm = m.to_mont(x);
+        const auto xm = m.to_internal(x);
         for (const auto& y : values)
         {
             const auto expected =
                 udivrem(intx::uint<TypeParam::uint::num_bits + 64>{x} + y, m.mod()).rem;
 
-            const auto ym = m.to_mont(y);
+            const auto ym = m.to_internal(y);
             const auto s1m = m.add(xm, ym);
-            const auto s1 = m.from_mont(s1m);
+            const auto s1 = m.from_internal(s1m);
             EXPECT_EQ(s1, expected);
 
             // Conversion to Montgomery form is not necessary for addition to work.
@@ -110,15 +110,15 @@ TYPED_TEST(modarith_test, sub)
 
     for (const auto& x : values)
     {
-        const auto xm = m.to_mont(x);
+        const auto xm = m.to_internal(x);
         for (const auto& y : values)
         {
             const auto expected =
                 udivrem(intx::uint<TypeParam::uint::num_bits + 64>{x} + m.mod() - y, m.mod()).rem;
 
-            const auto ym = m.to_mont(y);
+            const auto ym = m.to_internal(y);
             const auto d1m = m.sub(xm, ym);
-            const auto d1 = m.from_mont(d1m);
+            const auto d1 = m.from_internal(d1m);
             EXPECT_EQ(d1, expected);
 
             // Conversion to Montgomery form is not necessary for subtraction to work.
@@ -135,14 +135,14 @@ TYPED_TEST(modarith_test, mul)
 
     for (const auto& x : values)
     {
-        const auto xm = m.to_mont(x);
+        const auto xm = m.to_internal(x);
         for (const auto& y : values)
         {
             const auto expected = udivrem(umul(x, y), m.mod()).rem;
 
-            const auto ym = m.to_mont(y);
+            const auto ym = m.to_internal(y);
             const auto pm = m.mul(xm, ym);
-            const auto p = m.from_mont(pm);
+            const auto p = m.from_internal(pm);
             EXPECT_EQ(p, expected);
         }
     }
@@ -153,7 +153,7 @@ TYPED_TEST(modarith_test, inv)
     const TypeParam m;
     for (const auto& x : get_test_values(m))
     {
-        const auto xm = m.to_mont(x);
+        const auto xm = m.to_internal(x);
         const auto xm_inv = m.inv(xm);
         if (xm_inv == 0)  // not invertible
         {
@@ -164,6 +164,6 @@ TYPED_TEST(modarith_test, inv)
             continue;
         }
         const auto pm = m.mul(xm, xm_inv);
-        EXPECT_EQ(m.from_mont(pm), 1);
+        EXPECT_EQ(m.from_internal(pm), 1);
     }
 }

--- a/test/unittests/secp256k1_test.cpp
+++ b/test/unittests/secp256k1_test.cpp
@@ -58,7 +58,7 @@ TEST(secp256k1, field_sqrt_invalid)
 
 TEST(secp256k1, scalar_inv)
 {
-    const evmone::crypto::ModArith n{Curve::ORDER};
+    const evmone::crypto::MontgomeryArith n{Curve::ORDER};
 
     for (const auto& t : {
              1_u256,
@@ -67,10 +67,10 @@ TEST(secp256k1, scalar_inv)
          })
     {
         ASSERT_LT(t, Curve::ORDER);
-        const auto a = n.to_mont(t);
+        const auto a = n.to_internal(t);
         const auto a_inv = n.inv(a);
         const auto p = n.mul(a, a_inv);
-        EXPECT_EQ(n.from_mont(p), 1) << hex(t);
+        EXPECT_EQ(n.from_internal(p), 1) << hex(t);
     }
 }
 


### PR DESCRIPTION
`ModArith` implements one specific algorithm, so it is named after that algorithm. Arithmetics
keeping the values in other representations are coming — the pseudo-Mersenne reduction for
secp256k1 works in the plain representation — and they will not be Montgomery.

For the same reason `to_mont()`/`from_mont()` become `to_internal()`/`from_internal()`: the
Montgomery form is an implementation detail of this one arithmetic rather than something its users
need to name. In an arithmetic using the plain representation both conversions are identity.

## Verified no-op

The modulus stays a runtime member, so nothing about the generated code should move. Comparing the
linked `evmone-precompiles-bench` before and after:

| | master | this PR |
| --- | --- | --- |
| `.text` | 798,617 | 798,617 |
| defined symbols | 1,683 | 1,683 |
| multiset of function sizes | — | identical |

The next step in the series, which makes the modulus a template parameter, changes 57 function sizes
by comparison. Keeping the rename separate is what makes that measurable.
