### PR TITLE
test: Replace gtest with a test driver in the test tools

### DIFF
--- a/test/blockchaintest/CMakeLists.txt
+++ b/test/blockchaintest/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_executable(evmone-blockchaintest)
-target_link_libraries(evmone-blockchaintest PRIVATE evmone::testutils evmone evmone-buildinfo GTest::gtest CLI11::CLI11)
+target_link_libraries(evmone-blockchaintest PRIVATE evmone::testutils evmone evmone-buildinfo CLI11::CLI11)
 target_sources(
     evmone-blockchaintest PRIVATE
     blockchaintest.cpp

--- a/test/blockchaintest/blockchaintest.cpp
+++ b/test/blockchaintest/blockchaintest.cpp
@@ -5,124 +5,73 @@
 #include <CLI/CLI.hpp>
 #include <evmone/evmone.h>
 #include <evmone/version.h>
-#include <gtest/gtest.h>
 #include <test/utils/blockchaintest.hpp>
+#include <test/utils/test_driver.hpp>
 #include <test/utils/test_files.hpp>
-#include <test/utils/test_report.hpp>
 #include <iostream>
 
 namespace fs = std::filesystem;
+using evmone::test::TestCase;
 
 namespace
 {
-/// Reports each failure to gtest the moment the runner records it, so a run that dies part-way
-/// still shows what it found.
-///
-/// TODO: Bridge for as long as gtest drives these tests. Once the test driver replaces it the
-///   report is the verdict directly and this goes away.
-evmone::test::TestReport make_report()
-{
-    return evmone::test::TestReport{
-        [](const evmone::test::Failure& failure) { ADD_FAILURE() << failure; }};
-}
-
-/// Implementation of a gtest Test which runs all blockchain tests from a given file.
-class BlockchainGTestFile : public testing::Test
-{
-    fs::path m_json_test_file;
-    evmc::VM& m_vm;
-
-public:
-    explicit BlockchainGTestFile(fs::path json_test_file, evmc::VM& vm) noexcept
-      : m_json_test_file{std::move(json_test_file)}, m_vm{vm}
-    {}
-
-    void TestBody() final
-    {
-        auto report = make_report();
-        std::ifstream f{m_json_test_file};
-
-        try
-        {
-            evmone::test::run_blockchain_tests(
-                evmone::test::load_blockchain_tests(f), m_vm, report);
-        }
-        catch (const evmone::test::UnsupportedTestFeature& ex)
-        {
-            GTEST_SKIP() << ex.what();
-        }
-    }
-
-    static void register_one(const std::string& suite_name, const fs::path& file, evmc::VM& vm)
-    {
-        testing::RegisterTest(suite_name.c_str(), file.stem().string().c_str(), nullptr, nullptr,
-            file.string().c_str(), 0,
-            [file, &vm]() -> testing::Test* { return new BlockchainGTestFile(file, vm); });
-    }
-};
-
-/// Implementation of a gtest Test which runs a single blockchain test.
-class BlockchainGTest : public testing::Test
-{
-    const evmone::test::BlockchainTest m_blockchain_test;
-    evmc::VM& m_vm;
-
-public:
-    explicit BlockchainGTest(evmone::test::BlockchainTest blockchain_test, evmc::VM& vm) noexcept
-      : m_blockchain_test{std::move(blockchain_test)}, m_vm{vm}
-    {}
-
-    void TestBody() final
-    {
-        auto report = make_report();
-        evmone::test::run_blockchain_tests(std::array{m_blockchain_test}, m_vm, report);
-    }
-
-    static void register_one(const evmone::test::BlockchainTest& test,
-        const std::string& suite_name, const std::string& test_name, const fs::path& file,
-        evmc::VM& vm)
-    {
-        testing::RegisterTest(suite_name.c_str(), test_name.c_str(), nullptr, nullptr,
-            file.string().c_str(), 0,
-            [test, &vm]() -> testing::Test* { return new BlockchainGTest(test, vm); });
-    }
-};
-
-/// Registers every test under @p root, or prints its path if @p collect_only.
-void register_test_files(
-    const fs::path& root, std::span<const fs::path> ignored, bool collect_only, evmc::VM& vm)
+/// Adds to @p cases every test under @p root: one per file for a directory, one per test case in
+/// the file when the file itself is named. Returns whether every test was collected.
+bool collect_tests(std::vector<TestCase>& cases, const fs::path& root,
+    std::span<const fs::path> ignored, evmc::VM& vm)
 {
     if (is_directory(root))
     {
         auto files = evmone::test::collect_test_files(root);
         evmone::test::ignore_test_files(files, ignored);
-        for (const auto& [path, suite_name] : files)
+        cases.reserve(cases.size() + files.size());
+        for (const auto& file : files)
         {
-            if (collect_only)
-                std::cout << path.string() << '\n';
-            else
-                BlockchainGTestFile::register_one(suite_name, path, vm);
+            // Loaded when the test runs: loading a whole tree up front costs far more. A
+            // load which throws over an unsupported fixture reaches the driver, which skips.
+            cases.push_back(
+                {file.path.string(), [path = file.path, &vm](evmone::test::TestReport& report) {
+                     std::ifstream f{path};
+                     evmone::test::run_blockchain_tests(
+                         evmone::test::load_blockchain_tests(f), vm, report);
+                 }});
         }
     }
     else  // Treat as a file.
     {
-        std::ifstream f{root};
+        // Naming a file loads it now, to name the test cases in it. One which cannot be
+        // loaded becomes a single test the driver skips or fails.
+        std::vector<evmone::test::BlockchainTest> tests;
         try
         {
-            const auto tests = evmone::test::load_blockchain_tests(f);
-            for (const auto& test : tests)
-            {
-                if (collect_only)
-                    std::cout << root.string() << "::" << test.name << '\n';
-                else
-                    BlockchainGTest::register_one(test, root.string(), test.name, root, vm);
-            }
+            std::ifstream f{root};
+            tests = evmone::test::load_blockchain_tests(f);
         }
-        catch (const evmone::test::UnsupportedTestFeature& ex)
+        catch (const evmone::test::UnsupportedTestFeature&)
         {
-            std::cerr << ex.what() << ": " << root.string() << '\n';
+            // An unsupported fixture is a skip, not a broken collection.
+            cases.push_back({root.string(),
+                [error = std::current_exception()](auto&) { std::rethrow_exception(error); }});
+            return true;
+        }
+        catch (const std::exception& ex)
+        {
+            // Also reported here: --collect-only never runs the test.
+            std::cerr << root.string() << ": " << ex.what() << '\n';
+            cases.push_back({root.string(),
+                [error = std::current_exception()](auto&) { std::rethrow_exception(error); }});
+            return false;
+        }
+
+        for (const auto& test : tests)
+        {
+            cases.push_back(
+                {root.string() + "::" + test.name, [test, &vm](evmone::test::TestReport& report) {
+                     evmone::test::run_blockchain_tests({&test, 1}, vm, report);
+                 }});
         }
     }
+    return true;
 }
 }  // namespace
 
@@ -131,8 +80,6 @@ int main(int argc, char* argv[])
 {
     try
     {
-        testing::InitGoogleTest(&argc, argv);  // Process GoogleTest flags.
-
         CLI::App app{"evmone blockchain test runner"};
 
         app.set_version_flag("--version", "evmone-blockchaintest " EVMONE_VERSION);
@@ -167,10 +114,16 @@ int main(int argc, char* argv[])
         if (trace_flag)
             vm.set_option("trace", "1");
 
+        std::vector<TestCase> cases;
+        bool all_collected = true;
         for (const auto& p : paths)
-            register_test_files(p, ignored, collect_only, vm);
+            all_collected &= collect_tests(cases, p, ignored, vm);
 
-        return collect_only ? 0 : RUN_ALL_TESTS();
+        const evmone::test::RunOptions options{
+            .collect_only = collect_only, .progress = !trace_flag};
+        const auto exit_code = evmone::test::run_tests(cases, std::cout, options);
+        // A file which could not be loaded fails the listing too, not only a run of it.
+        return all_collected ? exit_code : evmone::test::TESTS_FAILED;
     }
     catch (const std::exception& ex)
     {

--- a/test/integration/blockchaintest/CMakeLists.txt
+++ b/test/integration/blockchaintest/CMakeLists.txt
@@ -14,7 +14,7 @@ add_test(
 set_tests_properties(
     ${PREFIX}/json_test PROPERTIES
     # Make sure both tests in the file are executed (both should fail).
-    PASS_REGULAR_EXPRESSION ".*2 tests from"
+    PASS_REGULAR_EXPRESSION "2 failed, 0 passed"
 )
 
 # Exercise block-level gas accounting (EIP-7778), with tracing on so that flag is covered too.
@@ -52,7 +52,7 @@ add_test(
 )
 set_tests_properties(
     ${PREFIX}/directory PROPERTIES
-    PASS_REGULAR_EXPRESSION "SKIPPED \\] \\.unsupported_rlp"
+    PASS_REGULAR_EXPRESSION "SKIPPED [^\n]*unsupported_rlp\\.json - tests with invalidly"
 )
 
 # --collect-only lists what would run instead of running it, and --ignore drops a path from that
@@ -76,6 +76,13 @@ set_tests_properties(
     ${PREFIX}/collect_only_file PROPERTIES
     PASS_REGULAR_EXPRESSION "test\\.json::[^\n]*-call\\]\n[^\n]*test\\.json::[^\n]*-callcode\\]"
 )
+
+# A file which cannot be loaded is a failure of the listing too, not a name in it.
+add_test(
+    NAME ${PREFIX}/collect_only_unloadable
+    COMMAND evmone-blockchaintest ${TESTS1}/not_json.txt --collect-only
+)
+set_tests_properties(${PREFIX}/collect_only_unloadable PROPERTIES WILL_FAIL TRUE)
 
 get_directory_property(ALL_TESTS TESTS)
 set_tests_properties(${ALL_TESTS} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/integration-%p.profraw)

--- a/test/integration/blockchaintest/not_json.txt
+++ b/test/integration/blockchaintest/not_json.txt
@@ -1,0 +1,1 @@
+Not JSON, so the loader cannot read this as a test file.

--- a/test/integration/statetest/CMakeLists.txt
+++ b/test/integration/statetest/CMakeLists.txt
@@ -118,6 +118,11 @@ add_test(
 )
 set_tests_properties(
     ${PREFIX}/filter PROPERTIES
+    # The whole summary is what proves a case ran and passed: a count alone would hold just as
+    # well if the filter selected nothing, and ctest stops checking the exit code once a
+    # PASS_REGULAR_EXPRESSION is set. The summary names failures first, so this matches only a
+    # run with none.
+    PASS_REGULAR_EXPRESSION "= 1 passed in"
     FAIL_REGULAR_EXPRESSION "failing_test_case"
 )
 
@@ -145,6 +150,21 @@ set_tests_properties(
     PASS_REGULAR_EXPRESSION "tests1[^\n]*test1\\.json\n[^\n]*tests1[^\n]*test2_multi\\.json\n[^\n]*tests2[^\n]*test1\\.json"
     FAIL_REGULAR_EXPRESSION "T\\.json"
 )
+
+# Selecting nothing fails rather than passing vacuously. WILL_FAIL only asserts a nonzero exit;
+# the driver unit tests pin the code itself.
+add_test(
+    NAME ${PREFIX}/nothing_collected
+    COMMAND evmone-statetest ${TESTS1} --ignore B --ignore SuiteA
+)
+set_tests_properties(${PREFIX}/nothing_collected PROPERTIES WILL_FAIL TRUE)
+
+# A file which cannot be loaded is a failure of the listing too, not a name in it.
+add_test(
+    NAME ${PREFIX}/collect_only_unloadable
+    COMMAND evmone-statetest ${CMAKE_CURRENT_SOURCE_DIR}/tests1/SuiteA/notes.txt --collect-only
+)
+set_tests_properties(${PREFIX}/collect_only_unloadable PROPERTIES WILL_FAIL TRUE)
 
 get_directory_property(ALL_TESTS TESTS)
 set_tests_properties(${ALL_TESTS} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/integration-%p.profraw)

--- a/test/statetest/CMakeLists.txt
+++ b/test/statetest/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_executable(evmone-statetest)
-target_link_libraries(evmone-statetest PRIVATE evmone::testutils evmone evmone-buildinfo GTest::gtest CLI11::CLI11)
+target_link_libraries(evmone-statetest PRIVATE evmone::testutils evmone evmone-buildinfo CLI11::CLI11)
 target_sources(
     evmone-statetest PRIVATE
     statetest.cpp

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -5,123 +5,77 @@
 #include <CLI/CLI.hpp>
 #include <evmone/evmone.h>
 #include <evmone/version.h>
-#include <gtest/gtest.h>
 #include <test/utils/statetest.hpp>
+#include <test/utils/test_driver.hpp>
 #include <test/utils/test_files.hpp>
-#include <test/utils/test_report.hpp>
 #include <iostream>
 
 namespace fs = std::filesystem;
+using evmone::test::TestCase;
 
 namespace
 {
-/// Reports each failure to gtest the moment the runner records it, so a run that dies part-way
-/// still shows what it found.
-///
-/// TODO: Bridge for as long as gtest drives these tests. Once the test driver replaces it the
-///   report is the verdict directly and this goes away.
-evmone::test::TestReport make_report()
+/// Adds to @p cases every test under @p root: one per file for a directory, one per test case in
+/// the file when the file itself is named. Returns whether every test was collected.
+bool collect_tests(std::vector<TestCase>& cases, const fs::path& root,
+    const std::optional<std::string>& filter, std::span<const fs::path> ignored, evmc::VM& vm,
+    bool trace)
 {
-    return evmone::test::TestReport{
-        [](const evmone::test::Failure& failure) { ADD_FAILURE() << failure; }};
-}
+    // Which cases -k keeps. Over a directory it selects within the file's test, because
+    // naming the cases up front would mean loading the whole tree.
+    const auto selected = [&filter](const evmone::test::StateTransitionTest& test) {
+        return !filter.has_value() || test.name.find(*filter) != std::string::npos;
+    };
 
-/// Implementation of a gtest Test which runs all state tests from a given file.
-class StateTestFile : public testing::Test
-{
-    fs::path m_json_test_file;
-    std::optional<std::string> m_filter;
-    evmc::VM& m_vm;
-    bool m_trace = false;
-
-public:
-    explicit StateTestFile(fs::path json_test_file, const std::optional<std::string>& filter,
-        evmc::VM& vm, bool trace) noexcept
-      : m_json_test_file{std::move(json_test_file)}, m_filter{filter}, m_vm{vm}, m_trace{trace}
-    {}
-
-    void TestBody() final
-    {
-        auto report = make_report();
-        std::ifstream f{m_json_test_file};
-        const auto tests = evmone::test::load_state_tests(f);
-        for (const auto& test : tests)
-        {
-            if (m_filter.has_value() && test.name.find(*m_filter) == std::string::npos)
-                continue;
-            evmone::test::run_state_test(test, m_vm, m_trace, report);
-        }
-    }
-
-    static void register_one(const std::string& suite_name, const fs::path& file,
-        const std::optional<std::string>& filter, evmc::VM& vm, bool trace)
-    {
-        testing::RegisterTest(suite_name.c_str(), file.stem().string().c_str(), nullptr, nullptr,
-            file.string().c_str(), 0, [file, filter, &vm, trace]() -> testing::Test* {
-                return new StateTestFile(file, filter, vm, trace);
-            });
-    }
-};
-
-/// Implementation of a gtest Test which runs a single state test.
-class StateTest : public testing::Test
-{
-    evmone::test::StateTransitionTest m_state_transition_test;
-    evmc::VM& m_vm;
-    bool m_trace = false;
-
-public:
-    explicit StateTest(
-        evmone::test::StateTransitionTest state_transition_test, evmc::VM& vm, bool trace) noexcept
-      : m_state_transition_test{std::move(state_transition_test)}, m_vm{vm}, m_trace{trace}
-    {}
-
-    void TestBody() final
-    {
-        auto report = make_report();
-        evmone::test::run_state_test(m_state_transition_test, m_vm, m_trace, report);
-    }
-
-    static void register_one(const evmone::test::StateTransitionTest& test,
-        const std::string& suite_name, const std::string& test_name, const fs::path& file,
-        evmc::VM& vm, bool trace)
-    {
-        testing::RegisterTest(suite_name.c_str(), test_name.c_str(), nullptr, nullptr,
-            file.string().c_str(), 0,
-            [test, &vm, trace]() -> testing::Test* { return new StateTest(test, vm, trace); });
-    }
-};
-
-/// Registers every test under @p root, or prints its path if @p collect_only.
-void register_test_files(const fs::path& root, const std::optional<std::string>& filter,
-    std::span<const fs::path> ignored, bool collect_only, evmc::VM& vm, bool trace)
-{
     if (is_directory(root))
     {
         auto files = evmone::test::collect_test_files(root);
         evmone::test::ignore_test_files(files, ignored);
-        for (const auto& [path, suite_name] : files)
+        cases.reserve(cases.size() + files.size());
+        for (const auto& file : files)
         {
-            if (collect_only)
-                std::cout << path.string() << '\n';
-            else
-                StateTestFile::register_one(suite_name, path, filter, vm, trace);
+            // Loaded when the test runs: loading a whole tree up front costs far more.
+            cases.push_back({file.path.string(),
+                [path = file.path, selected, &vm, trace](evmone::test::TestReport& report) {
+                    std::ifstream f{path};
+                    for (const auto& test : evmone::test::load_state_tests(f))
+                    {
+                        if (selected(test))
+                            evmone::test::run_state_test(test, vm, trace, report);
+                    }
+                }});
         }
     }
     else  // Treat as a file.
     {
-        std::ifstream f{root};
-        const auto tests = evmone::test::load_state_tests(f);
+        // Naming a file loads it now, to name the test cases in it. One which cannot be
+        // loaded becomes a single test reporting why.
+        std::vector<evmone::test::StateTransitionTest> tests;
+        try
+        {
+            std::ifstream f{root};
+            tests = evmone::test::load_state_tests(f);
+        }
+        catch (const std::exception& ex)
+        {
+            // Also reported here: --collect-only never runs the test.
+            std::cerr << root.string() << ": " << ex.what() << '\n';
+            cases.push_back({root.string(),
+                [error = std::current_exception()](auto&) { std::rethrow_exception(error); }});
+            return false;
+        }
+
         for (const auto& test : tests)
         {
-            if (filter.has_value() && test.name.find(*filter) == std::string::npos)
+            if (!selected(test))
                 continue;
-            if (collect_only)
-                std::cout << root.string() << "::" << test.name << '\n';
-            else
-                StateTest::register_one(test, root.string(), test.name, root, vm, trace);
+            cases.push_back({root.string() + "::" + test.name,
+                [test, &vm, trace](evmone::test::TestReport& report) {
+                    evmone::test::run_state_test(test, vm, trace, report);
+                }});
         }
     }
+    return true;
 }
 }  // namespace
 
@@ -130,8 +84,6 @@ int main(int argc, char* argv[])
 {
     try
     {
-        testing::InitGoogleTest(&argc, argv);  // Process GoogleTest flags.
-
         CLI::App app{"evmone state test runner"};
 
         app.set_version_flag("--version", "evmone-statetest " EVMONE_VERSION);
@@ -176,10 +128,16 @@ int main(int argc, char* argv[])
             vm.set_option("trace", "1");
         }
 
+        std::vector<TestCase> cases;
+        bool all_collected = true;
         for (const auto& p : paths)
-            register_test_files(p, filter, ignored, collect_only, vm, trace || trace_summary);
+            all_collected &= collect_tests(cases, p, filter, ignored, vm, trace || trace_summary);
 
-        return collect_only ? 0 : RUN_ALL_TESTS();
+        const evmone::test::RunOptions options{
+            .collect_only = collect_only, .progress = !(trace || trace_summary)};
+        const auto exit_code = evmone::test::run_tests(cases, std::cout, options);
+        // A file which could not be loaded fails the listing too, not only a run of it.
+        return all_collected ? exit_code : evmone::test::TESTS_FAILED;
     }
     catch (const std::exception& ex)
     {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -85,6 +85,7 @@ target_sources(
     statetest_logs_hash_test.cpp
     statetest_runner_test.cpp
     statetest_withdrawals_test.cpp
+    test_driver_test.cpp
     test_files_test.cpp
     test_report_test.cpp
     tooling_run_test.cpp

--- a/test/unittests/test_driver_test.cpp
+++ b/test/unittests/test_driver_test.cpp
@@ -1,0 +1,120 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <test/utils/test_driver.hpp>
+
+using namespace evmone::test;
+
+namespace
+{
+/// The exit code and the report of one run.
+struct Run
+{
+    int exit_code = -1;
+    std::string output;
+};
+
+Run run(std::span<const TestCase> cases, const RunOptions& options = {})
+{
+    std::ostringstream out;
+    const auto exit_code = run_tests(cases, out, options);
+    return {exit_code, std::move(out).str()};
+}
+}  // namespace
+
+TEST(test_driver, nothing_collected)
+{
+    // pytest's exit code for a run which selected nothing, which is rarely what was meant.
+    const auto [exit_code, output] = run({});
+    EXPECT_EQ(NO_TESTS_COLLECTED, 5);  // The value pytest uses, not just whatever we declared.
+    EXPECT_EQ(exit_code, NO_TESTS_COLLECTED);
+    EXPECT_NE(output.find("collected 0 tests"), std::string::npos);
+}
+
+TEST(test_driver, collect_only_lists_without_running)
+{
+    bool ran = false;
+    const std::vector<TestCase> cases{{"a name", [&ran](TestReport&) { ran = true; }}};
+
+    const auto [exit_code, output] = run(cases, {.collect_only = true});
+    EXPECT_FALSE(ran);
+    EXPECT_EQ(exit_code, SUCCESS);
+    EXPECT_EQ(output, "a name\n");
+}
+
+TEST(test_driver, collect_only_nothing_collected)
+{
+    const auto [exit_code, output] = run({}, {.collect_only = true});
+    EXPECT_EQ(exit_code, NO_TESTS_COLLECTED);
+    EXPECT_EQ(output, "");
+}
+
+TEST(test_driver, exception_fails_only_its_own_test)
+{
+    bool last_ran = false;
+    const std::vector<TestCase> cases{
+        {"ok", [](TestReport&) {}},
+        {"throws", [](TestReport&) { throw std::runtime_error{"the reason"}; }},
+        {"unknown", [](TestReport&) { throw 42; }},  // NOLINT(hicpp-exception-baseclass)
+        {"last", [&last_ran](TestReport&) { last_ran = true; }},
+    };
+
+    const auto [exit_code, output] = run(cases);
+    EXPECT_TRUE(last_ran);
+    EXPECT_EQ(exit_code, 1);
+    EXPECT_NE(output.find("2 failed, 2 passed"), std::string::npos);
+    // The reason a test threw belongs in the summary, not only in the failure block.
+    EXPECT_NE(output.find("FAILED  throws - exception: the reason"), std::string::npos);
+}
+
+TEST(test_driver, unsupported_feature_skips)
+{
+    const std::vector<TestCase> cases{
+        {"ok", [](TestReport&) {}},
+        {"skipped", [](TestReport&) { throw UnsupportedTestFeature{"no support for it"}; }},
+    };
+
+    const auto [exit_code, output] = run(cases);
+    EXPECT_EQ(exit_code, 0);  // A skip does not fail the run.
+    EXPECT_NE(output.find("1 passed, 1 skipped"), std::string::npos);
+    EXPECT_NE(output.find("SKIPPED skipped - no support for it"), std::string::npos);
+}
+
+TEST(test_driver, summary_names_the_check_which_failed)
+{
+    const std::vector<TestCase> cases{
+        {"mismatch", [](TestReport& report) { report.check_eq("a value", 1, 2); }}};
+
+    const auto [exit_code, output] = run(cases);
+    EXPECT_EQ(exit_code, 1);
+    EXPECT_NE(output.find("FAILED  mismatch - a value"), std::string::npos);
+}
+
+TEST(test_driver, failure_outranks_a_later_exception)
+{
+    const std::vector<TestCase> cases{{"both", [](TestReport& report) {
+                                           report.check_eq("a value", 1, 2);
+                                           throw std::runtime_error{"gave up afterwards"};
+                                       }}};
+
+    const auto [exit_code, output] = run(cases);
+    EXPECT_EQ(exit_code, TESTS_FAILED);
+    // The summary names the check which failed, not the exception which ended the test.
+    EXPECT_NE(output.find("FAILED  both - a value"), std::string::npos);
+}
+
+TEST(test_driver, failure_outranks_a_later_skip)
+{
+    const std::vector<TestCase> cases{{"both", [](TestReport& report) {
+                                           report.check_eq("a value", 1, 2);
+                                           throw UnsupportedTestFeature{"gave up afterwards"};
+                                       }}};
+
+    const auto [exit_code, output] = run(cases);
+    EXPECT_EQ(exit_code, 1);
+    EXPECT_NE(output.find("1 failed"), std::string::npos);
+    // The summary names the check which failed, not what the test then gave up on.
+    EXPECT_NE(output.find("FAILED  both - a value"), std::string::npos);
+}

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -40,6 +40,8 @@ target_sources(
     statetest_runner.cpp
     t8n.hpp
     t8n.cpp
+    test_driver.hpp
+    test_driver.cpp
     test_files.hpp
     test_files.cpp
     test_report.hpp

--- a/test/utils/blockchaintest.hpp
+++ b/test/utils/blockchaintest.hpp
@@ -15,11 +15,6 @@
 
 namespace evmone::test
 {
-struct UnsupportedTestFeature : std::runtime_error
-{
-    using runtime_error::runtime_error;
-};
-
 // https://ethereum.org/en/developers/docs/blocks/
 struct BlockHeader
 {

--- a/test/utils/test_driver.cpp
+++ b/test/utils/test_driver.cpp
@@ -1,0 +1,201 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "test_driver.hpp"
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+namespace evmone::test
+{
+namespace
+{
+/// The report is laid out like pytest's.
+constexpr int LINE_WIDTH = 72;
+constexpr int PROGRESS_WIDTH = 60;
+
+/// The outcome of one test, spelled as the progress character for it.
+enum class Outcome : char
+{
+    passed = '.',
+    failed = 'F',
+    skipped = 's',
+};
+
+void banner(std::ostream& out, std::string_view title, char fill = '=')
+{
+    const auto padding = LINE_WIDTH - static_cast<int>(title.size()) - 2;
+    const auto left = std::max(padding / 2, 1);
+    out << std::string(static_cast<size_t>(left), fill) << ' ' << title << ' '
+        << std::string(static_cast<size_t>(std::max(padding - left, 1)), fill) << '\n';
+}
+
+/// A test which did not pass: what the summary says about it and what it recorded.
+struct Note
+{
+    Outcome outcome;
+    std::string name;
+    std::string reason;
+    std::vector<Failure> failures;
+};
+
+/// One progress character per test, wrapped, each line ending in the percentage done.
+class Progress
+{
+    std::ostream& m_out;
+    size_t m_total;
+    size_t m_done = 0;
+    int m_column = 0;
+
+public:
+    Progress(std::ostream& out, size_t total) noexcept : m_out{out}, m_total{total} {}
+
+    void advance(Outcome outcome)
+    {
+        m_out << static_cast<char>(outcome);
+        ++m_done;
+        if (++m_column != PROGRESS_WIDTH && m_done != m_total)
+            return;
+
+        m_out << std::string(static_cast<size_t>(PROGRESS_WIDTH - m_column), ' ') << " ["
+              << std::setw(3) << m_done * 100 / m_total << "%]\n"
+              << std::flush;
+        m_column = 0;
+    }
+};
+}  // namespace
+
+int run_tests(std::span<const TestCase> cases, std::ostream& out, const RunOptions& options)
+{
+    if (options.collect_only)
+    {
+        for (const auto& test : cases)
+            out << test.name << '\n';
+        return cases.empty() ? NO_TESTS_COLLECTED : SUCCESS;
+    }
+
+    const auto started = std::chrono::steady_clock::now();
+
+    banner(out, "test session starts");
+    out << "collected " << cases.size() << (cases.size() == 1 ? " test\n\n" : " tests\n\n");
+
+    std::vector<Note> notes;
+    size_t passed = 0;
+    size_t failed = 0;
+    size_t skipped = 0;
+    Progress row{out, cases.size()};
+
+    for (const auto& test : cases)
+    {
+        // Held until the run ends, as pytest holds them, so nothing interleaves.
+        std::vector<Failure> failures;
+        TestReport report{[&failures](const Failure& failure) { failures.push_back(failure); }};
+        report.start_case(test.name);
+
+        auto outcome = Outcome::passed;
+        std::string reason;
+        std::string exception_reason;
+        std::string skip_reason;
+        if (!options.progress)
+            out << test.name << '\n';  // The only thing naming what the test prints next.
+        out << std::flush;
+        try
+        {
+            test.run(report);
+        }
+        catch (const UnsupportedTestFeature& ex)
+        {
+            outcome = Outcome::skipped;
+            skip_reason = ex.what();
+        }
+        catch (const std::exception& ex)
+        {
+            // One unloadable fixture in a tree of thousands fails its own test, not the run.
+            report.fail("exception", ex.what());
+            exception_reason = concat("exception: ", ex.what());
+        }
+        catch (...)
+        {
+            report.fail("exception", "not derived from std::exception");
+            exception_reason = "exception not derived from std::exception";
+        }
+        // A test writes its own output, an EVM trace above all, to another stream.
+        std::clog << std::flush;
+
+        // A recorded failure outranks giving up afterwards, in the summary too: the exception
+        // is the reason only when nothing failed before it threw.
+        if (!failures.empty())
+        {
+            outcome = Outcome::failed;
+            reason = failures.size() == 1 && !exception_reason.empty() ?
+                         std::move(exception_reason) :
+                         failures.front().what;
+        }
+        else if (outcome == Outcome::skipped)
+        {
+            reason = std::move(skip_reason);
+        }
+        if (outcome != Outcome::passed)
+            notes.push_back({outcome, test.name, std::move(reason), std::move(failures)});
+
+        switch (outcome)
+        {
+        case Outcome::passed:
+            ++passed;
+            break;
+        case Outcome::failed:
+            ++failed;
+            break;
+        case Outcome::skipped:
+            ++skipped;
+            break;
+        }
+        if (options.progress)
+            row.advance(outcome);
+    }
+
+    if (failed != 0)
+    {
+        out << '\n';
+        banner(out, "FAILURES");
+        for (const auto& note : notes)
+        {
+            if (note.outcome != Outcome::failed)
+                continue;
+            banner(out, note.name, '_');
+            for (const auto& failure : note.failures)
+                out << failure << '\n';
+        }
+    }
+
+    if (!notes.empty())
+    {
+        out << '\n';
+        banner(out, "short test summary info");
+        for (const auto& note : notes)
+        {
+            out << (note.outcome == Outcome::failed ? "FAILED  " : "SKIPPED ") << note.name;
+            if (!note.reason.empty())
+                out << " - " << note.reason;
+            out << '\n';
+        }
+    }
+
+    const std::chrono::duration<double> elapsed = std::chrono::steady_clock::now() - started;
+    std::ostringstream summary;
+    if (failed != 0)
+        summary << failed << " failed, ";
+    summary << passed << " passed";
+    if (skipped != 0)
+        summary << ", " << skipped << " skipped";
+    summary << " in " << std::fixed << std::setprecision(2) << elapsed.count() << "s";
+    out << '\n';
+    banner(out, std::move(summary).str());
+
+    if (failed != 0)
+        return TESTS_FAILED;
+    return cases.empty() ? NO_TESTS_COLLECTED : SUCCESS;
+}
+}  // namespace evmone::test

--- a/test/utils/test_driver.hpp
+++ b/test/utils/test_driver.hpp
@@ -1,0 +1,41 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2026 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <test/utils/test_report.hpp>
+
+namespace evmone::test
+{
+/// The process exit codes, following pytest.
+constexpr int SUCCESS = 0;
+constexpr int TESTS_FAILED = 1;
+constexpr int NO_TESTS_COLLECTED = 5;
+
+/// A single test: its name and how to run it.
+struct TestCase
+{
+    std::string name;
+
+    /// Executes the test, recording what did not hold in the report.
+    std::function<void(TestReport&)> run;
+};
+
+/// How to run and what to report.
+struct RunOptions
+{
+    /// List the tests instead of running them.
+    bool collect_only = false;
+
+    /// Mark each test with a progress character rather than report its name. A progress line
+    /// has no terminating newline, so anything a test prints itself would continue it.
+    bool progress = true;
+};
+
+/// Runs @p cases, reports to @p out and returns the process exit code.
+///
+/// The failures are printed once the run ends, so a run killed part-way reports only how far it
+/// got.
+[[nodiscard]] int run_tests(
+    std::span<const TestCase> cases, std::ostream& out, const RunOptions& options = {});
+}  // namespace evmone::test

--- a/test/utils/test_report.hpp
+++ b/test/utils/test_report.hpp
@@ -18,6 +18,12 @@
 
 namespace evmone::test
 {
+/// A test cannot be run at all. Skipped rather than failed.
+struct UnsupportedTestFeature : std::runtime_error
+{
+    using runtime_error::runtime_error;
+};
+
 namespace detail
 {
 /// Writes @p value the way a report shows it: byte sequences as hex, error codes as their
@@ -67,16 +73,12 @@ struct Failure
     std::string detail;
 };
 
-/// Where a runner records what did not hold.
-///
-/// A runner takes it by reference; each failure reaches the driver's sink as it happens and is
-/// not kept, so a run that dies part-way has still reported what it found. Nothing is global:
-/// two runs can happen at once, each with its own report.
+/// Records what did not hold in one test case. Each failure goes to the sink as it happens.
+/// Holds no global state, so reports are independent of each other.
 class TestReport
 {
 public:
-    /// Called with each failure as it is recorded, and the only place a failure goes. Type-erased
-    /// so that testutils, which is built without gtest, need not know what the driver reports to.
+    /// Called with each failure as it is recorded, and the only place a failure goes.
     using Sink = std::function<void(const Failure&)>;
 
     explicit TestReport(Sink sink) : m_sink{std::move(sink)}


### PR DESCRIPTION
Both test tools drive themselves now. `run_tests()` takes the collected
tests, runs each with its own report and prints what pytest prints: a
progress character per test, a block per failure and a summary line. A
green run of the 8281 EEST state fixtures is about 140 lines rather than
one `[ RUN ]`/`[ OK ]` pair per test.

The driver is also the one place that catches, which settles three
things the two tools disagreed on: an exception fails the test it came
from instead of ending the run, `UnsupportedTestFeature` skips a test
whether its fixture was reached through a directory or named directly,
and a file that cannot be loaded is one failed test rather than the end
of the run.

CI runs exactly what it ran before: 8281 state tests and 8725 passed
plus 6 skipped blockchain tests per EEST release, 479 ValidBlocks and
221 InvalidBlocks. On a tree with many failures the set of failing files
is identical to master's. Only two ctest expectations were tied to
gtest's output shape and both are rewritten here.

Three changes worth knowing about:

- A run which selects nothing exits 5, as pytest does. An over-broad
  `--ignore` or a fixture archive that unpacks under a renamed
  directory now fails its job instead of passing vacuously.
- The `--gtest_*` flags are gone. Nothing in the repo passes one, but an
  external wrapper that does will get an argument error rather than
  being ignored. The shard environment variables go with them; wrapping
  the runner in ctest for `-j` is the intended replacement.
- `evmone-blockchaintest` still has no `-k`, which `evmone-statetest`
  has. Left for the consolidation of the two tools.

The tools remain under `EVMONE_TESTING`, which requires GTest, so
nothing yet builds them without it — that becomes possible once they
move under `EVMONE_TOOLS`.
