### PR TITLE
test: Build one fixture test from its JSON value

### DIFF
--- a/test/utils/blockchaintest.hpp
+++ b/test/utils/blockchaintest.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <evmc/evmc.hpp>
+#include <nlohmann/json.hpp>
 #include <test/state/block.hpp>
 #include <test/state/bloom_filter.hpp>
 #include <test/state/transaction.hpp>
@@ -12,6 +13,8 @@
 #include <test/utils/test_state.hpp>
 #include <test/utils/utils.hpp>
 #include <vector>
+
+namespace json = nlohmann;
 
 namespace evmone::test
 {
@@ -73,6 +76,9 @@ struct BlockchainTest
 };
 
 std::vector<BlockchainTest> load_blockchain_tests(std::istream& input);
+
+/// Builds the test named @p name in a fixture file from its JSON value @p j.
+BlockchainTest make_blockchain_test(const std::string& name, const json::json& j);
 
 /// Execute the blockchain @p tests using the @p vm, recording what does not match into @p report.
 void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm, TestReport& report);

--- a/test/utils/blockchaintest_loader.cpp
+++ b/test/utils/blockchaintest_loader.cpp
@@ -118,9 +118,7 @@ static TestBlock load_test_block(
     return tb;
 }
 
-namespace
-{
-BlockchainTest load_blockchain_test_case(const std::string& name, const json::json& j)
+BlockchainTest make_blockchain_test(const std::string& name, const json::json& j)
 {
     using namespace state;
 
@@ -175,12 +173,11 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
 
     return bt;
 }
-}  // namespace
 
 static void from_json(const json::json& j, std::vector<BlockchainTest>& o)
 {
     for (const auto& elem_it : j.items())
-        o.emplace_back(load_blockchain_test_case(elem_it.key(), elem_it.value()));
+        o.emplace_back(make_blockchain_test(elem_it.key(), elem_it.value()));
 }
 
 std::vector<BlockchainTest> load_blockchain_tests(std::istream& input)

--- a/test/utils/statetest.hpp
+++ b/test/utils/statetest.hpp
@@ -156,6 +156,9 @@ json::json to_state_test(std::string_view test_name, const state::BlockInfo& blo
 
 std::vector<StateTransitionTest> load_state_tests(std::istream& input);
 
+/// Builds the test named @p name in a fixture file from its JSON value @p j.
+StateTransitionTest make_state_test(const std::string& name, const json::json& j);
+
 /// Validates the invariants of the Ethereum state (e.g. no zero-value storage entries).
 /// Throws std::invalid_argument exception.
 void validate_state(const TestState& state, evmc_revision rev);

--- a/test/utils/statetest_loader.cpp
+++ b/test/utils/statetest_loader.cpp
@@ -506,11 +506,14 @@ static void from_json(const json::json& j_t, StateTransitionTest& o)
 static void from_json(const json::json& j, std::vector<StateTransitionTest>& o)
 {
     for (const auto& elem_it : j.items())
-    {
-        auto test = elem_it.value().get<StateTransitionTest>();
-        test.name = elem_it.key();
-        o.emplace_back(std::move(test));
-    }
+        o.emplace_back(make_state_test(elem_it.key(), elem_it.value()));
+}
+
+StateTransitionTest make_state_test(const std::string& name, const json::json& j)
+{
+    auto test = j.get<StateTransitionTest>();
+    test.name = name;
+    return test;
 }
 
 std::vector<StateTransitionTest> load_state_tests(std::istream& input)


### PR DESCRIPTION
Both loaders parse a whole fixture file and convert every test in it, so
a caller which wants one test has to hand over the file and accept the
format it guessed. Splitting the conversion out gives a caller which has
already parsed the JSON a way to build one test of a known format.

`make_state_test()` is new. `make_blockchain_test()` was already written,
one anonymous namespace short of being usable. The whole-file loaders now
go through them, so nothing changes and their existing tests cover it.

Groundwork for a command which runs both fixture formats and decides
which each test is as it goes.
