### PR TITLE
Use gas_left uniformly in halting instruction results

### DIFF
--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -814,7 +814,7 @@ inline void tload(StackTop stack, ExecutionState& state) noexcept
 inline Result tstore(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
 {
     if (state.in_static_mode())
-        return {EVMC_STATIC_MODE_VIOLATION, 0};
+        return {EVMC_STATIC_MODE_VIOLATION, gas_left};
 
     const auto key = intx::be::store<evmc::bytes32>(stack.pop());
     const auto value = intx::be::store<evmc::bytes32>(stack.pop());
@@ -1003,7 +1003,7 @@ inline Result log(StackTop stack, int64_t gas_left, ExecutionState& state) noexc
     static_assert(NumTopics <= 4);
 
     if (state.in_static_mode())
-        return {EVMC_STATIC_MODE_VIOLATION, 0};
+        return {EVMC_STATIC_MODE_VIOLATION, gas_left};
 
     const auto& offset = stack.pop();
     const auto& size = stack.pop();

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -85,6 +85,7 @@ Result call_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexce
 
     if (state.rev >= EVMC_BERLIN && state.host.access_account(dst) == EVMC_ACCESS_COLD)
     {
+        // TODO: gas_left is used as no-op and ignored by caller. Refactor this.
         if ((gas_left -= instr::additional_cold_account_access_cost) < 0)
             return {EVMC_OUT_OF_GAS, gas_left};
     }


### PR DESCRIPTION
Two of the six `EVMC_STATIC_MODE_VIOLATION` exits (TSTORE, LOG) returned a literal `0` while the other 43 halting exits returned `gas_left`.

The value is unspecified either way: `make_execution_result()` replaces it with 0 for any status other than `EVMC_SUCCESS`/`EVMC_REVERT`, and no consumer compares against anything else. In fact it was never meaningful — the 36 out-of-gas exits return a *negative* value, since they follow `(gas_left -= cost) < 0`.

Returning `gas_left` everywhere keeps all halting exits identical, so the compiler merges them into a single epilogue (`mov %r8,%rdx; mov %esi,%eax; ret`, with only the status preloaded per site) instead of emitting one per site. Also adds a TODO at the first such use in `call_impl`.

### Code size (`.text` of instructions_calls + baseline_execution + instructions_storage + advanced_instructions)

| | gcc 15.2 | clang 23 |
|---|---|---|
| master | 153759 | 98764 |
| this PR | 152472 (−1287) | 98700 (−64) |

Interestingly none of the gain is in the two edited functions: gcc's is `baseline_execution` −1015 and `advanced_instructions` −272. TSTORE and LOG are inlined into the dispatch loops, so making their exits match the rest is what enables the merge there.

No behaviour change. Tested: `ctest` 1230/1230 and `tests@v20.0.1` state 8172/8172, gcc and clang-23 both clean.

Preparation for the CALL rework in #1668. The `[[unlikely]]` sweep that was originally part of this branch is now #1670.
