### PR TITLE
test: Move hex0x() to utils.hpp

### DIFF
--- a/test/utils/statetest.hpp
+++ b/test/utils/statetest.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "blob_schedule.hpp"
+#include "utils.hpp"
 #include <nlohmann/json.hpp>
 #include <test/state/block.hpp>
 #include <test/state/errors.hpp>
@@ -166,20 +167,6 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
 /// Computes the hash of the RLP-encoded list of transaction logs.
 /// This method is only used in tests.
 hash256 logs_hash(const std::vector<state::Log>& logs);
-
-/// Converts an integer to hex string representation with 0x prefix.
-///
-/// This handles also builtin types like uint64_t. Not optimal but works for now.
-inline std::string hex0x(const intx::uint256& v)
-{
-    return "0x" + intx::hex(v);
-}
-
-/// Encodes bytes as hex with 0x prefix.
-inline std::string hex0x(bytes_view v)
-{
-    return "0x" + evmc::hex(v);
-}
 }  // namespace evmone::test
 
 inline std::ostream& operator<<(std::ostream& out, const evmone::address& a)

--- a/test/utils/utils.hpp
+++ b/test/utils/utils.hpp
@@ -5,6 +5,7 @@
 
 #include <evmc/evmc.hpp>
 #include <evmc/hex.hpp>
+#include <intx/intx.hpp>
 #include <algorithm>
 
 namespace evmone::test
@@ -39,6 +40,20 @@ evmc_revision to_rev(std::string_view s);
 
 /// Translates tests fork name to the EVM revision schedule.
 RevisionSchedule to_rev_schedule(std::string_view s);
+
+/// Converts an integer to hex string representation with 0x prefix.
+///
+/// This handles also builtin types like uint64_t. Not optimal but works for now.
+inline std::string hex0x(const intx::uint256& v)
+{
+    return "0x" + intx::hex(v);
+}
+
+/// Encodes bytes as hex with 0x prefix.
+inline std::string hex0x(bytes_view v)
+{
+    return "0x" + evmc::hex(v);
+}
 
 /// Converts a string to bytes by casting individual characters.
 inline bytes to_bytes(std::string_view s)


### PR DESCRIPTION
`hex0x()` needs nothing from `statetest.hpp`, which pulls in nlohmann/json and the whole state model. Moving it to `utils.hpp`, next to the other small conversions, lets lighter headers use it.