### PR TITLE
test: Cover what a fixture file's broken cases do to it

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -56,6 +56,38 @@ DUP1,4
 
 endif()
 
+# A file holding a case which is not a fixture at all, beside one which runs.
+add_test(NAME ${PREFIX}/fixture_fault COMMAND evmone-statetest
+    ${CMAKE_CURRENT_SOURCE_DIR}/testcmd_fault)
+set_tests_properties(${PREFIX}/fixture_fault PROPERTIES WILL_FAIL TRUE)
+
+# WILL_FAIL above accepts any non-zero exit, and a fault downgraded to a skip exits non-zero too,
+# so the counts are what distinguish the two.
+add_test(NAME ${PREFIX}/fixture_fault_is_not_a_skip COMMAND evmone-statetest
+    ${CMAKE_CURRENT_SOURCE_DIR}/testcmd_fault)
+set_tests_properties(
+    ${PREFIX}/fixture_fault_is_not_a_skip PROPERTIES PASS_REGULAR_EXPRESSION "1 failed, 0 passed")
+
+# Selecting only the case which is not a fixture must still fault.
+add_test(NAME ${PREFIX}/fixture_fault_survives_filter COMMAND evmone-statetest
+    ${CMAKE_CURRENT_SOURCE_DIR}/testcmd_fault -k b_not_a_fixture)
+set_tests_properties(
+    ${PREFIX}/fixture_fault_survives_filter PROPERTIES
+    PASS_REGULAR_EXPRESSION "1 failed, 0 passed")
+
+# A case whose load throws takes the rest of the file with it: the whole file is loaded before
+# any of it runs, so the case after it is never reached and the failure is named after the file
+# rather than the case it came from. FAILED pins that as a failure: a PASS_REGULAR_EXPRESSION
+# makes CTest ignore the exit code, and a fault downgraded to a skip names the file too.
+add_test(NAME ${PREFIX}/case_after_exception COMMAND evmone-statetest
+    ${CMAKE_CURRENT_SOURCE_DIR}/testcmd_cases)
+set_tests_properties(
+    ${PREFIX}/case_after_exception PROPERTIES
+    PASS_REGULAR_EXPRESSION
+    "collected 1 test.*FAILED[^\n]*case_after_exception\\.json[^\n]*exception"
+    FAIL_REGULAR_EXPRESSION "b_wrong_state_root"
+)
+
 add_subdirectory(blockchaintest)
 add_subdirectory(export)
 add_subdirectory(statetest)

--- a/test/integration/testcmd_cases/case_after_exception.json
+++ b/test/integration/testcmd_cases/case_after_exception.json
@@ -1,0 +1,70 @@
+{
+ "a_load_error": {
+  "_info": {
+   "fixture-format": "state_test",
+   "comment": "A state test with no pre state, so loading it throws."
+  }
+ },
+ "b_wrong_state_root": {
+  "_info": {
+   "comment": "Runs and fails on the state root. Only reported if the case before it did not abandon the file."
+  },
+  "env": {
+   "currentBaseFee": "0x0a",
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentDifficulty": "0x020000",
+   "currentGasLimit": "0xff112233445566",
+   "currentNumber": "0x01",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+   "currentTimestamp": "0x03e8"
+  },
+  "post": {
+   "London": [
+    {
+     "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+    }
+   ]
+  },
+  "pre": {
+   "0x095e7baea6a6c7c4c2dfeb977efac326af552d87": {
+    "balance": "0x0de0b6b3a7640000",
+    "code": "0x600160010160005500",
+    "nonce": "0x00",
+    "storage": {}
+   },
+   "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+    "balance": "0x00",
+    "code": "0x",
+    "nonce": "0x01",
+    "storage": {}
+   },
+   "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+    "balance": "0x0de0b6b3a7640000",
+    "code": "0x",
+    "nonce": "0x00",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "data": [
+    "0x"
+   ],
+   "gasLimit": [
+    "0x061a80"
+   ],
+   "gasPrice": "0x0a",
+   "nonce": "0x00",
+   "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+   "to": "0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+   "value": [
+    "0x0186a0"
+   ]
+  }
+ }
+}

--- a/test/integration/testcmd_fault/unrecognised_case.json
+++ b/test/integration/testcmd_fault/unrecognised_case.json
@@ -1,0 +1,67 @@
+{
+ "a_runs": {
+  "_info": {},
+  "env": {
+   "currentBaseFee": "0x0a",
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentDifficulty": "0x020000",
+   "currentGasLimit": "0xff112233445566",
+   "currentNumber": "0x01",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+   "currentTimestamp": "0x03e8"
+  },
+  "post": {
+   "London": [
+    {
+     "hash": "0xe8010ce590f401c9d61fef8ab05bea9bcec24281b795e5868809bc4e515aa530",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+    }
+   ]
+  },
+  "pre": {
+   "0x095e7baea6a6c7c4c2dfeb977efac326af552d87": {
+    "balance": "0x0de0b6b3a7640000",
+    "code": "0x600160010160005500",
+    "nonce": "0x00",
+    "storage": {}
+   },
+   "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+    "balance": "0x00",
+    "code": "0x",
+    "nonce": "0x01",
+    "storage": {}
+   },
+   "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+    "balance": "0x0de0b6b3a7640000",
+    "code": "0x",
+    "nonce": "0x00",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "data": [
+    "0x"
+   ],
+   "gasLimit": [
+    "0x061a80"
+   ],
+   "gasPrice": "0x0a",
+   "nonce": "0x00",
+   "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+   "to": "0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+   "value": [
+    "0x0186a0"
+   ]
+  }
+ },
+ "b_not_a_fixture": {
+  "_info": {
+   "comment": "Not a test: no fixture fields at all. Beside a case which runs, so this is unmistakably a fixture file with one broken case in it."
+  }
+ }
+}


### PR DESCRIPTION
A fixture file the tool can only partly read has no coverage at all, so
two fixtures nobody would write on purpose: one whose second case is not
a test, and one whose first case cannot be loaded.

The second pins behaviour worth being explicit about: the whole file is
loaded before any of it runs, so one case which fails to load takes the
rest of the file with it, and the failure is reported against the file
rather than the case it came from.
