### PR TITLE
tooling: Run one command per invocation

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -21,6 +21,34 @@ if(TARGET evmone-cli)
         ${PREFIX}/run_bad_rev PROPERTIES PASS_REGULAR_EXPRESSION
         "unknown revision: NoSuchRev")
 
+    # A subcommand's own name among another's arguments is an argument. CLI11 would otherwise
+    # take it as a second command and run that one instead, exiting 0 with the wrong work done:
+    # the dispatch tries run first, so a trailing "run" hijacked every other subcommand.
+    add_test(NAME ${PREFIX}/one_command_per_invocation COMMAND evmone-cli
+        t8n --state.fork Cancun run 6000)
+    set_tests_properties(
+        ${PREFIX}/one_command_per_invocation PROPERTIES
+        PASS_REGULAR_EXPRESSION "arguments were not expected"
+        FAIL_REGULAR_EXPRESSION "Result: *success")
+
+    add_test(NAME ${PREFIX}/one_command_per_invocation_reversed COMMAND evmone-cli
+        run 6000 t8n)
+    set_tests_properties(
+        ${PREFIX}/one_command_per_invocation_reversed PROPERTIES
+        PASS_REGULAR_EXPRESSION "argument was not expected: t8n"
+        FAIL_REGULAR_EXPRESSION "Result: *success")
+
+    # A PASS_REGULAR_EXPRESSION makes CTest ignore the exit code, so run them again for that alone.
+    add_test(NAME ${PREFIX}/one_command_per_invocation_exit_code COMMAND evmone-cli
+        t8n --state.fork Cancun run 6000)
+    set_tests_properties(
+        ${PREFIX}/one_command_per_invocation_exit_code PROPERTIES WILL_FAIL TRUE)
+
+    add_test(NAME ${PREFIX}/one_command_per_invocation_reversed_exit_code COMMAND evmone-cli
+        run 6000 t8n)
+    set_tests_properties(
+        ${PREFIX}/one_command_per_invocation_reversed_exit_code PROPERTIES WILL_FAIL TRUE)
+
     add_test(NAME ${PREFIX}/version COMMAND evmone-cli --version)
     set_tests_properties(
         ${PREFIX}/version PROPERTIES PASS_REGULAR_EXPRESSION "evmone")

--- a/test/integration/blockchaintest/CMakeLists.txt
+++ b/test/integration/blockchaintest/CMakeLists.txt
@@ -73,6 +73,8 @@ set_tests_properties(
     ${PREFIX}/stops_at_one_test PROPERTIES
     PASS_REGULAR_EXPRESSION
     "a_stops_early:.*block validity.*b_still_runs:.*post state root"
+    # Every failure repeats the test name, so a second one means it did not stop.
+    FAIL_REGULAR_EXPRESSION "a_stops_early:.*a_stops_early:"
 )
 
 # --collect-only lists what would run instead of running it, and --ignore drops a path from that

--- a/tools/evmone/main.cpp
+++ b/tools/evmone/main.cpp
@@ -173,6 +173,7 @@ int main(int argc, const char* const* argv) noexcept
         VM vm{evmc_create_evmone()};
 
         CLI::App app{"evmone EVM tool"};
+        app.require_subcommand(0, 1);  // Forbid multiple subcommands: run would hijack the rest.
         app.set_version_flag(
             "--version", [&vm] { return std::string{vm.name()} + " " + vm.version(); });
         app.add_flag("--trace", trace, "Enable execution trace");


### PR DESCRIPTION
CLI11 lets a subcommand's own name appear among another subcommand's
arguments and parses it as a second command. Both then match, and the
dispatch tries `run` first, so a trailing `run` silently replaced
whatever was asked for:

    $ evmone t8n --state.fork Cancun run 6000
    Result:   success        <- executed bytecode, exit 0

The t8n was discarded without a word. `require_subcommand(0, 1)` makes
the stray name an argument again, which fails to parse and says so.

Two tests cover it, one per direction. Each asserts the error and, more
importantly, that `Result: success` does not appear, so a regression
which runs the wrong command is caught even if the wording changes.
Both fail when the fix is reverted.
