### PR TITLE
ci: Add a native riscv64 build on GitHub Actions

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -26,6 +26,8 @@ jobs:
     # They are 64-bit only, so the riscv32 build stays cross-compiled and emulated on CircleCI.
     runs-on: ubuntu-24.04-riscv
     timeout-minutes: 120
+    permissions:
+      contents: read  # required for actions/checkout
 
     steps:
       - uses: actions/checkout@v5
@@ -33,8 +35,8 @@ jobs:
           submodules: recursive
 
       - name: Environment
-        # Nothing sets a parallel level: ninja and ctest take the CPU count themselves, so report
-        # what they see. A container is where that count stops being the machine's.
+        # Nothing pins a parallel level: ninja takes the CPU count itself and ctest is handed it,
+        # so report what they see. A container is where that count stops being the machine's.
         run: |
           uname -srm
           echo "nproc: $(nproc)"
@@ -51,7 +53,7 @@ jobs:
       - name: Configure
         run: >
           cmake -S . -B $BUILD_DIR -G Ninja
-          -DCMAKE_INSTALL_PREFIX=install
+          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE
           -DEVMONE_TESTING=ON
@@ -65,7 +67,9 @@ jobs:
       - name: Test
         # ctest takes the job count without an argument only from CMake 3.29; the runner's
         # 3.28 accepts the bare flag and silently runs the tests one at a time.
-        run: ctest --test-dir $BUILD_DIR --schedule-random --output-on-failure --parallel $(nproc)
+        run: >
+          ctest --test-dir $BUILD_DIR --schedule-random --output-on-failure
+          --no-tests=error --parallel $(nproc)
 
       - name: Package
         run: cmake --build $BUILD_DIR --target package
@@ -74,3 +78,4 @@ jobs:
         with:
           name: riscv64
           path: ${{ env.BUILD_DIR }}/evmone-*.*
+          if-no-files-found: error

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -1,0 +1,76 @@
+# evmone: Fast Ethereum Virtual Machine implementation
+# Copyright 2026 The evmone Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: RISC-V
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  BUILD_DIR: build
+
+jobs:
+  riscv64:
+    name: riscv64
+    # A native build on real hardware: Scaleway EM-RV1, 4 T-Head C910 cores at 1.85 GHz. The
+    # runners are operated by the RISE project: https://riscv-runners.riseproject.dev.
+    # They are 64-bit only, so the riscv32 build stays cross-compiled and emulated on CircleCI.
+    runs-on: ubuntu-24.04-riscv
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Environment
+        # Nothing sets a parallel level: ninja and ctest take the CPU count themselves, so report
+        # what they see. A container is where that count stops being the machine's.
+        run: |
+          uname -srm
+          echo "nproc: $(nproc)"
+          cmake --version | head -1
+          ninja --version
+          c++ --version | head -1
+
+      - name: Restore the Hunter cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.hunter/_Base/Cache
+          key: hunter-riscv64-${{ hashFiles('cmake/Hunter/*.cmake') }}
+
+      - name: Configure
+        run: >
+          cmake -S . -B $BUILD_DIR -G Ninja
+          -DCMAKE_INSTALL_PREFIX=install
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE
+          -DEVMONE_TESTING=ON
+
+      - name: Build
+        run: cmake --build $BUILD_DIR --parallel
+
+      - name: Install
+        run: cmake --build $BUILD_DIR --target install
+
+      - name: Test
+        # ctest takes the job count without an argument only from CMake 3.29; the runner's
+        # 3.28 accepts the bare flag and silently runs the tests one at a time.
+        run: ctest --test-dir $BUILD_DIR --schedule-random --output-on-failure --parallel $(nproc)
+
+      - name: Package
+        run: cmake --build $BUILD_DIR --target package
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: riscv64
+          path: ${{ env.BUILD_DIR }}/evmone-*.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,11 @@ if(CABLE_COMPILER_GNULIKE)
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-field-initializers>
 
-        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>>:-Wno-attributes=clang::>
-        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>>:-Wno-attributes=msvc::>
-        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,12>>:-Wno-attributes>
+        # GCC has the namespaced form from 12, but only keeps it across a precompiled header
+        # from 14 on.
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14>>:-Wno-attributes=clang::>
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14>>:-Wno-attributes=msvc::>
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,14>>:-Wno-attributes>
         $<$<CXX_COMPILER_ID:GNU>:-Wduplicated-cond>
         $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
 


### PR DESCRIPTION
Build and test on real RISC-V hardware: Scaleway EM-RV1, 4 T-Head C910
cores at 1.85 GHz and 16 GB of RAM, one job per node. The runners are
operated by the RISE project for open source, and the app is installed
on the org already.

The steps are the CircleCI job's, minus the JUnit report nothing reads
here.

The riscv32 job stays on CircleCI. These runners are 64-bit only and
offer no emulation, and rv32 cannot follow: every riscv-gnu-toolchain
release is hosted on x86_64, so there is no rv32 cross-compiler which
runs on riscv64.
