### PR TITLE
test: Fail a test run which verified nothing

### DIFF
--- a/test/integration/blockchaintest/CMakeLists.txt
+++ b/test/integration/blockchaintest/CMakeLists.txt
@@ -33,16 +33,24 @@ add_test(
     COMMAND evmone-blockchaintest ${TESTS1}/unrecovered_sender_deposit_log.json
 )
 
-# A block with expectException but no rlp_decoded is a shape the loader does not support. As a
-# single file it is reported and nothing is registered.
+# A block with expectException but no rlp_decoded is a shape the loader does not support, so the
+# only test in this file is skipped and the run verifies nothing.
 add_test(
     NAME ${PREFIX}/unsupported_rlp
     COMMAND evmone-blockchaintest ${TESTS1}/unsupported_rlp.json
 )
 set_tests_properties(
     ${PREFIX}/unsupported_rlp PROPERTIES
-    PASS_REGULAR_EXPRESSION "tests with invalidly rlp-encoded blocks are not supported"
+    PASS_REGULAR_EXPRESSION
+    "tests with invalidly rlp-encoded blocks are not supported.*0 passed, 1 skipped"
 )
+
+# A PASS_REGULAR_EXPRESSION makes CTest ignore the exit code, so run it again for that alone.
+add_test(
+    NAME ${PREFIX}/unsupported_rlp_exit_code
+    COMMAND evmone-blockchaintest ${TESTS1}/unsupported_rlp.json
+)
+set_tests_properties(${PREFIX}/unsupported_rlp_exit_code PROPERTIES WILL_FAIL TRUE)
 
 # The directory form registers one test per file, which none of the tests above reach, and skips
 # the unsupported one rather than failing on it.

--- a/test/unittests/test_driver_test.cpp
+++ b/test/unittests/test_driver_test.cpp
@@ -26,10 +26,9 @@ Run run(std::span<const TestCase> cases, const RunOptions& options = {})
 
 TEST(test_driver, nothing_collected)
 {
-    // pytest's exit code for a run which selected nothing, which is rarely what was meant.
     const auto [exit_code, output] = run({});
-    EXPECT_EQ(NO_TESTS_COLLECTED, 5);  // The value pytest uses, not just whatever we declared.
-    EXPECT_EQ(exit_code, NO_TESTS_COLLECTED);
+    EXPECT_EQ(NOTHING_VERIFIED, 5);  // pytest's value, not just whatever we declared.
+    EXPECT_EQ(exit_code, NOTHING_VERIFIED);
     EXPECT_NE(output.find("collected 0 tests"), std::string::npos);
 }
 
@@ -47,7 +46,7 @@ TEST(test_driver, collect_only_lists_without_running)
 TEST(test_driver, collect_only_nothing_collected)
 {
     const auto [exit_code, output] = run({}, {.collect_only = true});
-    EXPECT_EQ(exit_code, NO_TESTS_COLLECTED);
+    EXPECT_EQ(exit_code, NOTHING_VERIFIED);
     EXPECT_EQ(output, "");
 }
 
@@ -80,6 +79,16 @@ TEST(test_driver, unsupported_feature_skips)
     EXPECT_EQ(exit_code, 0);  // A skip does not fail the run.
     EXPECT_NE(output.find("1 passed, 1 skipped"), std::string::npos);
     EXPECT_NE(output.find("SKIPPED skipped - no support for it"), std::string::npos);
+}
+
+TEST(test_driver, everything_skipped_verifies_nothing)
+{
+    const std::vector<TestCase> cases{
+        {"skipped", [](TestReport&) { throw UnsupportedTestFeature{"no support for it"}; }}};
+
+    const auto [exit_code, output] = run(cases);
+    EXPECT_EQ(exit_code, NOTHING_VERIFIED);
+    EXPECT_NE(output.find("0 passed, 1 skipped"), std::string::npos);
 }
 
 TEST(test_driver, summary_names_the_check_which_failed)

--- a/test/utils/test_driver.cpp
+++ b/test/utils/test_driver.cpp
@@ -73,7 +73,7 @@ int run_tests(std::span<const TestCase> cases, std::ostream& out, const RunOptio
     {
         for (const auto& test : cases)
             out << test.name << '\n';
-        return cases.empty() ? NO_TESTS_COLLECTED : SUCCESS;
+        return cases.empty() ? NOTHING_VERIFIED : SUCCESS;
     }
 
     const auto started = std::chrono::steady_clock::now();
@@ -196,6 +196,8 @@ int run_tests(std::span<const TestCase> cases, std::ostream& out, const RunOptio
 
     if (failed != 0)
         return TESTS_FAILED;
-    return cases.empty() ? NO_TESTS_COLLECTED : SUCCESS;
+    // No test passed: nothing was collected, or every test was skipped. A test which holds no
+    // case of its own still counts as passed, which this does not change.
+    return passed == 0 ? NOTHING_VERIFIED : SUCCESS;
 }
 }  // namespace evmone::test

--- a/test/utils/test_driver.hpp
+++ b/test/utils/test_driver.hpp
@@ -7,10 +7,15 @@
 
 namespace evmone::test
 {
-/// The process exit codes, following pytest.
+/// Nothing failed and something passed.
 constexpr int SUCCESS = 0;
+
+/// At least one test failed.
 constexpr int TESTS_FAILED = 1;
-constexpr int NO_TESTS_COLLECTED = 5;
+
+/// No test passed, whether none was collected or every one was skipped. pytest returns this
+/// value for the first of those; a test skipped has verified no more than a missing one.
+constexpr int NOTHING_VERIFIED = 5;
 
 /// A single test: its name and how to run it.
 struct TestCase


### PR DESCRIPTION
A run whose every test was skipped passed, because the exit code asked
only whether anything had been collected. Both are the same state to
whoever reads the result: nothing was checked. `NO_TESTS_COLLECTED` is
renamed `NOTHING_VERIFIED`, since it no longer means what it said.

`evmone-blockchaintest` now exits 5 on a fixture it wholly declines,
where it used to exit 0. The integration test for one such fixture could
not see that, because a `PASS_REGULAR_EXPRESSION` makes CTest ignore the
exit code, so it gains the counts and a sibling which asserts on nothing
else.

Nothing in CI reaches this: every job runs thousands of passing tests.
It matters for the tool pointed at a fixture release whose format has
moved on, which is a run that should not go green.
