### PR TITLE
test: Replace gtest assertions in the fixture runners

### DIFF
--- a/test/blockchaintest/blockchaintest.cpp
+++ b/test/blockchaintest/blockchaintest.cpp
@@ -7,12 +7,24 @@
 #include <evmone/evmone.h>
 #include <evmone/version.h>
 #include <gtest/gtest.h>
+#include <test/utils/test_report.hpp>
 #include <iostream>
 
 namespace fs = std::filesystem;
 
 namespace
 {
+/// Reports each failure to gtest the moment the runner records it, so a run that dies part-way
+/// still shows what it found.
+///
+/// TODO: Bridge for as long as gtest drives these tests. Once the test driver replaces it the
+///   report is the verdict directly and this goes away.
+evmone::test::TestReport make_report()
+{
+    return evmone::test::TestReport{
+        [](const evmone::test::Failure& failure) { ADD_FAILURE() << failure; }};
+}
+
 /// Implementation of a gtest Test which runs all blockchain tests from a given file.
 class BlockchainGTestFile : public testing::Test
 {
@@ -26,11 +38,13 @@ public:
 
     void TestBody() final
     {
+        auto report = make_report();
         std::ifstream f{m_json_test_file};
 
         try
         {
-            evmone::test::run_blockchain_tests(evmone::test::load_blockchain_tests(f), m_vm);
+            evmone::test::run_blockchain_tests(
+                evmone::test::load_blockchain_tests(f), m_vm, report);
         }
         catch (const evmone::test::UnsupportedTestFeature& ex)
         {
@@ -59,7 +73,8 @@ public:
 
     void TestBody() final
     {
-        evmone::test::run_blockchain_tests(std::array{m_blockchain_test}, m_vm);
+        auto report = make_report();
+        evmone::test::run_blockchain_tests(std::array{m_blockchain_test}, m_vm, report);
     }
 
     static void register_one(const evmone::test::BlockchainTest& test,

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "blockchaintest_runner.hpp"
-#include <gtest/gtest.h>
 #include <test/state/errors.hpp>
 #include <test/state/ethash_difficulty.hpp>
 #include <test/state/requests.hpp>
@@ -14,6 +13,7 @@
 #include <test/utils/rlp.hpp>
 #include <test/utils/rlp_encode.hpp>
 #include <test/utils/statetest.hpp>
+#include <test/utils/test_report.hpp>
 
 namespace evmone::test
 {
@@ -133,21 +133,30 @@ std::error_code validate_block(evmc_revision rev, state::BlobParams blob_params,
 
 /// Checks the transaction codec against a block's own serialization: every transaction in it must
 /// decode, and encode back to the very same bytes.
-void expect_transactions_round_trip(bytes_view block_rlp)
+void check_transactions_round_trip(bytes_view block_rlp, TestReport& report)
 {
     bytes_view body;  // A block is [header, transactions, ...].
-    ASSERT_TRUE(rlp::take_list_payload(block_rlp, body));
-    ASSERT_TRUE(block_rlp.empty()) << "trailing bytes after the block";
-    bytes_view block_header;
-    ASSERT_TRUE(rlp::take_list_payload(body, block_header));  // Skipped over.
+    if (!report.check(rlp::take_list_payload(block_rlp, body), "block RLP", "not a list"))
+        return;
+    if (!report.check(block_rlp.empty(), "block RLP", "trailing bytes after the block"))
+        return;
+    bytes_view block_header;  // Skipped over.
+    if (!report.check(
+            rlp::take_list_payload(body, block_header), "block RLP", "the header is not a list"))
+        return;
     bytes_view txs;
-    ASSERT_TRUE(rlp::take_list_payload(body, txs));
+    if (!report.check(
+            rlp::take_list_payload(body, txs), "block RLP", "the transactions are not a list"))
+        return;
 
     while (!txs.empty())
     {
         const auto item = txs;
         rlp::Header h;
-        ASSERT_TRUE(rlp::decode_header(txs, h));  // Advances txs to the item's payload.
+        // decode_header() advances txs to the item's payload.
+        if (!report.check(
+                rlp::decode_header(txs, h), "block RLP", "a transaction has no RLP header"))
+            return;
         const auto header_size = item.size() - txs.size();
         txs.remove_prefix(h.payload_length);
 
@@ -157,8 +166,12 @@ void expect_transactions_round_trip(bytes_view block_rlp)
                                           item.substr(header_size, h.payload_length);
 
         const auto tx = state::decode_transaction(tx_bytes);
-        ASSERT_TRUE(tx.has_value()) << hex(tx_bytes);
-        EXPECT_EQ(rlp::encode(*tx), tx_bytes);
+        if (!tx.has_value())
+        {
+            report.fail("transaction decoding", hex(tx_bytes));
+            return;
+        }
+        report.check_eq("transaction re-encoding", rlp::encode(*tx), tx_bytes);
     }
 }
 
@@ -199,25 +212,31 @@ std::string print_state(const TestState& s)
 }
 }  // namespace
 
-void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
+void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm, TestReport& report)
 {
     for (size_t case_index = 0; case_index != tests.size(); ++case_index)
     {
         const auto& c = tests[case_index];
         const auto rev_schedule = to_rev_schedule(c.network);
-        SCOPED_TRACE(std::string{evmc::to_string(rev_schedule.get_revision(0))} + '/' +
-                     std::to_string(case_index) + '/' + c.name);
+        report.start_case(c.name);
+        // The network names the whole schedule, so a fork transition shows at the case level and
+        // a block needs only its index. The block number would not do: an invalid block does not
+        // advance it, so two of them can share one.
+        const auto in_case = report.at(c.network, '/', case_index);
 
         // Validate the genesis block header.
-        EXPECT_EQ(c.genesis_block_header.block_number, 0);
-        EXPECT_EQ(c.genesis_block_header.gas_used, 0);
-        EXPECT_EQ(c.genesis_block_header.transactions_root, state::EMPTY_MPT_HASH);
-        EXPECT_EQ(c.genesis_block_header.receipts_root, state::EMPTY_MPT_HASH);
-        EXPECT_EQ(c.genesis_block_header.withdrawal_root,
+        report.check_eq("genesis block number", c.genesis_block_header.block_number, 0);
+        report.check_eq("genesis gas used", c.genesis_block_header.gas_used, 0);
+        report.check_eq("genesis transactions root", c.genesis_block_header.transactions_root,
+            state::EMPTY_MPT_HASH);
+        report.check_eq(
+            "genesis receipts root", c.genesis_block_header.receipts_root, state::EMPTY_MPT_HASH);
+        report.check_eq("genesis withdrawals root", c.genesis_block_header.withdrawal_root,
             rev_schedule.get_revision(c.genesis_block_header.timestamp) >= EVMC_SHANGHAI ?
                 state::EMPTY_MPT_HASH :
                 bytes32{});
-        EXPECT_EQ(c.genesis_block_header.logs_bloom, bytes_view{state::BloomFilter{}});
+        report.check_eq("genesis logs bloom", bytes_view{c.genesis_block_header.logs_bloom},
+            bytes_view{state::BloomFilter{}});
 
         TestBlockHashes block_hashes{
             {c.genesis_block_header.block_number, c.genesis_block_header.hash}};
@@ -252,20 +271,25 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
             const auto blob_gas_limit =
                 static_cast<int64_t>(state::max_blob_gas_per_block(blob_params));
 
-            SCOPED_TRACE(std::string{evmc::to_string(rev)} + '/' + std::to_string(case_index) +
-                         '/' + c.name + '/' + std::to_string(test_block.block_info.number));
+            const auto in_block = report.at(i);
 
             // Invalid blocks are skipped: they may carry transactions that do not even decode.
             if (test_block.expected_exception.empty())
-                expect_transactions_round_trip(test_block.rlp);
+                check_transactions_round_trip(test_block.rlp, report);
 
             const auto block_error =
                 validate_block(rev, blob_params, test_block, parent_header, parent_has_ommers);
 
             if (test_block.expected_exception.empty())
             {
-                ASSERT_FALSE(block_error)
-                    << "Expected block to be valid (validate_block): " << block_error.message();
+                if (block_error)
+                {
+                    report.fail("block validity",
+                        "expected the block to be valid: " + block_error.message());
+                    // TODO: This and the requests failure below abandon the whole file, not
+                    //   just this case. Give each case its own run so only that case stops.
+                    return;
+                }
 
                 // Block being valid guarantees its parent was found.
                 assert(parent_data_it != block_data.end());
@@ -274,7 +298,11 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 auto res = apply_block(pre_state, vm, bi, block_hashes, test_block.transactions,
                     rev, blob_gas_limit, {.block_reward = mining_reward(rev)});
 
-                ASSERT_FALSE(res.requests_error);
+                if (res.requests_error)
+                {
+                    report.fail("requests", res.requests_error.message());
+                    return;
+                }
 
                 block_hashes[test_block.expected_block_header.block_number] =
                     test_block.expected_block_header.hash;
@@ -297,32 +325,37 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                     max_total_difficulty = inserted_it->second.total_difficulty;
                 }
 
-                EXPECT_TRUE(res.rejected.empty())
-                    << "Invalid transaction in block expected to be valid";
-                EXPECT_EQ(blob_gas_limit - res.blob_gas_left,
-                    static_cast<int64_t>(bi.blob_gas_used.value_or(0)))
-                    << "Transactions used more or less blob gas than expected in block header";
+                if (!res.rejected.empty())
+                {
+                    report.fail("transactions in a valid block",
+                        "invalid transaction: " + res.rejected.front().error.message());
+                }
 
-                EXPECT_EQ(state_root, test_block.expected_block_header.state_root);
+                report.check_eq("blob gas used", blob_gas_limit - res.blob_gas_left,
+                    static_cast<int64_t>(bi.blob_gas_used.value_or(0)));
+                report.check_eq(
+                    "state root", state_root, test_block.expected_block_header.state_root);
 
                 if (rev >= EVMC_SHANGHAI)
                 {
-                    EXPECT_EQ(state::mpt_hash(test_block.block_info.withdrawals),
+                    report.check_eq("withdrawals root",
+                        state::mpt_hash(test_block.block_info.withdrawals),
                         test_block.expected_block_header.withdrawal_root);
                 }
 
-                EXPECT_EQ(state::mpt_hash(test_block.transactions),
+                report.check_eq("transactions root", state::mpt_hash(test_block.transactions),
                     test_block.expected_block_header.transactions_root);
-                EXPECT_EQ(
-                    state::mpt_hash(res.receipts), test_block.expected_block_header.receipts_root);
+                report.check_eq("receipts root", state::mpt_hash(res.receipts),
+                    test_block.expected_block_header.receipts_root);
                 if (rev >= EVMC_PRAGUE)
                 {
-                    EXPECT_EQ(calculate_requests_hash(res.requests),
+                    report.check_eq("requests hash", calculate_requests_hash(res.requests),
                         test_block.expected_block_header.requests_hash);
                 }
-                EXPECT_EQ(res.gas_used, test_block.expected_block_header.gas_used);
-                EXPECT_EQ(
-                    bytes_view{res.bloom}, bytes_view{test_block.expected_block_header.logs_bloom});
+                report.check_eq(
+                    "gas used", res.gas_used, test_block.expected_block_header.gas_used);
+                report.check_eq("logs bloom", bytes_view{res.bloom},
+                    bytes_view{test_block.expected_block_header.logs_bloom});
             }
             else
             {
@@ -330,10 +363,9 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 {
                     // Block correctly rejected at validation; verify the reason matches the
                     // fixture's expected exception.
-                    EXPECT_TRUE(
-                        is_expected_block_exception(block_error, test_block.expected_exception))
-                        << "Block invalidity reason mismatch: got " << block_error.message()
-                        << ", expected " << test_block.expected_exception;
+                    report.check(
+                        is_expected_block_exception(block_error, test_block.expected_exception),
+                        "block rejection reason", block_error, test_block.expected_exception);
                     continue;
                 }
 
@@ -363,11 +395,10 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                     const auto& rejected = res.rejected.front();
                     if (names_spec_exception && !sender_not_recovered)
                     {
-                        EXPECT_TRUE(
-                            is_expected_tx_exception(rejected.error, test_block.expected_exception))
-                            << "Transaction-level invalidity mismatch: got \""
-                            << rejected.error.message() << "\", expected "
-                            << test_block.expected_exception;
+                        report.check(
+                            is_expected_tx_exception(rejected.error, test_block.expected_exception),
+                            "transaction rejection reason", rejected.error,
+                            test_block.expected_exception);
                     }
                     continue;
                 }
@@ -375,11 +406,10 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 {
                     if (!sender_not_recovered)
                     {
-                        EXPECT_TRUE(is_expected_block_exception(
-                            res.requests_error, test_block.expected_exception))
-                            << "Block invalidity reason mismatch: got "
-                            << res.requests_error.message() << ", expected "
-                            << test_block.expected_exception;
+                        report.check(is_expected_block_exception(
+                                         res.requests_error, test_block.expected_exception),
+                            "block rejection reason", res.requests_error,
+                            test_block.expected_exception);
                     }
                     continue;
                 }
@@ -397,9 +427,8 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 const auto expect_fixture_names = [&](std::string_view names) {
                     if (!names_spec_exception || ommers_not_validated || sender_not_recovered)
                         return;
-                    EXPECT_TRUE(contains_any(test_block.expected_exception, names))
-                        << "Block invalidity reason mismatch: the block failed the check for "
-                        << names << ", expected " << test_block.expected_exception;
+                    report.check(contains_any(test_block.expected_exception, names),
+                        "block rejection reason", names, test_block.expected_exception);
                 };
 
                 if (blob_gas_limit - res.blob_gas_left !=
@@ -454,11 +483,10 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                     continue;
                 }
 
-                EXPECT_TRUE(false) << "Expected block to be invalid but resulted valid";
+                report.fail("block validity", "expected the block to be invalid");
             }
         }
-        EXPECT_EQ(canonical_tip_hash, c.expectation.last_block_hash)
-            << "Canonical chain tip differs from expected `lastblockhash`";
+        report.check_eq("canonical chain tip", canonical_tip_hash, c.expectation.last_block_hash);
 
         const auto expected_post_hash =
             std::holds_alternative<TestState>(c.expectation.post_state) ?
@@ -468,13 +496,15 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
         // Get the final state hash. In case none blocks have been applied, compute genesis one.
         const auto canonical_post_hash =
             canonical_state_root ? canonical_state_root : state::mpt_hash(c.pre_state);
-        EXPECT_EQ(canonical_post_hash, expected_post_hash)
-            << "Result state:\n"
-            << print_state(*canonical_state)
-            << (std::holds_alternative<TestState>(c.expectation.post_state) ?
-                       "\n\nExpected state:\n" +
-                           print_state(std::get<TestState>(c.expectation.post_state)) :
-                       "");
+        // The state dumps are a callable so that formatting the whole state only happens once
+        // the roots are already known to differ.
+        report.check_eq("post state root", canonical_post_hash, expected_post_hash, [&] {
+            return "Result state:\n" + print_state(*canonical_state) +
+                   (std::holds_alternative<TestState>(c.expectation.post_state) ?
+                           "\n\nExpected state:\n" +
+                               print_state(std::get<TestState>(c.expectation.post_state)) :
+                           "");
+        });
     }
 }
 

--- a/test/blockchaintest/blockchaintest_runner.hpp
+++ b/test/blockchaintest/blockchaintest_runner.hpp
@@ -4,8 +4,10 @@
 #pragma once
 
 #include <test/utils/blockchaintest.hpp>
+#include <test/utils/test_report.hpp>
 
 namespace evmone::test
 {
-void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm);
+/// Execute the blockchain @p tests using the @p vm, recording what does not match into @p report.
+void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm, TestReport& report);
 }  // namespace evmone::test

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -7,12 +7,24 @@
 #include <evmone/version.h>
 #include <gtest/gtest.h>
 #include <test/utils/statetest.hpp>
+#include <test/utils/test_report.hpp>
 #include <iostream>
 
 namespace fs = std::filesystem;
 
 namespace
 {
+/// Reports each failure to gtest the moment the runner records it, so a run that dies part-way
+/// still shows what it found.
+///
+/// TODO: Bridge for as long as gtest drives these tests. Once the test driver replaces it the
+///   report is the verdict directly and this goes away.
+evmone::test::TestReport make_report()
+{
+    return evmone::test::TestReport{
+        [](const evmone::test::Failure& failure) { ADD_FAILURE() << failure; }};
+}
+
 /// Implementation of a gtest Test which runs all state tests from a given file.
 class StateTestFile : public testing::Test
 {
@@ -29,13 +41,14 @@ public:
 
     void TestBody() final
     {
+        auto report = make_report();
         std::ifstream f{m_json_test_file};
         const auto tests = evmone::test::load_state_tests(f);
         for (const auto& test : tests)
         {
             if (m_filter.has_value() && test.name.find(*m_filter) == std::string::npos)
                 continue;
-            evmone::test::run_state_test(test, m_vm, m_trace);
+            evmone::test::run_state_test(test, m_vm, m_trace, report);
         }
     }
 
@@ -62,7 +75,11 @@ public:
       : m_state_transition_test{std::move(state_transition_test)}, m_vm{vm}, m_trace{trace}
     {}
 
-    void TestBody() final { evmone::test::run_state_test(m_state_transition_test, m_vm, m_trace); }
+    void TestBody() final
+    {
+        auto report = make_report();
+        evmone::test::run_state_test(m_state_transition_test, m_vm, m_trace, report);
+    }
 
     static void register_one(const evmone::test::StateTransitionTest& test,
         const std::string& suite_name, const std::string& test_name, const fs::path& file,

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -2,24 +2,26 @@
 // Copyright 2022 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gtest/gtest.h>
 #include <test/utils/error_matching.hpp>
 #include <test/utils/mpt_hash.hpp>
 #include <test/utils/rlp.hpp>
 #include <test/utils/rlp_encode.hpp>
 #include <test/utils/statetest.hpp>
+#include <test/utils/test_report.hpp>
+#include <iostream>
 
 namespace evmone::test
 {
-void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_summary)
+void run_state_test(
+    const StateTransitionTest& test, evmc::VM& vm, bool trace_summary, TestReport& report)
 {
-    SCOPED_TRACE(test.name);
+    report.start_case(test.name);
     for (const auto& [rev, cases, block] : test.cases)
     {
         validate_state(test.pre_state, rev);
         for (size_t case_index = 0; case_index != cases.size(); ++case_index)
         {
-            SCOPED_TRACE(std::string{evmc::to_string(rev)} + '/' + std::to_string(case_index));
+            const auto in_case = report.at(evmc::to_string(rev), '/', case_index);
             // if (rev != EVMC_FRONTIER)
             //     continue;
             // if (case_index != 3)
@@ -41,7 +43,7 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
                 else
                 {
                     // Decoding is the inverse of encoding: what decoded must encode back exactly.
-                    EXPECT_EQ(rlp::encode(*tx), *expected.txbytes);
+                    report.check_eq("transaction re-encoding", rlp::encode(*tx), *expected.txbytes);
 
                     // Recover the signer, as a node does, instead of taking it from JSON.
                     const auto sender = state::recover_sender(*tx, *expected.txbytes);
@@ -87,26 +89,35 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
 
             if (!expected.exception.empty())
             {
-                ASSERT_FALSE(holds_alternative<state::TransactionReceipt>(res))
-                    << "unexpected valid transaction";
+                if (holds_alternative<state::TransactionReceipt>(res))
+                {
+                    report.fail("transaction validity", "unexpected valid transaction");
+                    return;
+                }
 
                 // The transaction must be rejected for the reason the fixture states, not merely
                 // rejected: a wrong reason is a wrong implementation of the rule being tested.
                 const auto& reason = get<std::error_code>(res);
-                EXPECT_TRUE(is_expected_tx_exception(reason, expected.exception))
-                    << "transaction rejected as \"" << reason.message() << "\", expected "
-                    << expected.exception;
+                report.check(is_expected_tx_exception(reason, expected.exception),
+                    "transaction rejection reason", reason, expected.exception);
 
-                EXPECT_EQ(logs_hash(std::vector<state::Log>()), expected.logs_hash);
+                report.check_eq(
+                    "logs hash", logs_hash(std::vector<state::Log>()), expected.logs_hash);
             }
             else
             {
-                ASSERT_TRUE(holds_alternative<state::TransactionReceipt>(res))
-                    << "unexpected invalid transaction: " << get<std::error_code>(res).message();
-                EXPECT_EQ(logs_hash(get<state::TransactionReceipt>(res).logs), expected.logs_hash);
+                if (!holds_alternative<state::TransactionReceipt>(res))
+                {
+                    report.fail("transaction validity",
+                        "unexpected invalid transaction: " + get<std::error_code>(res).message());
+                    return;
+                }
+
+                report.check_eq("logs hash", logs_hash(get<state::TransactionReceipt>(res).logs),
+                    expected.logs_hash);
             }
 
-            EXPECT_EQ(state_root, expected.state_hash);
+            report.check_eq("state root", state_root, expected.state_hash);
         }
     }
 }

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -83,6 +83,7 @@ target_sources(
     statetest_loader_tx_test.cpp
     statetest_logs_hash_test.cpp
     statetest_withdrawals_test.cpp
+    test_report_test.cpp
     tooling_run_test.cpp
     tooling_t8n_test.cpp
     tracing_test.cpp

--- a/test/unittests/test_report_test.cpp
+++ b/test/unittests/test_report_test.cpp
@@ -1,0 +1,253 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Tests of the failure report the fixture runners write into: what a check records, and how a
+/// recorded failure is rendered. The rendering is the runners' entire output, and a green fixture
+/// run never reaches it.
+
+#include <evmc/evmc.hpp>
+#include <gtest/gtest.h>
+#include <test/utils/test_report.hpp>
+#include <sstream>
+#include <system_error>
+#include <vector>
+
+using namespace evmone;
+using namespace evmone::test;
+using namespace evmc::literals;
+using evmc::bytes;
+
+namespace
+{
+/// A report whose sink keeps every failure, so a test can look at what was reported.
+class Recorded
+{
+    std::vector<Failure> m_failures;
+
+public:
+    TestReport report{[this](const Failure& failure) { m_failures.push_back(failure); }};
+
+    Recorded() = default;
+    Recorded(Recorded&&) = delete;  // The sink holds `this`.
+
+    [[nodiscard]] const std::vector<Failure>& failures() const noexcept { return m_failures; }
+
+    /// The failures as the runners print them.
+    [[nodiscard]] std::string render() const
+    {
+        std::ostringstream out;
+        for (const auto& failure : m_failures)
+            out << failure << '\n';
+        return std::move(out).str();
+    }
+};
+}  // namespace
+
+TEST(test_report, no_failures)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    EXPECT_TRUE(recorded.report.check_eq("state root", 1, 1));
+    EXPECT_TRUE(recorded.report.check(true, "rejection reason", "a", "b"));
+    EXPECT_TRUE(recorded.failures().empty());
+}
+
+TEST(test_report, check_eq_reports_both_values)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    const auto in_case = recorded.report.at("Prague", '/', 0);
+
+    EXPECT_FALSE(recorded.report.check_eq("state root", 0x01_bytes32, 0x02_bytes32));
+
+    ASSERT_EQ(recorded.failures().size(), 1u);
+    EXPECT_EQ(recorded.render(),
+        "t:\n"
+        "  Prague/0:\n"
+        "    state root:\n"
+        "      actual   0x0000000000000000000000000000000000000000000000000000000000000001\n"
+        "      expected 0x0000000000000000000000000000000000000000000000000000000000000002\n");
+}
+
+TEST(test_report, check_reports_both_values_without_equality)
+{
+    // The rejection-reason checks compare through is_expected_tx_exception(), not ==.
+    Recorded recorded;
+    recorded.report.start_case("t");
+    EXPECT_FALSE(recorded.report.check(false, "rejection reason", "GOT", "WANTED"));
+    EXPECT_EQ(recorded.render(),
+        "t:\n"
+        "    rejection reason:\n"
+        "      actual   GOT\n"
+        "      expected WANTED\n");
+}
+
+TEST(test_report, what_stays_at_the_same_level_without_a_place)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    recorded.report.fail("block validity", "expected the block to be invalid");
+    EXPECT_EQ(recorded.render(),
+        "t:\n"
+        "    block validity:\n"
+        "      expected the block to be invalid\n");
+}
+
+TEST(test_report, at_scopes_nest_and_restore)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    {
+        const auto outer = recorded.report.at("Prague");
+        {
+            const auto inner = recorded.report.at(3);
+            recorded.report.fail("inner", "d");
+        }
+        recorded.report.fail("outer", "d");
+    }
+    recorded.report.fail("case", "d");
+
+    ASSERT_EQ(recorded.failures().size(), 3u);
+    EXPECT_EQ(recorded.failures()[0].where, "Prague/3");
+    EXPECT_EQ(recorded.failures()[1].where, "Prague");
+    EXPECT_EQ(recorded.failures()[2].where, "");
+}
+
+TEST(test_report, extra_detail_extends_the_failure)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    ASSERT_FALSE(recorded.report.check_eq(
+        "post state root", 1, 2, [] { return std::string{"Result state:\nan account"}; }));
+
+    EXPECT_EQ(recorded.render(),
+        "t:\n"
+        "    post state root:\n"
+        "      actual   1\n"
+        "      expected 2\n"
+        "      Result state:\n"
+        "      an account\n");
+}
+
+TEST(test_report, byte_sequences_render_as_hex)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    recorded.report.check_eq("bytes", bytes{0xb0, 0xb1}, bytes{0xb2});
+    recorded.report.check_eq("address", 0xaa_address, 0xbb_address);
+
+    ASSERT_EQ(recorded.failures().size(), 2u);
+    EXPECT_EQ(recorded.failures()[0].detail, "actual   0xb0b1\nexpected 0xb2");
+    EXPECT_EQ(recorded.failures()[1].detail,
+        "actual   0x00000000000000000000000000000000000000aa\n"
+        "expected 0x00000000000000000000000000000000000000bb");
+}
+
+TEST(test_report, concat_renders_mixed_values)
+{
+    EXPECT_EQ(concat("n=", 42, ' ', 0x01_bytes32),
+        "n=42 0x0000000000000000000000000000000000000000000000000000000000000001");
+    EXPECT_EQ(concat(intx::uint256{255}), "0xff");
+}
+
+TEST(test_report, error_codes_render_as_their_message)
+{
+    const auto ec = std::make_error_code(std::errc::invalid_argument);
+    EXPECT_EQ(concat(ec), ec.message());
+    EXPECT_NE(ec.message(), "generic:22");  // What streaming it directly would produce.
+}
+
+TEST(test_report, bytes_render_as_numbers_and_chars_as_text)
+{
+    EXPECT_EQ(concat(uint8_t{65}), "65");
+    EXPECT_EQ(concat('/'), "/");
+}
+
+TEST(test_report, blank_detail_lines_carry_no_indent)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    ASSERT_FALSE(recorded.report.check_eq("post state root", 1, 2,
+        [] { return std::string{"Result state:\naccount\n\nExpected state:\naccount\n"}; }));
+
+    EXPECT_EQ(recorded.render(),
+        "t:\n"
+        "    post state root:\n"
+        "      actual   1\n"
+        "      expected 2\n"
+        "      Result state:\n"
+        "      account\n"
+        "\n"
+        "      Expected state:\n"
+        "      account\n"
+        "\n");
+}
+
+TEST(test_report, a_place_that_renders_empty_adds_no_separator)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    const auto outer = recorded.report.at("Prague");
+    {
+        const auto inner = recorded.report.at(std::string{});
+        recorded.report.fail("what");
+    }
+    recorded.report.fail("after");
+
+    ASSERT_EQ(recorded.failures().size(), 2u);
+    EXPECT_EQ(recorded.failures()[0].where, "Prague");
+    EXPECT_EQ(recorded.failures()[1].where, "Prague");
+}
+
+TEST(test_report, extra_detail_is_not_formatted_when_the_check_holds)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    int calls = 0;
+    EXPECT_TRUE(recorded.report.check_eq("root", 1, 1, [&] {
+        ++calls;
+        return std::string{"expensive"};
+    }));
+    EXPECT_EQ(calls, 0);
+}
+
+TEST(test_report, the_sink_sees_each_failure_complete_as_it_is_recorded)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+
+    recorded.report.check_eq("root", 1, 2, [] { return std::string{"dump"}; });
+    // Delivered during the run rather than at the end of it, and already carrying its detail.
+    ASSERT_EQ(recorded.failures().size(), 1u);
+    EXPECT_EQ(recorded.failures()[0].detail, "actual   1\nexpected 2\ndump");
+
+    recorded.report.fail("other");
+    ASSERT_EQ(recorded.failures().size(), 2u);
+    EXPECT_EQ(recorded.failures()[1].what, "other");
+}
+
+TEST(test_report, check_with_only_a_detail_reports_no_columns)
+{
+    // A structural check has nothing to put in an actual/expected pair.
+    Recorded recorded;
+    recorded.report.start_case("t");
+    EXPECT_TRUE(recorded.report.check(true, "block RLP", "not a list"));
+    EXPECT_FALSE(recorded.report.check(false, "block RLP", "not a list"));
+
+    EXPECT_EQ(recorded.render(),
+        "t:\n"
+        "    block RLP:\n"
+        "      not a list\n");
+}
+
+TEST(test_report, a_failure_without_detail_ends_after_what)
+{
+    Recorded recorded;
+    recorded.report.start_case("t");
+    recorded.report.fail("block RLP");
+
+    EXPECT_EQ(recorded.render(),
+        "t:\n"
+        "    block RLP\n");
+}

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -38,6 +38,8 @@ target_sources(
     statetest_logs_hash.cpp
     t8n.hpp
     t8n.cpp
+    test_report.hpp
+    test_report.cpp
     test_state.hpp
     test_state.cpp
     utils.hpp

--- a/test/utils/statetest.hpp
+++ b/test/utils/statetest.hpp
@@ -9,6 +9,7 @@
 #include <test/state/block.hpp>
 #include <test/state/errors.hpp>
 #include <test/state/transaction.hpp>
+#include <test/utils/test_report.hpp>
 #include <test/utils/test_state.hpp>
 #include <optional>
 
@@ -159,10 +160,11 @@ std::vector<StateTransitionTest> load_state_tests(std::istream& input);
 /// Throws std::invalid_argument exception.
 void validate_state(const TestState& state, evmc_revision rev);
 
-/// Execute the state @p test using the @p vm.
+/// Execute the state @p test using the @p vm, recording what does not match into @p report.
 ///
 /// @param trace_summary  Output execution summary to the default trace stream.
-void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_summary);
+void run_state_test(
+    const StateTransitionTest& test, evmc::VM& vm, bool trace_summary, TestReport& report);
 
 /// Computes the hash of the RLP-encoded list of transaction logs.
 /// This method is only used in tests.

