### PR TITLE
ci: Cache clang-tidy results with ctcache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -573,10 +573,39 @@ jobs:
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_GENERATOR: Ninja
-      CMAKE_OPTIONS: -DCMAKE_CXX_CLANG_TIDY=clang-tidy
+      CMAKE_OPTIONS: -DCMAKE_CXX_CLANG_TIDY=clang-tidy-cache;clang-tidy
       BUILD_TYPE: None
+      CTCACHE_DIR: /tmp/ctcache
+      # Hash comments too, otherwise editing a NOLINT reuses the old result.
+      CTCACHE_KEEP_COMMENTS: 1
     steps:
+      - run:
+          name: "Check clang-tidy version"
+          # The version is part of the cache key: ctcache does not hash the analyzer itself.
+          command: clang-tidy --version | tee /tmp/clang-tidy-version
+      - restore_cache:
+          name: "Restore clang-tidy cache"
+          key: clang-tidy-cache-{{checksum "/tmp/clang-tidy-version"}}
+      - run:
+          name: "Setup clang-tidy-cache"
+          command: |
+            mkdir -p /tmp/ctcache
+            find /tmp/ctcache -type f -mtime +7 -delete
+            # ctcache 1.2.0, pinned by commit because tags are mutable.
+            curl -L --fail --retry 3 -o /tmp/clang-tidy-cache https://raw.githubusercontent.com/matus-chochlik/ctcache/e33c063ca6e52b48bcefbc45d46d8c150ffa81ca/src/ctcache/clang_tidy_cache.py
+            sudo install -m 0755 /tmp/clang-tidy-cache /usr/local/bin/clang-tidy-cache
+            clang-tidy-cache --zero-stats
       - build
+      - run:
+          name: "clang-tidy cache stats"
+          when: always
+          command: clang-tidy-cache --print-stats
+      - save_cache:
+          name: "Save clang-tidy cache"
+          when: always
+          key: clang-tidy-cache-{{checksum "/tmp/clang-tidy-version"}}-{{epoch}}
+          paths:
+            - /tmp/ctcache
 
   clang-latest-coverage:
     executor: linux-clang-latest


### PR DESCRIPTION
The `clang-tidy` job re-analyzes the whole source tree on every run, and clang-tidy is several times the cost of the plain compile — it is one of the slowest jobs in the workflow.

This wraps it in [ctcache](https://github.com/matus-chochlik/ctcache) (`clang-tidy-cache`, pinned to the 1.2.0 commit, since tags are mutable — a single self-contained Python script, the project has no PyPI package), keeping `CTCACHE_DIR` in the CircleCI cache with the same restore-by-prefix / save-with-`{{epoch}}` pattern the fuzzing corpus uses.

Measured on the self-hosted runner:

| run | job total | Build step | hit rate |
|---|---|---|---|
| master today | 430–460 s | ~380 s | — |
| cold, empty cache | 392 s | 353 s | 0/131 |
| unchanged sources | 86–101 s | 60–77 s | 129/131 |

Each run prints its own hit rate (stats are zeroed at setup):

```
{"local": {"cached_count": 144, "hit_count": 129, "miss_count": 2, "hit_rate": 0.9847328244274809, "miss_rate": 0.015267175572519083}}
```

Details:

- The stats and `save_cache` steps are `when: always`, so a run that *fails* clang-tidy still contributes its clean translation units and the next attempt only re-analyzes what changed. Verified by pushing a deliberate violation: the Build step failed, the cache was still saved, and the offending unit was **not** cached — ctcache only stores runs that exit clean with no output, so a violation can never be cached into a pass.
- Entries unused for 7 days are pruned before the build. ctcache touches every entry it hits and the CircleCI cache preserves mtimes (checked with a temporary probe step), so live entries stay fresh and the cache cannot grow without bound.
- The hash covers the preprocessed translation unit plus the resolved `.clang-tidy` config. Comments are included in it on purpose (`CTCACHE_KEEP_COMMENTS`): with them stripped, deleting a `NOLINT` leaves the code tokens unchanged, so the old clean result is reused and clang-tidy never runs. Measured on a `NOLINTNEXTLINE(readability-redundant-casting)` in `create_address.cpp`: stripped -> 23/23 hits and the job passes with the suppression gone; hashed -> that one unit re-analyzed, 1 diagnostic, job fails as it should.
- ctcache's digest does not cover the analyzer itself, so `clang-tidy --version` is part of the CircleCI cache key. An image rebuilt with a different clang-tidy therefore starts from an empty cache, instead of serving unchanged units results that the updated checks never saw.
- Two translation units miss on every run; at 1.5% I did not chase them.


