### PR TITLE
t8n: Emit the real receipt status, root and logs

### DIFF
--- a/test/unittests/tooling_t8n_test.cpp
+++ b/test/unittests/tooling_t8n_test.cpp
@@ -52,6 +52,60 @@ constexpr auto TX_JSON = R"([{
     "r": "0x468a915f087692bb9be503831a3dfef2cf9c8dee26deb40ff2ec99e8d22665ae",
     "s": "0x5cedae0810c3851ecd1004bfdbfe6ddc7753c2d665993bb01ce75af7857b13dc"
 }])";
+
+/// Runs t8n over the given pre-state and transactions, and returns the result JSON.
+std::string run_t8n(std::string_view alloc_json, std::string_view txs_json, evmc_revision rev)
+{
+    evmc::VM vm{evmc_create_evmone()};
+
+    std::istringstream env{ENV_JSON};
+    std::istringstream alloc{std::string{alloc_json}};
+    std::istringstream txs{std::string{txs_json}};
+    std::ostringstream out_result;
+
+    tooling::T8NArgs args;
+    args.rev = rev;
+    args.chain_id = 1;
+    args.alloc = &alloc;
+    args.env = &env;
+    args.txs = &txs;
+    args.out_result = &out_result;
+
+    tooling::t8n(vm, args);
+    return out_result.str();
+}
+
+/// Legacy transaction calling CALLEE. t8n takes `sender` from the JSON and only checks `hash`
+/// when present, so the signature is never recovered.
+constexpr auto TX_TO_CALLEE = R"([{
+    "to": "0x000000000000000000000000000000000000c0de",
+    "input": "0x",
+    "gas": "0x186a0",
+    "nonce": "0x0",
+    "value": "0x0",
+    "gasPrice": "0x32",
+    "chainId": "0x1",
+    "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    "v": "0x1b",
+    "r": "0x468a915f087692bb9be503831a3dfef2cf9c8dee26deb40ff2ec99e8d22665ae",
+    "s": "0x5cedae0810c3851ecd1004bfdbfe6ddc7753c2d665993bb01ce75af7857b13dc"
+}])";
+
+/// Runs TX_TO_CALLEE against a callee deployed with the given code.
+std::string run_call_to(std::string_view callee_code, evmc_revision rev)
+{
+    const auto alloc = R"({
+        "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+            "code": "", "nonce": "0x00", "balance": "0x02540be400"
+        },
+        "0x000000000000000000000000000000000000c0de": {
+            "code": ")" +
+                       std::string{callee_code} +
+                       R"(", "nonce": "0x00", "balance": "0x00"
+        }
+    })";
+    return run_t8n(alloc, TX_TO_CALLEE, rev);
+}
 }  // namespace
 
 TEST(tooling_t8n, no_inputs_no_outputs)
@@ -149,31 +203,13 @@ TEST(tooling_t8n, out_body_is_hex_rlp_of_transactions)
 
 TEST(tooling_t8n, pre_byzantium_sets_receipt_post_state)
 {
-    evmc::VM vm{evmc_create_evmone()};
+    // The TX_JSON fixture uses PUSH0 in its init code, so the inner CREATE fails at Homestead,
+    // but the outer tx still produces a receipt, which carries the post-state root instead of
+    // the EIP-658 status.
+    const auto result = run_t8n(ALLOC_JSON, TX_JSON, EVMC_HOMESTEAD);
 
-    // Pre-Byzantium receipts include the post-state root via receipt.post_state.
-    // The TX_JSON fixture uses PUSH0 in its init code, so the inner CREATE fails
-    // at Homestead, but the outer tx still produces a TransactionReceipt that
-    // exercises the `rev < EVMC_BYZANTIUM` branch in t8n().
-    std::istringstream env{ENV_JSON};
-    std::istringstream alloc{ALLOC_JSON};
-    std::istringstream txs{TX_JSON};
-    std::ostringstream out_result;
-
-    tooling::T8NArgs args;
-    args.rev = EVMC_HOMESTEAD;
-    args.chain_id = 1;
-    args.alloc = &alloc;
-    args.env = &env;
-    args.txs = &txs;
-    args.out_result = &out_result;
-
-    tooling::t8n(vm, args);
-
-    // The "receipts" array is initialized empty on every txs-present run; the
-    // distinguishing signal that a receipt was actually produced (i.e., the
-    // tx wasn't classified as rejected) is the presence of transactionHash.
-    EXPECT_THAT(out_result.str(), HasSubstr("\"transactionHash\""));
+    EXPECT_THAT(result, HasSubstr("\"transactionHash\""));
+    EXPECT_THAT(result, HasSubstr("\"root\": \"0x"));
 }
 
 TEST(tooling_t8n, mismatched_tx_hash_throws)
@@ -286,4 +322,22 @@ TEST(tooling_t8n, max_v)
 
     EXPECT_NO_THROW(tooling::t8n(vm, args));
     EXPECT_THAT(out_result.str(), HasSubstr("\"transactionHash\""));