--- a/test/utils/test_report.cpp
+++ b/test/utils/test_report.cpp
@@ -1,0 +1,37 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "test_report.hpp"
+#include <ostream>
+
+namespace evmone::test
+{
+std::ostream& operator<<(std::ostream& out, const Failure& failure)
+{
+    // A failure nests: the test, the place in it, the check, the values. The test name is a line
+    // of its own because fixture names run to ~300 characters. The columns are fixed, so a check
+    // with no place to report at leaves the second rung empty rather than shifting.
+    out << failure.test << ":\n";
+    if (!failure.where.empty())
+        out << "  " << failure.where << ":\n";
+    out << "    " << failure.what;
+
+    if (failure.detail.empty())
+        return out;
+
+    out << ':';
+    const std::string_view detail{failure.detail};
+    for (size_t pos = 0;;)
+    {
+        const auto end = detail.find('\n', pos);
+        const auto line = detail.substr(pos, end - pos);
+        out << '\n';
+        if (!line.empty())  // A blank line separating blocks stays blank, not six spaces.
+            out << "      " << line;
+        if (end == std::string_view::npos)
+            return out;
+        pos = end + 1;
+    }
+}
+}  // namespace evmone::test

--- a/test/utils/test_report.hpp
+++ b/test/utils/test_report.hpp
@@ -1,0 +1,175 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "utils.hpp"
+#include <evmc/bytes.hpp>
+#include <intx/intx.hpp>
+#include <cassert>
+#include <concepts>
+#include <functional>
+#include <iosfwd>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
+
+namespace evmone::test
+{
+namespace detail
+{
+/// Writes @p value the way a report shows it: byte sequences as hex, error codes as their
+/// message, everything else the way it streams itself.
+template <typename T>
+void stream(std::ostream& out, const T& value)
+{
+    // A byte buffer must arrive as a bytes_view: both bytes_view and the stream operators
+    // take their length from a terminating zero, so a raw pointer or array either reports the
+    // wrong length or reads past the end. Text is the one pointer worth streaming as it is.
+    using Pointee = std::remove_cv_t<std::remove_pointer_t<std::decay_t<T>>>;
+    static_assert(!std::is_pointer_v<std::decay_t<T>> || std::same_as<Pointee, char>,
+        "pass bytes_view{...} rather than a raw pointer or array");
+
+    if constexpr (std::convertible_to<const T&, bytes_view>)
+        out << hex0x(bytes_view{value});
+    else if constexpr (std::same_as<T, intx::uint256>)
+        out << hex0x(value);
+    else if constexpr (std::same_as<T, std::error_code>)
+        out << value.message();  // Not the "<category>:<value>" it streams as.
+    else if constexpr (std::integral<T> && sizeof(T) == 1 && !std::same_as<T, char>)
+        out << +value;  // A byte is a number in a report, not a character.
+    else
+        out << value;
+}
+}  // namespace detail
+
+/// Joins @p parts into a string the way a report shows them.
+template <typename... Ts>
+[[nodiscard]] std::string concat(const Ts&... parts)
+{
+    std::ostringstream out;
+    (detail::stream(out, parts), ...);
+    return std::move(out).str();
+}
+
+/// A check that did not hold.
+struct Failure
+{
+    /// The test case it fired in: the fixture's top-level name.
+    std::string test;
+    /// Where in that case, as built by TestReport::at(), e.g. "Prague/0".
+    std::string where;
+    /// What was checked, named in the terms the fixture uses.
+    std::string what;
+    /// The values that differ and anything further worth saying.
+    std::string detail;
+};
+
+/// Where a runner records what did not hold.
+///
+/// A runner takes it by reference; each failure reaches the driver's sink as it happens and is
+/// not kept, so a run that dies part-way has still reported what it found. Nothing is global:
+/// two runs can happen at once, each with its own report.
+class TestReport
+{
+public:
+    /// Called with each failure as it is recorded, and the only place a failure goes. Type-erased
+    /// so that testutils, which is built without gtest, need not know what the driver reports to.
+    using Sink = std::function<void(const Failure&)>;
+
+    explicit TestReport(Sink sink) : m_sink{std::move(sink)}
+    {
+        assert(m_sink && "a report without a sink discards every failure");
+    }
+
+    /// Restores the place its at() extended.
+    class [[nodiscard]] Scope
+    {
+        TestReport& m_report;
+        size_t m_restore_length;
+
+        friend class TestReport;
+        Scope(TestReport& report, size_t restore_length) noexcept
+          : m_report{report}, m_restore_length{restore_length}
+        {}
+
+    public:
+        Scope(Scope&&) = delete;
+        ~Scope() { m_report.m_where.resize(m_restore_length); }
+    };
+
+    /// Names the test case the failures that follow belong to, until the next call.
+    void start_case(std::string name) { m_test = std::move(name); }
+
+    /// Extends the place within the test case with @p position, until the scope ends.
+    /// Nested calls read as a path: at(1) inside at("Prague") is "Prague/1".
+    [[nodiscard]] Scope at(const auto&... position)
+    {
+        const auto restore_length = m_where.size();
+        // The suffix is built whole before m_where is touched, so a place that renders empty
+        // adds no separator and a throw part-way through leaves nothing behind.
+        auto suffix = concat(position...);
+        if (!m_where.empty() && !suffix.empty())
+            suffix.insert(suffix.begin(), '/');
+        m_where += suffix;
+        return Scope{*this, restore_length};  // A prvalue: Scope is not movable.
+    }
+
+    /// Records that @p what did not hold.
+    void fail(std::string_view what, std::string detail = {})
+    {
+        m_sink(Failure{m_test, m_where, std::string{what}, std::move(detail)});
+    }
+
+    /// Records a failure with @p detail, unless @p ok holds. Returns @p ok. For a check that
+    /// has nothing to put in two columns, such as a structure that did not decode.
+    ///
+    /// @p detail is an ordinary argument, so a caller whose detail costs anything to build
+    /// needs the explicit `if` and fail() instead.
+    bool check(bool ok, std::string_view what, std::string detail = {})
+    {
+        if (ok)
+            return true;
+
+        fail(what, std::move(detail));
+        return false;
+    }
+
+    /// Records a failure showing what was produced against what the fixture expects, unless
+    /// @p ok holds. Returns @p ok, so a caller can skip what only makes sense once it does not.
+    ///
+    /// @p more, if given, is invoked only when the check fails, for detail too expensive to
+    /// format otherwise. It runs before the failure is recorded, so the failure is complete the
+    /// first time anything sees it.
+    bool check(bool ok, std::string_view what, const auto& actual, const auto& expected,
+        const std::invocable auto&... more)
+    {
+        if (ok)
+            return true;
+
+        auto detail = concat("actual   ", actual, "\nexpected ", expected);
+        (detail.append("\n").append(more()), ...);
+        fail(what, std::move(detail));
+        return false;
+    }
+
+    /// The same, for the common case of the two having to be equal.
+    bool check_eq(std::string_view what, const auto& actual, const auto& expected,
+        const std::invocable auto&... more)
+    {
+        return check(actual == expected, what, actual, expected, more...);
+    }
+
+private:
+    Sink m_sink;
+    std::string m_test;
+    std::string m_where;
+};
+
+/// Writes @p failure the way pytest reports one: the test it fired in and where, then what was
+/// checked and its detail. The C++ location of the check is deliberately absent — the name of the
+/// check identifies it, and the fixture is what the reader is debugging.
+std::ostream& operator<<(std::ostream& out, const Failure& failure);
+}  // namespace evmone::test


### PR DESCRIPTION
`evmone-statetest` and `evmone-blockchaintest` use gtest for two unrelated jobs: registering and
driving the tests, and an assertion vocabulary inside the runners. This replaces the second with
`TestReport`, which the runners take by reference and record into: `start_case()` names the
fixture's test, `at()` the place within it, `check()`/`check_eq()` what is compared, `fail()` what
did not hold. There are no macros, so the report is a parameter rather than a global and a check
is named in the fixture's own terms instead of by a stringified expression. Each failure reaches
the driver's sink as it is recorded, where a small bridge turns it into a gtest failure; the
bridge goes away with the driver.

```
tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_contract_create[fork_Prague-state_test]:
  Prague/0:
    state root:
      actual   0x52d14b553a8578ef2c4f2574061ba0140de743e87fb0429e0faffc48b94b1e75
      expected 0xdededededededededededededededededededededededededededededededede
```

Behaviour is unchanged: every former `ASSERT_*` became an explicit `return` with the same scope,
every `EXPECT_*` a non-returning check. A green fixture run reaches none of this code, so the
polarity of all 40 sites was checked against the original rather than inferred from passing
suites.
