### PR TITLE
evm: Don't check call depth limit in Osaka

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -35,6 +35,10 @@ add_library(evmone
 )
 target_compile_features(evmone PUBLIC cxx_std_20)
 target_link_libraries(evmone PUBLIC evmc::evmc intx::intx PRIVATE evmone::precompiles)
+
+# Nested EVM calls recurse ~2.6 KB of stack per frame, too much for Windows' 1 MB default.
+target_link_options(evmone INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/STACK:8388608>)
+
 target_include_directories(evmone PUBLIC
     $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -175,7 +175,7 @@ Result call_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noexce
         }
     }
 
-    if (state.msg->depth >= 1024)
+    if (state.rev < EVMC_OSAKA && state.msg->depth >= 1024)
         return {EVMC_SUCCESS, gas_left};  // "Light" failure.
 
     const auto result = state.host.call(msg);
@@ -232,7 +232,7 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
     if ((gas_left -= init_code_cost) < 0)
         return {EVMC_OUT_OF_GAS, gas_left};
 
-    if (state.msg->depth >= 1024)
+    if (state.rev < EVMC_OSAKA && state.msg->depth >= 1024)
         return {EVMC_SUCCESS, gas_left};  // "Light" failure.
 
     if (endowment != 0 &&

--- a/test/unittests/state_transition_call_test.cpp
+++ b/test/unittests/state_transition_call_test.cpp
@@ -50,3 +50,21 @@ TEST_F(state_transition, delegatecall_static_legacy)
     expect.post[CALLEE1].storage[0x01_bytes32] = 0xdd_bytes32;
     expect.post[CALLEE2].storage[0x01_bytes32] = 0xdd_bytes32;
 }
+
+TEST_F(state_transition, osaka_call_depth_limit_unreachable)
+{
+    // EIP-7825 caps the transaction gas and the 63/64 rule leaves each frame a 64th less, so the
+    // cheapest possible self-recursion runs out of gas at depth 494 and the 1024 limit is
+    // unreachable. gas_used pins it: a frame stopped by the limit would keep the gas it forwarded.
+    rev = EVMC_OSAKA;
+    tx.gas_limit = state::MAX_TX_GAS_LIMIT;
+    block.gas_limit = tx.gas_limit;
+    pre[Sender].balance = intx::uint256{tx.gas_limit} * tx.max_gas_price + 1;
+    tx.to = To;
+    pre[To] = {
+        .code =
+            delegatecall(OP_ADDRESS).gas(OP_GAS).input(push0(), push0()).output(push0(), push0())};
+
+    expect.gas_used = 76'314;  // 21'000 intrinsic + 493 frames x 112 + 98 in the final frame
+    expect.post[To].exists = true;
+}


### PR DESCRIPTION
The call depth limit (1024) is not reachable in Osaka because of the transaction gas limit (EIP-7825) and the 63/64 call gas rule. The max call depth reachable is less than 500.