+}
+
+TEST(tooling_t8n, receipt_reports_emitted_logs)
+{
+    // MSTORE8(0, 0xaa); LOG1(offset=0, size=1, topic=0x42).
+    const auto result = run_call_to("0x60aa600053604260016000a100", EVMC_SHANGHAI);
+
+    EXPECT_THAT(result, HasSubstr("\"address\": \"0x000000000000000000000000000000000000c0de\""));
+    EXPECT_THAT(result,
+        HasSubstr("\"0x0000000000000000000000000000000000000000000000000000000000000042\""));
+    EXPECT_THAT(result, HasSubstr("\"data\": \"0xaa\""));
+}
+
+TEST(tooling_t8n, receipt_status_reports_failure)
+{
+    // The callee is the INVALID instruction, so the transaction fails.
+    EXPECT_THAT(run_call_to("0xfe", EVMC_SHANGHAI), HasSubstr("\"status\": \"0x0\""));
+    EXPECT_THAT(run_call_to("0x00", EVMC_SHANGHAI), HasSubstr("\"status\": \"0x1\""));
 }

--- a/test/utils/statetest.hpp
+++ b/test/utils/statetest.hpp
@@ -144,6 +144,9 @@ T load_or(const json::json& j, std::string_view key, T default_value)
 /// Exports the State (accounts) to JSON format (aka pre/post/alloc state).
 json::json to_json(const TestState& state);
 
+/// Exports a transaction log to JSON format (as in a receipt's log list).
+json::json to_json(const state::Log& log);
+
 /// Export the state test to JSON format.
 json::json to_state_test(std::string_view test_name, const state::BlockInfo& block,
     state::Transaction& tx, const TestState& pre, evmc_revision rev,

--- a/test/utils/statetest_export.cpp
+++ b/test/utils/statetest_export.cpp
@@ -44,6 +44,17 @@ json::json to_json(const TestState& state)
     return j;
 }
 
+json::json to_json(const state::Log& log)
+{
+    json::json j;
+    j["address"] = hex0x(log.addr);
+    auto& j_topics = j["topics"] = json::json::array();
+    for (const auto& topic : log.topics)
+        j_topics.push_back(hex0x(topic));
+    j["data"] = hex0x(log.data);
+    return j;
+}
+
 json::json to_state_test(std::string_view test_name, const state::BlockInfo& block,
     state::Transaction& tx, const TestState& pre, evmc_revision rev,
     const std::variant<state::TransactionReceipt, std::error_code>& res, const TestState& post)

--- a/test/utils/t8n.cpp
+++ b/test/utils/t8n.cpp
@@ -149,9 +149,14 @@ void t8n(evmc::VM& vm, const T8NArgs& args)
                 j_receipt["blockHash"] = hex0x(bytes32{});
                 j_receipt["contractAddress"] = hex0x(address{});
                 j_receipt["logsBloom"] = hex0x(receipt.logs_bloom_filter);
-                j_receipt["logs"] = JSON::array();  // FIXME: Add to_json<state:Log>
-                j_receipt["root"] = "";
-                j_receipt["status"] = "0x1";
+                auto& j_logs = j_receipt["logs"] = JSON::array();
+                for (const auto& log : receipt.logs)
+                    j_logs.push_back(to_json(log));
+                // A pre-Byzantium receipt is keyed on the post-state root instead of the
+                // EIP-658 status. Emit both, as go-ethereum does: the root takes precedence.
+                j_receipt["root"] =
+                    receipt.post_state.has_value() ? hex0x(*receipt.post_state) : "";
+                j_receipt["status"] = hex0x(uint64_t{receipt.status == EVMC_SUCCESS});
                 j_receipt["transactionIndex"] = hex0x(i);
                 transactions.emplace_back(std::move(txs[i]));
             }


### PR DESCRIPTION
The receipts JSON hard-coded the status to `"0x1"` and the logs to `[]`, while the t8n's own `receiptsRoot` was built from the real receipt status and logs. The JSON and the trie hash therefore agreed only for successful zero-log transactions.

This breaks filling. `execution-specs` asserts the two against each other for every single-transaction state test — `specs/state.py` rebuilds a `FixtureTransactionReceipt` from the receipt JSON (its RLP covers logs and status) and compares its root with the `receiptsRoot` the tool reported:

```
AssertionError: Receipts root mismatch:
  0xea172341021a44ccd443700f500c8aa1b6f03d40ce90bc591ad0790030d9e103
  != 4dcfc751a42386805efef49737a1a76732de03f13b8a7966463c397414bcbeb3
```

That receipt's RLP ends in `c0`, an empty logs list, while its bloom filter has bits set.

Filling `tests/frontier/opcodes/test_log.py` at Shanghai with `--evm-bin` pointing at each build:

| t8n | Result |
| --- | --- |
| before | 25 failed, 50 passed |
| after | 75 passed |

A pre-Byzantium receipt is keyed on the post-state root rather than the EIP-658 status, so both fields are emitted, as go-ethereum does; the consumer gives a non-empty root precedence.

Extracted from the Amsterdam branch's t8n work, where filling against the devnet releases exercised it. The fix itself is fork-independent.
